### PR TITLE
Implement serde Serializer for Sia encoding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Setup Environment
         run: |
           rustup update stable
+      - name: Rustfmt
+        run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,12 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,7 +300,6 @@ version = "0.1.0"
 dependencies = [
  "bip39",
  "blake2b_simd",
- "byteorder",
  "ed25519-dalek",
  "hex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/lib.rs"
 [dependencies]
 bip39 = "2.0.0"
 blake2b_simd = "1.0.2"
-byteorder = "1.5.0"
 ed25519-dalek = "2.1.1"
 hex = "0.4.3"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,4 +1,3 @@
-use byteorder::{LittleEndian, WriteBytesExt};
 use serde::{
     ser::{self, SerializeSeq},
     Serialize,
@@ -98,7 +97,7 @@ impl<W: io::Write> ser::Serializer for &mut Serializer<'_, W> {
     }
 
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_u8(v)?;
+        self.writer.write_all(&v.to_le_bytes())?;
         Ok(())
     }
 
@@ -111,7 +110,7 @@ impl<W: io::Write> ser::Serializer for &mut Serializer<'_, W> {
     }
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        self.writer.write_u64::<LittleEndian>(v)?;
+        self.writer.write_all(&v.to_le_bytes())?;
         Ok(())
     }
 
@@ -205,7 +204,7 @@ impl<W: io::Write> ser::Serializer for &mut Serializer<'_, W> {
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
         match len {
             Some(len) => {
-                self.writer.write_u64::<LittleEndian>(len as u64)?;
+                self.writer.write_all(&(len as u64).to_le_bytes())?;
                 Ok(self)
             }
             None => Err(Error::LengthUnavailable),


### PR DESCRIPTION
This PR implements and encoder for the Sia encoding by implementing the `serde::Serializer` trait.

2 functions are exposed publicly. `to_bytes` which is a convenience method which serialises into a vector and `to_writer` which accepts a `io::Write` to write to.

Some types aren't implemented since there are no counterparts in Go and I thought I'd keep it simple. e.g. all variations of enums.

I went with a template (`W`) that is constrained to `io::Write` instead of passing a `dyn io::Write` since it seems to be the preferred solution for cases like this where you know at compile time what sort of type the function is used with thus avoiding the runtime check.