### PR TITLE
Fix FFI writer

### DIFF
--- a/.changeset/changed_download_function_to_borrow_the_writer.md
+++ b/.changeset/changed_download_function_to_borrow_the_writer.md
@@ -1,0 +1,5 @@
+---
+indexd: major
+---
+
+# Changed download function to borrow the writer.

--- a/.changeset/fixed_an_issue_with_downloaded_data_not_always_being_flushed_to_the_passed_in_writer.md
+++ b/.changeset/fixed_an_issue_with_downloaded_data_not_always_being_flushed_to_the_passed_in_writer.md
@@ -1,0 +1,5 @@
+---
+indexd_ffi: minor
+---
+
+# Fixed an issue with downloaded data not always being flushed to the passed in writer.

--- a/indexd/benches/upload.rs
+++ b/indexd/benches/upload.rs
@@ -157,7 +157,7 @@ fn upload_benchmark(c: &mut Criterion) {
             b.to_async(&runtime).iter(|| async {
                 downloader
                     .download(
-                        sink(),
+                        &mut sink(),
                         object,
                         DownloadOptions {
                             max_inflight: 30,
@@ -177,7 +177,7 @@ fn upload_benchmark(c: &mut Criterion) {
             b.to_async(&runtime).iter(|| async {
                 downloader
                     .download(
-                        sink(),
+                        &mut sink(),
                         object,
                         DownloadOptions {
                             max_inflight: 10,
@@ -196,7 +196,7 @@ fn upload_benchmark(c: &mut Criterion) {
         |b, object| {
             b.to_async(&runtime).iter(|| async {
                 downloader
-                    .download(sink(), object, DownloadOptions::default())
+                    .download(&mut sink(), object, DownloadOptions::default())
                     .await
                     .expect("download to complete");
             });

--- a/indexd/src/download.rs
+++ b/indexd/src/download.rs
@@ -236,7 +236,7 @@ where
     /// provided writer.
     pub async fn download<W: AsyncWriteExt + Unpin>(
         &self,
-        w: W,
+        w: &mut W,
         object: &Object,
         options: DownloadOptions,
     ) -> Result<(), DownloadError> {

--- a/indexd/src/lib.rs
+++ b/indexd/src/lib.rs
@@ -129,7 +129,7 @@ impl SDK {
     /// Downloads an object using the provided writer and options.
     pub async fn download<W: AsyncWriteExt + Unpin>(
         &self,
-        w: W,
+        w: &mut W,
         object: &Object,
         options: DownloadOptions,
     ) -> Result<(), DownloadError> {
@@ -382,7 +382,7 @@ mod test {
         let mut output = BytesMut::zeroed(13);
         downloader
             .download(
-                Cursor::new(&mut output[..]),
+                &mut Cursor::new(&mut output[..]),
                 &objects[0],
                 DownloadOptions::default(),
             )
@@ -394,7 +394,7 @@ mod test {
         let mut output = BytesMut::zeroed(13);
         downloader
             .download(
-                Cursor::new(&mut output[..]),
+                &mut Cursor::new(&mut output[..]),
                 &objects[1],
                 DownloadOptions::default(),
             )
@@ -467,7 +467,7 @@ mod test {
         let mut output = BytesMut::zeroed(objects[0].size() as usize);
         downloader
             .download(
-                Cursor::new(&mut output[..]),
+                &mut Cursor::new(&mut output[..]),
                 &objects[0],
                 DownloadOptions::default(),
             )
@@ -479,7 +479,7 @@ mod test {
         let mut output = BytesMut::zeroed(objects[1].size() as usize);
         downloader
             .download(
-                Cursor::new(&mut output[..]),
+                &mut Cursor::new(&mut output[..]),
                 &objects[1],
                 DownloadOptions::default(),
             )
@@ -537,7 +537,7 @@ mod test {
         let mut output = BytesMut::zeroed(objects[0].size() as usize);
         downloader
             .download(
-                Cursor::new(&mut output[..]),
+                &mut Cursor::new(&mut output[..]),
                 &objects[0],
                 DownloadOptions::default(),
             )
@@ -585,7 +585,7 @@ mod test {
         let mut output = BytesMut::zeroed(object.size() as usize);
         downloader
             .download(
-                Cursor::new(&mut output[..]),
+                &mut Cursor::new(&mut output[..]),
                 &object,
                 DownloadOptions::default(),
             )
@@ -598,7 +598,7 @@ mod test {
         let mut output = BytesMut::zeroed(range.end - range.start);
         downloader
             .download(
-                Cursor::new(&mut output[..]),
+                &mut Cursor::new(&mut output[..]),
                 &object,
                 DownloadOptions {
                     offset: range.start as u64,

--- a/indexd/src/mock.rs
+++ b/indexd/src/mock.rs
@@ -121,7 +121,7 @@ impl MockDownloader {
 
     pub async fn download<W: AsyncWriteExt + Send + Sync + Unpin>(
         &self,
-        w: W,
+        w: &mut W,
         object: &Object,
         options: DownloadOptions,
     ) -> Result<(), DownloadError> {

--- a/indexd_ffi/examples/python/example.py
+++ b/indexd_ffi/examples/python/example.py
@@ -90,8 +90,9 @@ async def main():
 
     start = datetime.now(timezone.utc)
     writer = BytesWriter()
+    print(f"Downloading object {objects[-1].id()} {objects[-1].size()} bytes")
     await sdk.download(writer, objects[-1], DownloadOptions())
     elapsed = datetime.now(timezone.utc) - start
-    print(f"Downloaded object {objects[-1].id()} with {writer.get_data()} bytes in {elapsed}")
+    print(f"Downloaded object {objects[-1].id()} with {len(writer.get_data())} bytes in {elapsed}")
 
 asyncio.run(main())


### PR DESCRIPTION
The FFIWriter had a race condition that could cause data to not be flushed. `poll_shutdown` returned immediately after closing the channel without waiting for the background task to drain all buffered data. This caused issues in Swift, but async scheduling seemed to always get lucky in Python and JS.

Also changes `download` to borrow the writer instead of taking ownership to get rid of it needing to be `Clone`.

A bit cleaner and more idiomatic than #248 since it hooks into shutdown on the trait instead of awaiting the join handle directly.

@peterjan can you verify this against #249 