### PR TITLE
Update SealedObject

### DIFF
--- a/indexd/src/slabs.rs
+++ b/indexd/src/slabs.rs
@@ -111,10 +111,10 @@ pub struct SealedObject {
     pub slabs: Vec<Slab>,
     pub data_signature: Signature,
 
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(as = "DefaultOnNull<Base64>")]
     pub encrypted_metadata_key: Vec<u8>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(as = "DefaultOnNull<Base64>")]
     pub encrypted_metadata: Vec<u8>,
     pub metadata_signature: Signature,


### PR DESCRIPTION
Don't serialize metadata and the accompanying key if they are empty.  I was on the fence between this and `Option<Vec<u8>>`... I guess that's more idiomatic Rust but it would've required more changes and `Option` is a little annoying to work with? 

This PR is related to https://github.com/SiaFoundation/indexd/pull/736