### PR TITLE
Refactor V1 transaction signing

### DIFF
--- a/.changeset/remove_transactionsign.md
+++ b/.changeset/remove_transactionsign.md
@@ -1,0 +1,7 @@
+---
+sia_sdk: minor
+---
+
+# Refactor V1 transaction signing
+
+Replaced `v1::Transaction::sign` with `v1::Transaction::whole_sig_hash` and `v1::Transaction::partial_sig_hash`. This change is primarily to provide a more consistent experience with `core` and the V2::Transaction API.


### PR DESCRIPTION
Replaces `v1::Transaction::sign` with `v1::Transaction::whole_sig_hash` and `v1::Transaction::partial_sig_hash`. This change is primarily to provide a more consistent experience with `core` and the V2::Transaction API. It also makes it slightly less annoying for the JS SDK to implement signing.