### PR TITLE
Add License section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ for production use. The API will have breaking changes.
 - [ ] Transaction signing
 - [ ] RHP4
 - [ ] State tree verification
+
+## License
+This project makes use of the `webpki-roots` crate which contains data from
+Common CA Database (CCADB) and is used under the CDLA-2.0-Permissive license.
+The remaining code in this project is licensed under the MIT License.


### PR DESCRIPTION
This PR adds a license section to the repo. This was triggered by a [socket alert](https://github.com/SiaFoundation/sia-sdk-rs/pull/226#issuecomment-3710179101) indicating that a potentially incompatible license is used by one of our dependencies.

After some reading it seems like CDLA-2.0-Permissive license is compatible with MIT but [requires](https://www.ccadb.org/rootstores/usage#ccadb-data-usage-terms) a disclaimer when using CCADB data in derived work.