### PR TITLE
Track failure rate rather than total RPC count

### DIFF
--- a/.changeset/track_rpc_failure_rate_when_selecting_hosts_rather_than_raw_rpcs.md
+++ b/.changeset/track_rpc_failure_rate_when_selecting_hosts_rather_than_raw_rpcs.md
@@ -1,0 +1,6 @@
+---
+indexd_ffi: minor
+indexd: minor
+---
+
+# Track RPC failure rate when selecting hosts rather than raw RPCs.


### PR DESCRIPTION
Changes the host priority queue to track failure rate rather than RPC count to improve host selection when a host succeeds once, but fails repeatedly afterwards.

Changes downloads to prioritize shards based on the performance of the hosts.