### PR TITLE
SDK client

### DIFF
--- a/.changeset/add_sdk_client.md
+++ b/.changeset/add_sdk_client.md
@@ -1,0 +1,4 @@
+---
+---
+
+# Expose an SDK client that exposes an upload and download method.

--- a/.changeset/add_sdk_client.md
+++ b/.changeset/add_sdk_client.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-# Expose an SDK client that exposes an upload and download method.
+# Add an SDK client that exposes an upload and download method.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,8 @@ dependencies = [
  "httptest",
  "rand",
  "reqwest",
+ "rustls",
+ "rustls-platform-verifier 0.6.1",
  "serde",
  "serde_json",
  "sia_sdk",

--- a/indexd/Cargo.toml
+++ b/indexd/Cargo.toml
@@ -15,11 +15,14 @@ path = "src/lib.rs"
 
 [dependencies]
 reqwest = { version = "0.12.23", features = ["json"] }
+rustls = { version = "0.23.31", features = ["ring"] }
+rustls-platform-verifier = "0.6.1"
 serde = "1.0.219"
 serde_json = "1.0.143"
 thiserror = "2.0.16"
-sia_sdk = { path = "../sia_sdk" }
+sia_sdk = { path = "../sia_sdk", features=["quic"] }
 time = "0.3.41"
+tokio = { version = "1.47.1", features = ["fs", "macros", "rt", "rt-multi-thread"] }
 rand = "0.9.2"
 blake2b_simd = "1.0.3"
 url = "2.5.7"

--- a/indexd/src/lib.rs
+++ b/indexd/src/lib.rs
@@ -1,1 +1,188 @@
-pub mod app_client;
+mod app_client;
+
+use crate::app_client::{Client, RegisterAppRequest};
+pub use reqwest::{IntoUrl, Url};
+use rustls_platform_verifier::ConfigVerifierExt;
+use sia::objects::slabs::Slab;
+use sia::objects::{Downloader, HostDialer, Uploader};
+use sia::rhp::quic::Dialer;
+use sia::signing::PrivateKey;
+use std::time::Duration;
+use thiserror::Error;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+pub struct DisconnectedState;
+
+pub struct RegisteredState {
+    app: Client,
+    app_key: PrivateKey,
+
+    connect_url: Option<Url>,
+    status_url: Option<Url>,
+}
+
+pub struct ConnectedState {
+    downloader: Downloader<Dialer>,
+    uploader: Uploader<Dialer>,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("app error: {0}")]
+    App(String),
+    #[error("SDK error: {0}")]
+    SDK(String),
+    #[error("TLS error: {0}")]
+    Tls(String),
+}
+
+pub struct SDK<S> {
+    state: S,
+}
+
+impl SDK<DisconnectedState> {
+    pub async fn connect(
+        app_url: &str,
+        app_key: PrivateKey,
+        app_name: String,
+        app_description: String,
+        app_service_url: Url,
+    ) -> Result<SDK<RegisteredState>, Error> {
+        let client =
+            Client::new(app_url, app_key.clone()).map_err(|e| Error::App(format!("{e:?}")))?;
+
+        let authenticated = client
+            .check_app_authenticated()
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+
+        if authenticated {
+            return Ok(SDK {
+                state: RegisteredState {
+                    app: client,
+                    app_key,
+                    connect_url: None,
+                    status_url: None,
+                },
+            });
+        }
+
+        let res = client
+            .request_app_connection(&RegisterAppRequest {
+                name: app_name,
+                description: app_description,
+                service_url: app_service_url,
+                logo_url: None,
+                callback_url: None,
+            })
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+
+        Ok(SDK {
+            state: RegisteredState {
+                app: client,
+                app_key,
+                connect_url: Some(
+                    res.response_url
+                        .parse()
+                        .map_err(|e| Error::App(format!("{e:?}")))?,
+                ),
+                status_url: Some(
+                    res.status_url
+                        .parse()
+                        .map_err(|e| Error::App(format!("{e:?}")))?,
+                ),
+            },
+        })
+    }
+}
+
+impl SDK<RegisteredState> {
+    pub fn needs_approval(&self) -> bool {
+        self.state.connect_url.is_some()
+    }
+
+    pub fn approval_url(&self) -> Option<&Url> {
+        self.state.connect_url.as_ref()
+    }
+
+    pub async fn connected(
+        self,
+        tls_config: Option<rustls::ClientConfig>,
+    ) -> Result<SDK<ConnectedState>, Error> {
+        if self.state.connect_url.is_some() {
+            loop {
+                let ok = self
+                    .state
+                    .app
+                    .check_request_status(self.state.status_url.clone().unwrap())
+                    .await
+                    .map_err(|e| Error::App(format!("{e:?}")))?;
+                if ok {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+            tokio::time::sleep(Duration::from_secs(30)).await; // wait for accounts to get funded
+        }
+
+        if rustls::crypto::CryptoProvider::get_default().is_none() {
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .map_err(|e| Error::Tls(format!("{e:?}")))?;
+        }
+        let tls_config = match tls_config {
+            Some(c) => c,
+            None => rustls::ClientConfig::with_platform_verifier()
+                .map_err(|_| Error::Tls("with_platform_verifier() failed".into()))?,
+        };
+
+        let hosts = self
+            .state
+            .app
+            .hosts()
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+
+        let mut dialer = Dialer::new(tls_config).map_err(|e| Error::Tls(format!("{e:?}")))?;
+        dialer.update_hosts(hosts);
+
+        let downloader = Downloader::new(dialer.clone(), self.state.app_key.clone(), 12);
+        let uploader = Uploader::new(dialer.clone(), self.state.app_key.clone(), 12);
+
+        Ok(SDK {
+            state: ConnectedState {
+                downloader,
+                uploader,
+            },
+        })
+    }
+}
+
+impl SDK<ConnectedState> {
+    pub async fn upload<R: AsyncReadExt + Unpin + Send + 'static>(
+        &self,
+        reader: &mut R,
+        encryption_key: [u8; 32],
+        data_shards: u8,
+        parity_shards: u8,
+    ) -> Result<Vec<Slab>, Error> {
+        self.state
+            .uploader
+            .upload(reader, encryption_key, data_shards, parity_shards)
+            .await
+            .map_err(|e| Error::SDK(format!("{e:?}")))
+    }
+
+    pub async fn download<W: AsyncWriteExt + Unpin>(
+        &self,
+        writer: &mut W,
+        slabs: &[Slab],
+    ) -> Result<(), Error> {
+        self.state
+            .downloader
+            .download(writer, slabs)
+            .await
+            .map_err(|e| Error::SDK(format!("{e:?}")))
+    }
+}

--- a/indexd/src/lib.rs
+++ b/indexd/src/lib.rs
@@ -162,7 +162,7 @@ impl SDK<RegisteredState> {
 impl SDK<ConnectedState> {
     pub async fn upload<R: AsyncReadExt + Unpin + Send + 'static>(
         &self,
-        reader: &mut R,
+        reader: R,
         encryption_key: [u8; 32],
         data_shards: u8,
         parity_shards: u8,

--- a/sia_sdk/src/objects.rs
+++ b/sia_sdk/src/objects.rs
@@ -7,11 +7,11 @@ use bytes::Bytes;
 use futures::StreamExt;
 use futures::future::try_join_all;
 use futures::stream::FuturesUnordered;
+use log::debug;
 use thiserror::Error;
 use tokio::io::{AsyncReadExt, BufReader, BufWriter};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
-use log::debug;
 
 use crate::objects::encryption::{encrypt_shard, encrypt_shards};
 use crate::objects::erasure_coding::ErasureCoder;

--- a/sia_sdk/src/objects.rs
+++ b/sia_sdk/src/objects.rs
@@ -269,7 +269,7 @@ where
             let index = slabs.len();
             sector_jobs.spawn(async move {
                 encrypt_shards(&encryption_key, &mut shards, 0);
-                Self::try_upload_shards(inner, shards.drain(..).map(Bytes::from).collect())
+                Self::try_upload_shards(inner, shards.into_iter().map(Bytes::from).collect())
                     .await
                     .map(|sectors| (index, sectors))
             });


### PR DESCRIPTION
**NOTE**: verified with Nate's upload demo, see [here](https://github.com/SiaFoundation/indexd-utils/pull/3)

To be able to upload a file using the rust SDK we have to instantiate an app client, a dialer and use those to construct an uploader and downloader. That's not ideal, it should be as close as possible to:

```rust
let sdk = SDK::new(opts)
sdk.upload(...)
sdk.download(...)
```

Unfortunately that's not possible because of the connect flow. If we're not connected yet, we have to register the application by navigating to the connect URL and then polling until the status changes. I used type states to return an SDK in three different kind of states. A disconnected, connecting and connected state.

```rust
    let sdk = SDK::connect( 
            APP_URL,
            app_key,
            "upload-rs".into(),
            "A simple upload tool ".into(),
            "https://foo.bar".parse().unwrap(),
        )
        .await?;

    if sdk.needs_approval() {
        info!("approve the app at: {}", sdk.approval_url().unwrap());
    }

    let sdk = sdk.connected(None).await?;
    info!("app connected");
    
    sdk.upload(...)
    sdk.download(...)
```

This is definitely better than what we have now.