### PR TITLE
Remove SlabFetcher

### DIFF
--- a/.changeset/remove_slabfetcher_now_that_we_have_the_full_slab_info_in_the_object.md
+++ b/.changeset/remove_slabfetcher_now_that_we_have_the_full_slab_info_in_the_object.md
@@ -1,0 +1,5 @@
+---
+indexd: patch
+---
+
+# Remove SlabFetcher now that we have the full slab info in the object.

--- a/indexd/src/quic/download.rs
+++ b/indexd/src/quic/download.rs
@@ -240,8 +240,8 @@ impl Downloader {
         }
     }
 
-    /// Downloads slabs from the provided SlabIterator and writes
-    /// the encrypted data to the provided writer.
+    /// Downloads the provided slabs and writes the encrypted data to the
+    /// provided writer.
     ///
     /// This is a low-level function that can be used to download
     /// arbitrary slabs. Most users should use [Downloader::download]


### PR DESCRIPTION
Since we now return full objects, we can use that instead of fetching slabs on demand.