### PR TITLE
Support partial sector uploads

### DIFF
--- a/.changeset/support_partial_sectors_for_erasure_coding_and_rpc_write.md
+++ b/.changeset/support_partial_sectors_for_erasure_coding_and_rpc_write.md
@@ -1,0 +1,7 @@
+---
+sia_sdk: minor
+indexd: minor
+indexd_ffi: minor
+---
+
+# Support partial sectors for erasure coding and RPC write.

--- a/indexd/src/quic/client.rs
+++ b/indexd/src/quic/client.rs
@@ -301,10 +301,9 @@ impl HostMetric {
 impl Ord for HostMetric {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // new hosts are higher priority to get a baseline
-        if !self.tried && other.tried {
-            return std::cmp::Ordering::Greater;
-        } else if self.tried && !other.tried {
-            return std::cmp::Ordering::Less;
+        let tried_cmp = other.tried.cmp(&self.tried);
+        if tried_cmp != std::cmp::Ordering::Equal {
+            return tried_cmp;
         }
         match other.avg().cmp(&self.avg()) {
             std::cmp::Ordering::Equal => self.successful.cmp(&other.successful), // more successful RPCs is higher priority

--- a/sia_sdk/src/rhp/rpc.rs
+++ b/sia_sdk/src/rhp/rpc.rs
@@ -772,6 +772,7 @@ impl<T: Transport> RPCWriteSector<T, RPCInit> {
         let (tx, rx) = oneshot::channel();
         let root_data = data.clone();
         rayon::spawn(move || {
+            // pad data to SECTOR_SIZE if needed
             let root_data = if root_data.len() != SECTOR_SIZE {
                 let mut data = BytesMut::with_capacity(SECTOR_SIZE);
                 data.extend_from_slice(&root_data);


### PR DESCRIPTION
Significantly reduces bandwidth consumption when uploading small files in resource constrained environments by utilizing RHP4's support for partial sectors.

This will require a change in indexd's repair code to ensure the sector root stays constant. Not ideal, but might be worth it for the bandwidth savings on mobile.