### PR TITLE
fix: use AsyncRead/AsyncWrite instead of AsyncReadExt/AsyncWriteExt in trait bounds

### DIFF
--- a/indexd/src/download.rs
+++ b/indexd/src/download.rs
@@ -9,7 +9,7 @@ use sia::erasure_coding::{self, ErasureCoder};
 use sia::rhp::SEGMENT_SIZE;
 use sia::signing::PrivateKey;
 use thiserror::Error;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::{JoinSet, spawn_blocking};
 use tokio::time::error::Elapsed;
@@ -234,7 +234,7 @@ where
 
     /// Downloads the provided slabs and writes the decrypted data to the
     /// provided writer.
-    pub async fn download<W: AsyncWriteExt + Unpin>(
+    pub async fn download<W: AsyncWrite + Unpin>(
         &self,
         w: &mut W,
         object: &Object,

--- a/indexd/src/lib.rs
+++ b/indexd/src/lib.rs
@@ -14,7 +14,7 @@ use crate::app_client::{Account, ObjectsCursor};
 use sia::rhp::Host;
 use sia::types::Hash256;
 use thiserror::Error;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 pub use reqwest::{IntoUrl, Url};
 
@@ -105,7 +105,7 @@ impl SDK {
     /// # Returns
     /// A new object containing the metadata needed to download the object. The object can be sealed and pinned to the
     /// indexer when ready.
-    pub async fn upload<R: AsyncReadExt + Unpin + Send + 'static>(
+    pub async fn upload<R: AsyncRead + Unpin + Send + 'static>(
         &self,
         reader: R,
         options: UploadOptions,
@@ -127,7 +127,7 @@ impl SDK {
     }
 
     /// Downloads an object using the provided writer and options.
-    pub async fn download<W: AsyncWriteExt + Unpin>(
+    pub async fn download<W: AsyncWrite + Unpin>(
         &self,
         w: &mut W,
         object: &Object,

--- a/indexd/src/mock.rs
+++ b/indexd/src/mock.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 use sia::rhp::{self, HostPrices};
 use sia::signing::{PrivateKey, PublicKey, Signature};
 use sia::types::{Currency, Hash256};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::sleep;
 
 use crate::rhp4::{self, RHP4Client};
@@ -140,7 +140,7 @@ impl MockUploader {
         }
     }
 
-    pub async fn upload<R: AsyncReadExt + Send + Sync + Unpin + 'static>(
+    pub async fn upload<R: AsyncRead + Send + Sync + Unpin + 'static>(
         &self,
         r: R,
         options: UploadOptions,
@@ -164,7 +164,7 @@ impl MockDownloader {
         }
     }
 
-    pub async fn download<W: AsyncWriteExt + Send + Sync + Unpin>(
+    pub async fn download<W: AsyncWrite + Send + Sync + Unpin>(
         &self,
         w: &mut W,
         object: &Object,

--- a/indexd/src/upload.rs
+++ b/indexd/src/upload.rs
@@ -9,7 +9,7 @@ use sia::erasure_coding::{self, ErasureCoder};
 use sia::rhp::{self, SECTOR_SIZE};
 use sia::signing::{PrivateKey, PublicKey};
 use thiserror::Error;
-use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, SimplexStream, WriteHalf, copy, simplex};
+use tokio::io::{AsyncRead, AsyncWriteExt, BufReader, SimplexStream, WriteHalf, copy, simplex};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 use tokio::task::{JoinSet, spawn_blocking};
 use tokio::time::error::Elapsed;
@@ -168,7 +168,7 @@ impl PackedUpload {
     /// Adds a new object to the upload. The data will be read until EOF and packed into
     /// the upload. The resulting object will contain the metadata needed to download the object. The caller
     /// must call [finalize](Self::finalize) to get the resulting objects after all objects have been added.
-    pub async fn add<R: AsyncReadExt + Unpin>(&mut self, r: R) -> io::Result<u64> {
+    pub async fn add<R: AsyncRead + Unpin>(&mut self, r: R) -> io::Result<u64> {
         if self.upload_handle.is_finished() {
             // should only happen if the upload errored; callers can get the error by calling finalize
             return Err(io::Error::other("cannot add object to finalized upload"));
@@ -304,7 +304,7 @@ where
         }
     }
 
-    async fn upload_slabs<R: AsyncReadExt + Unpin + Send + 'static>(
+    async fn upload_slabs<R: AsyncRead + Unpin + Send + 'static>(
         transport: T,
         hosts: Hosts,
         app_key: Arc<PrivateKey>,
@@ -475,7 +475,7 @@ where
     /// # Returns
     /// A new object containing the metadata needed to download the object. The caller
     /// must pin the object to an indexer after uploading.
-    pub async fn upload<R: AsyncReadExt + Unpin + Send + 'static>(
+    pub async fn upload<R: AsyncRead + Unpin + Send + 'static>(
         &self,
         r: R,
         options: UploadOptions,

--- a/sia_sdk/src/encoding_async/v2.rs
+++ b/sia_sdk/src/encoding_async/v2.rs
@@ -1,7 +1,7 @@
 use super::Error as EncodingError;
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, Duration, Utc};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 pub trait AsyncEncoder {
     type Error: From<EncodingError>;
@@ -24,7 +24,7 @@ pub trait AsyncSiaDecodable: Sized {
     fn decode_async<D: AsyncDecoder>(r: &mut D) -> impl Future<Output = Result<Self, D::Error>>;
 }
 
-impl<T: AsyncWriteExt + Unpin> AsyncEncoder for T {
+impl<T: AsyncWrite + Unpin> AsyncEncoder for T {
     type Error = EncodingError;
     async fn encode_buf(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
         self.write_all(buf).await?;
@@ -32,7 +32,7 @@ impl<T: AsyncWriteExt + Unpin> AsyncEncoder for T {
     }
 }
 
-impl<T: AsyncReadExt + Unpin> AsyncDecoder for T {
+impl<T: AsyncRead + Unpin> AsyncDecoder for T {
     type Error = EncodingError;
     async fn decode_buf(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
         self.read_exact(buf).await?;


### PR DESCRIPTION
Function trait bounds were using `AsyncReadExt`/`AsyncWriteExt` when they only need `AsyncRead`/`AsyncWrite`.

The `Ext` traits are automatically implemented for anything that implements the base traits, so using them as bounds makes the API more restrictive than necessary.