### PR TITLE
Mux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: tenki-standard-autoscale
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Build Go interop helper
+        run: cd mux/testutil/go-interop && go build -o interop .
       - name: Setup Environment
         run: |
           rustup update stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,6 +1679,7 @@ dependencies = [
 name = "mux"
 version = "0.1.0"
 dependencies = [
+ "chacha20poly1305",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,11 +1681,15 @@ name = "mux"
 version = "0.1.0"
 dependencies = [
  "blake2b_simd",
+ "bytes",
  "chacha20poly1305",
  "ed25519-dalek",
  "rand_core 0.6.4",
+ "serde_json",
+ "sia_sdk",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "x25519-dalek",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "mux"
+version = "0.1.0"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,9 +1679,13 @@ dependencies = [
 name = "mux"
 version = "0.1.0"
 dependencies = [
+ "blake2b_simd",
  "chacha20poly1305",
+ "ed25519-dalek",
+ "rand_core 0.6.4",
  "thiserror 2.0.18",
  "tokio",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -3947,6 +3951,18 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,6 +1678,10 @@ dependencies = [
 [[package]]
 name = "mux"
 version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.18",
+ "tokio",
+]
 
 [[package]]
 name = "nom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["sia_sdk", "sia_derive", "indexd", "indexd_ffi"]
+members = ["sia_sdk", "sia_derive", "indexd", "indexd_ffi", "mux"]
 
 # CPU-intensive operations (erasure coding, hashing, encryption) are
 # ~100x slower without optimizations. Some tests will be extremely

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+thiserror = "2.0.18"

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+blake2b_simd = "1.0.4"
 chacha20poly1305 = "0.10.1"
+ed25519-dalek = "2.2.0"
+rand_core = { version = "0.6", features = ["getrandom"] }
 thiserror = "2.0.18"
 tokio = { version = "1", features = ["io-util", "rt", "macros"] }
+x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+chacha20poly1305 = "0.10.1"
 thiserror = "2.0.18"
 tokio = { version = "1", features = ["io-util", "rt", "macros"] }

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -9,5 +9,11 @@ chacha20poly1305 = "0.10.1"
 ed25519-dalek = { version = "2.2.0", features = ["rand_core"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 thiserror = "2.0.18"
-tokio = { version = "1", features = ["io-util", "rt", "macros"] }
+tokio = { version = "1", features = ["io-util", "rt", "rt-multi-thread", "macros", "sync", "time", "net"] }
+tokio-util = "0.7.18"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
+
+[dev-dependencies]
+sia_sdk = { path = "../sia_sdk" }
+bytes = "1"
+serde_json = "1"

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 blake2b_simd = "1.0.4"
 chacha20poly1305 = "0.10.1"
-ed25519-dalek = "2.2.0"
+ed25519-dalek = { version = "2.2.0", features = ["rand_core"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 thiserror = "2.0.18"
 tokio = { version = "1", features = ["io-util", "rt", "macros"] }

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 thiserror = "2.0.18"
+tokio = { version = "1", features = ["io-util", "rt", "macros"] }

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "mux"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/mux/examples/rpc_settings.rs
+++ b/mux/examples/rpc_settings.rs
@@ -1,0 +1,121 @@
+//! Dial a Sia host over TCP, establish a mux connection, and call RPCSettings.
+//!
+//! Usage:
+//!   cargo run -p mux --example rpc_settings -- <host:port> <ed25519:pubkey>
+//!   cargo run -p mux --example rpc_settings -- --anonymous <host:port>
+
+use std::env;
+
+use bytes::Bytes;
+use ed25519_dalek::VerifyingKey;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use mux::{DialError, MuxError};
+use sia::encoding::Error as EncodingError;
+use sia::encoding_async::AsyncDecoder;
+use sia::rhp::{self, RPCRequest, RPCResponse, RPCSettings, Transport};
+use sia::signing::PublicKey;
+
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error("mux: {0}")]
+    Mux(#[from] MuxError),
+    #[error("handshake: {0}")]
+    Handshake(#[from] mux::handshake::HandshakeError),
+    #[error("rhp: {0}")]
+    Rhp(#[from] rhp::Error),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("encoding: {0}")]
+    Encoding(#[from] EncodingError),
+    #[error("dial: {0}")]
+    Dial(#[from] DialError),
+}
+
+/// Wraps a mux [`Stream`](mux::Stream) to implement [`Transport`].
+struct MuxTransport(mux::Stream);
+
+impl AsyncDecoder for MuxTransport {
+    type Error = Error;
+    async fn decode_buf(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        self.0.read_exact(buf).await?;
+        Ok(())
+    }
+}
+
+impl Transport for MuxTransport {
+    type Error = Error;
+
+    async fn write_request<R: RPCRequest>(&mut self, req: &R) -> Result<(), Self::Error> {
+        req.encode_request(&mut self.0).await?;
+        Ok(())
+    }
+
+    async fn write_bytes(&mut self, data: Bytes) -> Result<(), Self::Error> {
+        self.0.write_all(&data).await?;
+        Ok(())
+    }
+
+    async fn read_response<R: RPCResponse>(&mut self) -> Result<R, Self::Error> {
+        R::decode_response(self).await
+    }
+
+    async fn write_response<RR: RPCResponse>(&mut self, resp: &RR) -> Result<(), Self::Error> {
+        resp.encode_response(&mut self.0).await?;
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let args: Vec<String> = env::args().collect();
+
+    let (addr, anonymous) = match args.get(1).map(String::as_str) {
+        Some("--anonymous") => (
+            args.get(2)
+                .expect("usage: rpc_settings --anonymous <host:port>")
+                .as_str(),
+            true,
+        ),
+        Some(addr) => (addr, false),
+        None => {
+            eprintln!("usage: rpc_settings [--anonymous] <host:port> [ed25519:pubkey]");
+            std::process::exit(1);
+        }
+    };
+
+    // Connect TCP
+    eprintln!("connecting to {addr}...");
+    let tcp = TcpStream::connect(addr).await?;
+
+    // Establish mux
+    let m = if anonymous {
+        eprintln!("performing anonymous mux handshake...");
+        mux::dial_anonymous(tcp).await?
+    } else {
+        let key_str = args.get(2).expect("missing host public key (ed25519:...)");
+        let sia_key: PublicKey = key_str.parse().expect("invalid public key format");
+        let bytes: [u8; 32] = sia_key.into();
+        let vk = VerifyingKey::from_bytes(&bytes).expect("invalid ed25519 key");
+        eprintln!("performing mux handshake (verifying host key)...");
+        mux::dial(tcp, &vk).await?
+    };
+    eprintln!("mux established");
+
+    // Open a stream and call RPCSettings
+    let stream = m.dial_stream()?;
+    let result = RPCSettings::send_request(MuxTransport(stream))
+        .await?
+        .complete()
+        .await?;
+
+    // Print the host settings as JSON
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&result.settings).unwrap()
+    );
+
+    m.close().await?;
+    Ok(())
+}

--- a/mux/src/frame.rs
+++ b/mux/src/frame.rs
@@ -1,4 +1,7 @@
+use std::io;
+use std::ops::Range;
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 /// Frame flags.
 pub const FLAG_FIRST: u16 = 1 << 0; // first frame in stream
@@ -20,6 +23,22 @@ pub const FRAME_HEADER_SIZE: usize = 4 + 2 + 2;
 pub enum FrameHeaderError {
     #[error("buffer too short for frame header")]
     BufferTooShort,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum PacketReaderError {
+    #[error("could not read frame header: {0}")]
+    ReadHeader(io::Error),
+    #[error("could not read frame payload: {0}")]
+    ReadPayload(io::Error),
+    #[error("peer sent too-large frame ({0} bytes)")]
+    FrameTooLarge(u16),
+    #[error("decryption failed: {0}")]
+    Decrypt(io::Error),
+    #[error("unexpected EOF reading packet")]
+    UnexpectedEof,
+    #[error("buffer too small ({0} bytes, need at least {FRAME_HEADER_SIZE})")]
+    BufferTooSmall(usize),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,6 +86,139 @@ pub fn append_frame(buf: &mut Vec<u8>, h: FrameHeader, payload: &[u8]) {
     let header_bytes: [u8; FRAME_HEADER_SIZE] = h.into();
     buf.extend_from_slice(&header_bytes);
     buf.extend_from_slice(payload);
+}
+
+/// Trait for sequential packet decryption. The handshake module will provide
+/// the concrete implementation (`seqCipher`).
+pub(crate) trait PacketCipher {
+    /// Decrypts `buf` in place, returning the length of the plaintext.
+    /// The plaintext occupies `buf[..len]` after decryption.
+    fn decrypt_in_place(&mut self, buf: &mut [u8]) -> Result<usize, io::Error>;
+}
+
+pub(crate) struct PacketReader<R, C> {
+    reader: R,
+    cipher: C,
+    packet_size: usize,
+    buf: Vec<u8>,
+    decrypted: Range<usize>, // region of buf containing decrypted plaintext to consume
+    encrypted: Range<usize>, // region of buf containing encrypted packets to decrypt
+}
+
+impl<R: AsyncRead + Unpin, C: PacketCipher> PacketReader<R, C> {
+    pub fn new(reader: R, cipher: C, packet_size: usize) -> Self {
+        Self {
+            reader,
+            cipher,
+            packet_size,
+            buf: vec![0u8; packet_size * 10],
+            decrypted: 0..0,
+            encrypted: 0..0,
+        }
+    }
+
+    /// Skips any padding remaining in the current decrypted packet.
+    ///
+    /// Frame IDs are encoded as `(id << 1) | 1`, so bit 0 of a frame header
+    /// is always 1. Padding is zero-filled, so bit 0 is 0. Checking the
+    /// first bit of the next byte tells us whether we're at a frame or
+    /// padding — if padding, discard the rest of the packet.
+    pub fn skip_padding(&mut self) {
+        // Indexing is safe: decrypted ranges are only set in read(), which
+        // derives them from valid buffer positions.
+        if self.decrypted.is_empty() || self.buf[self.decrypted.start] & 1 != 0 {
+            return;
+        }
+        self.decrypted = self.decrypted.end..self.decrypted.end;
+    }
+
+    /// Reads the next frame from the stream into `buf`. Returns the decoded
+    /// header and a slice of `buf` containing the payload.
+    pub async fn next_frame<'a>(
+        &mut self,
+        buf: &'a mut [u8],
+    ) -> Result<(FrameHeader, &'a [u8]), PacketReaderError> {
+        self.skip_padding();
+
+        if buf.len() < FRAME_HEADER_SIZE {
+            return Err(PacketReaderError::BufferTooSmall(buf.len()));
+        }
+
+        // Read and decode header
+        self.read_exact(&mut buf[..FRAME_HEADER_SIZE])
+            .await
+            .map_err(PacketReaderError::ReadHeader)?;
+
+        let h = FrameHeader::try_from(&buf[..FRAME_HEADER_SIZE])?;
+
+        let max_payload = self.packet_size - FRAME_HEADER_SIZE;
+        if h.length as usize > max_payload {
+            return Err(PacketReaderError::FrameTooLarge(h.length));
+        }
+
+        // Read payload into the same buffer (overwrites header bytes)
+        let payload_len = h.length as usize;
+        self.read_exact(&mut buf[..payload_len])
+            .await
+            .map_err(PacketReaderError::ReadPayload)?;
+
+        Ok((h, &buf[..payload_len]))
+    }
+
+    /// Reads from the decrypted stream until `buf` is completely filled.
+    async fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<(), io::Error> {
+        while !buf.is_empty() {
+            let n = self.read(buf).await?;
+            buf = &mut buf[n..];
+        }
+        Ok(())
+    }
+
+    /// Reads decrypted data into `p`. Reads and decrypts packets from the
+    /// underlying reader as needed.
+    pub async fn read(&mut self, p: &mut [u8]) -> Result<usize, io::Error> {
+        // if we have decrypted data, use that; otherwise, if we have an encrypted
+        // packet, decrypt it and use that; otherwise, read at least one more packet,
+        // decrypt it, and use that
+
+        if self.decrypted.is_empty() {
+            if self.encrypted.len() < self.packet_size {
+                // Compact remaining encrypted data to the start of the buffer
+                let remaining = self.encrypted.len();
+                self.buf.copy_within(self.encrypted.clone(), 0);
+                self.encrypted = 0..remaining;
+
+                // Read at least enough to complete one packet
+                let needed = self.packet_size - remaining;
+                let mut filled = remaining;
+                while filled - remaining < needed {
+                    let n = self.reader.read(&mut self.buf[filled..]).await?;
+                    if n == 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "unexpected EOF reading packet",
+                        ));
+                    }
+                    filled += n;
+                }
+                self.encrypted = 0..filled;
+            }
+
+            // Decrypt the first available packet
+            let packet_start = self.encrypted.start;
+            let packet_end = packet_start + self.packet_size;
+            let plaintext_len = self
+                .cipher
+                .decrypt_in_place(&mut self.buf[packet_start..packet_end])?;
+            self.decrypted = packet_start..packet_start + plaintext_len;
+            self.encrypted.start = packet_end;
+        }
+
+        let n = p.len().min(self.decrypted.len());
+        p[..n].copy_from_slice(&self.buf[self.decrypted.start..self.decrypted.start + n]);
+        self.decrypted.start += n;
+        Ok(n)
+    }
 }
 
 #[cfg(test)]

--- a/mux/src/frame.rs
+++ b/mux/src/frame.rs
@@ -1,0 +1,139 @@
+use thiserror::Error;
+
+/// Frame flags.
+pub const FLAG_FIRST: u16 = 1 << 0; // first frame in stream
+pub const FLAG_LAST: u16 = 1 << 1; // stream is being closed gracefully
+pub const FLAG_ERROR: u16 = 1 << 2; // stream is being closed due to an error
+
+/// Reserved stream IDs.
+pub const ID_KEEPALIVE: u32 = 0; // empty frame to keep connection open
+pub const ID_LOWEST_STREAM: u32 = 1 << 8; // IDs below this value are reserved
+
+/// AEAD constants.
+pub const AEAD_NONCE_SIZE: usize = 12;
+pub const AEAD_TAG_SIZE: usize = 16;
+
+/// Size of a frame header on the wire: 4 (id) + 2 (length) + 2 (flags).
+pub const FRAME_HEADER_SIZE: usize = 4 + 2 + 2;
+
+#[derive(Debug, Error)]
+pub enum FrameHeaderError {
+    #[error("buffer too short for frame header")]
+    BufferTooShort,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameHeader {
+    pub id: u32,
+    pub length: u16,
+    pub flags: u16,
+}
+
+/// Encodes the header as an 8-byte little-endian array.
+///
+/// The ID is shifted left by 1 with the lowest bit set to 1, which
+/// distinguishes frame data from padding (see the spec's "Covert Frames"
+/// section).
+impl From<FrameHeader> for [u8; FRAME_HEADER_SIZE] {
+    fn from(h: FrameHeader) -> Self {
+        let mut buf = [0u8; FRAME_HEADER_SIZE];
+        let id_wire = (h.id << 1) | 1;
+        buf[0..4].copy_from_slice(&id_wire.to_le_bytes());
+        buf[4..6].copy_from_slice(&h.length.to_le_bytes());
+        buf[6..8].copy_from_slice(&h.flags.to_le_bytes());
+        buf
+    }
+}
+
+/// Decodes a header from a byte slice that must be at least [`FRAME_HEADER_SIZE`] bytes.
+impl TryFrom<&[u8]> for FrameHeader {
+    type Error = FrameHeaderError;
+
+    fn try_from(buf: &[u8]) -> Result<Self, Self::Error> {
+        if buf.len() < FRAME_HEADER_SIZE {
+            return Err(FrameHeaderError::BufferTooShort);
+        }
+        let id_wire = u32::from_le_bytes(buf[0..4].try_into().expect("slice length checked above"));
+        Ok(Self {
+            id: id_wire >> 1,
+            length: u16::from_le_bytes(buf[4..6].try_into().expect("slice length checked above")),
+            flags: u16::from_le_bytes(buf[6..8].try_into().expect("slice length checked above")),
+        })
+    }
+}
+
+/// Appends a complete frame (header + payload) to `buf`.
+pub fn append_frame(buf: &mut Vec<u8>, h: FrameHeader, payload: &[u8]) {
+    let header_bytes: [u8; FRAME_HEADER_SIZE] = h.into();
+    buf.extend_from_slice(&header_bytes);
+    buf.extend_from_slice(payload);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_header_roundtrip_header() {
+        let h = FrameHeader {
+            id: 256,
+            length: 1024,
+            flags: FLAG_FIRST,
+        };
+        let buf: [u8; FRAME_HEADER_SIZE] = h.into();
+
+        // verify the wire-encoded ID has the lowest bit set
+        let id_wire = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+        assert_eq!(id_wire & 1, 1);
+        assert_eq!(id_wire >> 1, 256);
+
+        let decoded = FrameHeader::try_from(buf.as_slice()).unwrap();
+        assert_eq!(decoded, h);
+    }
+
+    #[test]
+    fn frame_header_roundtrip_keepalive() {
+        let h = FrameHeader {
+            id: ID_KEEPALIVE,
+            length: 0,
+            flags: 0,
+        };
+        let buf: [u8; FRAME_HEADER_SIZE] = h.into();
+
+        let id_wire = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+        assert_eq!(id_wire, 1); // (0 << 1) | 1
+
+        let decoded = FrameHeader::try_from(buf.as_slice()).unwrap();
+        assert_eq!(decoded, h);
+    }
+
+    #[test]
+    fn frame_header_decode_too_short() {
+        let buf = [0u8; 4];
+        let result = FrameHeader::try_from(buf.as_slice());
+        assert!(matches!(result, Err(FrameHeaderError::BufferTooShort)));
+    }
+
+    #[test]
+    fn append_frame_builds_correct_bytes() {
+        let h = FrameHeader {
+            id: 300,
+            length: 5,
+            flags: FLAG_LAST | FLAG_ERROR,
+        };
+        let payload = b"hello";
+
+        let mut buf = Vec::new();
+        append_frame(&mut buf, h, payload);
+
+        assert_eq!(buf.len(), FRAME_HEADER_SIZE + payload.len());
+
+        let decoded = FrameHeader::try_from(buf.as_slice()).unwrap();
+        assert_eq!(decoded.id, 300);
+        assert_eq!(decoded.length, 5);
+        assert_ne!(decoded.flags & FLAG_LAST, 0);
+        assert_ne!(decoded.flags & FLAG_ERROR, 0);
+        assert_eq!(decoded.flags & FLAG_FIRST, 0);
+        assert_eq!(&buf[FRAME_HEADER_SIZE..], b"hello");
+    }
+}

--- a/mux/src/frame.rs
+++ b/mux/src/frame.rs
@@ -33,10 +33,6 @@ pub(crate) enum PacketReaderError {
     ReadPayload(io::Error),
     #[error("peer sent too-large frame ({0} bytes)")]
     FrameTooLarge(u16),
-    #[error("decryption failed: {0}")]
-    Decrypt(io::Error),
-    #[error("unexpected EOF reading packet")]
-    UnexpectedEof,
     #[error("buffer too small ({0} bytes, need at least {FRAME_HEADER_SIZE})")]
     BufferTooSmall(usize),
     #[error("invalid frame header: {0}")]

--- a/mux/src/frame.rs
+++ b/mux/src/frame.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::ops::Range;
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// Frame flags.
 pub const FLAG_FIRST: u16 = 1 << 0; // first frame in stream
@@ -39,6 +39,8 @@ pub(crate) enum PacketReaderError {
     UnexpectedEof,
     #[error("buffer too small ({0} bytes, need at least {FRAME_HEADER_SIZE})")]
     BufferTooSmall(usize),
+    #[error("invalid frame header: {0}")]
+    InvalidHeader(#[from] FrameHeaderError),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/mux/src/handshake.rs
+++ b/mux/src/handshake.rs
@@ -115,7 +115,7 @@ impl TryFrom<&[u8]> for ConnSettings {
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum ConnSettingsError {
+pub enum ConnSettingsError {
     #[error("buffer too short for connection settings")]
     BufferTooShort,
     #[error("requested packet size ({0}) is too small")]
@@ -129,7 +129,7 @@ pub(crate) enum ConnSettingsError {
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum HandshakeError {
+pub enum HandshakeError {
     #[error("could not write handshake request: {0}")]
     WriteRequest(io::Error),
     #[error("could not read handshake response: {0}")]

--- a/mux/src/handshake.rs
+++ b/mux/src/handshake.rs
@@ -7,7 +7,11 @@ use std::io;
 use chacha20poly1305::aead::AeadInPlace;
 use chacha20poly1305::aead::generic_array::GenericArray;
 
-use crate::frame::{AEAD_NONCE_SIZE, AEAD_TAG_SIZE, PacketCipher};
+use std::time::Duration;
+
+use thiserror::Error;
+
+use crate::frame::{AEAD_NONCE_SIZE, AEAD_TAG_SIZE, FRAME_HEADER_SIZE, PacketCipher};
 
 pub(crate) struct SeqCipher {
     aead: chacha20poly1305::ChaCha20Poly1305,
@@ -43,6 +47,97 @@ impl PacketCipher for SeqCipher {
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "AEAD decryption failed"))?;
         inc_nonce(&mut self.their_nonce);
         Ok(plaintext_len)
+    }
+}
+
+const IPV6_MTU: u32 = 1440; // 1500-byte Ethernet frame - 40-byte IPv6 header - 20-byte TCP header
+
+pub(crate) const CONN_SETTINGS_SIZE: usize = 4 + 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ConnSettings {
+    pub packet_size: u32,
+    pub max_timeout: Duration,
+}
+
+impl ConnSettings {
+    pub fn max_frame_size(&self) -> usize {
+        self.packet_size as usize - AEAD_TAG_SIZE
+    }
+
+    pub fn max_payload_size(&self) -> usize {
+        self.max_frame_size() - FRAME_HEADER_SIZE
+    }
+}
+
+impl Default for ConnSettings {
+    fn default() -> Self {
+        Self {
+            packet_size: IPV6_MTU * 3,
+            max_timeout: Duration::from_secs(20 * 60),
+        }
+    }
+}
+
+impl From<ConnSettings> for [u8; CONN_SETTINGS_SIZE] {
+    fn from(cs: ConnSettings) -> Self {
+        let mut buf = [0u8; CONN_SETTINGS_SIZE];
+        buf[0..4].copy_from_slice(&cs.packet_size.to_le_bytes());
+        buf[4..8].copy_from_slice(&(cs.max_timeout.as_millis() as u32).to_le_bytes());
+        buf
+    }
+}
+
+impl TryFrom<&[u8]> for ConnSettings {
+    type Error = ConnSettingsError;
+
+    fn try_from(buf: &[u8]) -> Result<Self, Self::Error> {
+        if buf.len() < CONN_SETTINGS_SIZE {
+            return Err(ConnSettingsError::BufferTooShort);
+        }
+        Ok(Self {
+            packet_size: u32::from_le_bytes(
+                buf[0..4].try_into().expect("slice length checked above"),
+            ),
+            max_timeout: Duration::from_millis(u32::from_le_bytes(
+                buf[4..8].try_into().expect("slice length checked above"),
+            ) as u64),
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ConnSettingsError {
+    #[error("buffer too short for connection settings")]
+    BufferTooShort,
+    #[error("requested packet size ({0}) is too small")]
+    PacketSizeTooSmall(u32),
+    #[error("requested packet size ({0}) is too large")]
+    PacketSizeTooLarge(u32),
+    #[error("maximum timeout ({0:?}) is too short")]
+    TimeoutTooShort(Duration),
+    #[error("maximum timeout ({0:?}) is too long")]
+    TimeoutTooLong(Duration),
+}
+
+pub(crate) fn merge_settings(
+    ours: ConnSettings,
+    theirs: ConnSettings,
+) -> Result<ConnSettings, ConnSettingsError> {
+    let merged = ConnSettings {
+        packet_size: ours.packet_size.min(theirs.packet_size),
+        max_timeout: ours.max_timeout.min(theirs.max_timeout),
+    };
+    match merged {
+        s if s.packet_size < 1220 => Err(ConnSettingsError::PacketSizeTooSmall(s.packet_size)),
+        s if s.packet_size > 32768 => Err(ConnSettingsError::PacketSizeTooLarge(s.packet_size)),
+        s if s.max_timeout < Duration::from_secs(2 * 60) => {
+            Err(ConnSettingsError::TimeoutTooShort(s.max_timeout))
+        }
+        s if s.max_timeout > Duration::from_secs(2 * 60 * 60) => {
+            Err(ConnSettingsError::TimeoutTooLong(s.max_timeout))
+        }
+        _ => Ok(merged),
     }
 }
 
@@ -123,5 +218,67 @@ mod tests {
         // decrypting with c1 (wrong nonce direction) should fail
         let result = c1.decrypt_in_place(&mut buf);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn conn_settings_roundtrip() {
+        let cs = ConnSettings {
+            packet_size: 4320,
+            max_timeout: Duration::from_secs(600),
+        };
+        let buf: [u8; CONN_SETTINGS_SIZE] = cs.into();
+        let decoded = ConnSettings::try_from(buf.as_slice()).unwrap();
+        assert_eq!(decoded, cs);
+    }
+
+    #[test]
+    fn conn_settings_decode_too_short() {
+        let buf = [0u8; 4];
+        let result = ConnSettings::try_from(buf.as_slice());
+        assert!(matches!(result, Err(ConnSettingsError::BufferTooShort)));
+    }
+
+    #[test]
+    fn conn_settings_default_is_valid() {
+        let result = merge_settings(ConnSettings::default(), ConnSettings::default());
+        assert_eq!(result.unwrap(), ConnSettings::default());
+    }
+
+    #[test]
+    fn merge_settings_picks_smaller() {
+        let a = ConnSettings {
+            packet_size: 4320,
+            max_timeout: Duration::from_secs(20 * 60),
+        };
+        let b = ConnSettings {
+            packet_size: 2000,
+            max_timeout: Duration::from_secs(5 * 60),
+        };
+        let merged = merge_settings(a, b).unwrap();
+        assert_eq!(merged.packet_size, 2000);
+        assert_eq!(merged.max_timeout, Duration::from_secs(5 * 60));
+    }
+
+    #[test]
+    fn merge_settings_rejects_too_small_packet() {
+        let small = ConnSettings {
+            packet_size: 500,
+            max_timeout: Duration::from_secs(5 * 60),
+        };
+        let result = merge_settings(ConnSettings::default(), small);
+        assert!(matches!(
+            result,
+            Err(ConnSettingsError::PacketSizeTooSmall(500))
+        ));
+    }
+
+    #[test]
+    fn merge_settings_rejects_too_short_timeout() {
+        let short = ConnSettings {
+            packet_size: 4320,
+            max_timeout: Duration::from_secs(30),
+        };
+        let result = merge_settings(ConnSettings::default(), short);
+        assert!(matches!(result, Err(ConnSettingsError::TimeoutTooShort(_))));
     }
 }

--- a/mux/src/handshake.rs
+++ b/mux/src/handshake.rs
@@ -8,7 +8,7 @@ use chacha20poly1305::aead::AeadInPlace;
 use chacha20poly1305::aead::generic_array::GenericArray;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit};
 
-use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey, SIGNATURE_LENGTH};
+use ed25519_dalek::{SIGNATURE_LENGTH, Signer, SigningKey, Verifier, VerifyingKey};
 use x25519_dalek::{EphemeralSecret, PublicKey};
 
 const X25519_PUBLIC_KEY_SIZE: usize = 32;
@@ -21,10 +21,11 @@ use thiserror::Error;
 
 use crate::frame::{AEAD_NONCE_SIZE, AEAD_TAG_SIZE, FRAME_HEADER_SIZE, PacketCipher};
 
+#[derive(Clone)]
 pub(crate) struct SeqCipher {
     aead: chacha20poly1305::ChaCha20Poly1305,
-    our_nonce: [u8; AEAD_NONCE_SIZE],
-    their_nonce: [u8; AEAD_NONCE_SIZE],
+    pub(crate) our_nonce: [u8; AEAD_NONCE_SIZE],
+    pub(crate) their_nonce: [u8; AEAD_NONCE_SIZE],
 }
 
 /// Increments the first 8 bytes of a nonce as a little-endian u64.

--- a/mux/src/handshake.rs
+++ b/mux/src/handshake.rs
@@ -1,0 +1,9 @@
+use std::io;
+
+use crate::frame::{PacketCipher, AEAD_NONCE_SIZE, AEAD_TAG_SIZE};
+
+pub(crate) struct SeqCipher {
+    aead: chacha20poly1305::ChaCha20Poly1305,
+    our_nonce: [u8; AEAD_NONCE_SIZE],
+    their_nonce: [u8; AEAD_NONCE_SIZE],
+}

--- a/mux/src/handshake.rs
+++ b/mux/src/handshake.rs
@@ -212,8 +212,9 @@ pub(crate) async fn initiate_handshake<T: AsyncRead + AsyncWrite + Unpin>(
     let plaintext_len = cipher
         .decrypt_in_place(&mut buf[SETTINGS_START..])
         .map_err(HandshakeError::DecryptSettings)?;
-    let their_settings = ConnSettings::try_from(&buf[SETTINGS_START..SETTINGS_START + plaintext_len])
-        .map_err(HandshakeError::InvalidSettings)?;
+    let their_settings =
+        ConnSettings::try_from(&buf[SETTINGS_START..SETTINGS_START + plaintext_len])
+            .map_err(HandshakeError::InvalidSettings)?;
     let merged = merge_settings(our_settings, their_settings)
         .map_err(HandshakeError::UnacceptableSettings)?;
 
@@ -704,8 +705,9 @@ mod tests {
         );
 
         // Full responder wire: xpk + sig + encrypted_settings
-        let mut responder_wire =
-            Vec::with_capacity(X25519_PUBLIC_KEY_SIZE + SIGNATURE_LENGTH + CONN_SETTINGS_SIZE + AEAD_TAG_SIZE);
+        let mut responder_wire = Vec::with_capacity(
+            X25519_PUBLIC_KEY_SIZE + SIGNATURE_LENGTH + CONN_SETTINGS_SIZE + AEAD_TAG_SIZE,
+        );
         responder_wire.extend_from_slice(responder_xpk.as_bytes());
         responder_wire.extend_from_slice(&sig.to_bytes());
         responder_wire.extend_from_slice(&responder_enc);

--- a/mux/src/handshake.rs
+++ b/mux/src/handshake.rs
@@ -1,9 +1,127 @@
+// chacha20poly1305 0.10.x re-exports generic-array 0.x which is deprecated.
+// Remove this allow when upgrading to chacha20poly1305 0.11.0 stable.
+#![allow(deprecated)]
+
 use std::io;
 
-use crate::frame::{PacketCipher, AEAD_NONCE_SIZE, AEAD_TAG_SIZE};
+use chacha20poly1305::aead::AeadInPlace;
+use chacha20poly1305::aead::generic_array::GenericArray;
+
+use crate::frame::{AEAD_NONCE_SIZE, AEAD_TAG_SIZE, PacketCipher};
 
 pub(crate) struct SeqCipher {
     aead: chacha20poly1305::ChaCha20Poly1305,
     our_nonce: [u8; AEAD_NONCE_SIZE],
     their_nonce: [u8; AEAD_NONCE_SIZE],
+}
+
+/// Increments the first 8 bytes of a nonce as a little-endian u64.
+fn inc_nonce(nonce: &mut [u8; AEAD_NONCE_SIZE]) {
+    let counter = u64::from_le_bytes(nonce[..8].try_into().expect("nonce is 12 bytes"));
+    nonce[..8].copy_from_slice(&(counter + 1).to_le_bytes());
+}
+
+impl PacketCipher for SeqCipher {
+    fn encrypt_in_place(&mut self, buf: &mut [u8]) {
+        let plaintext_len = buf.len() - AEAD_TAG_SIZE;
+        let nonce = GenericArray::from_slice(&self.our_nonce);
+        let tag = self
+            .aead
+            .encrypt_in_place_detached(nonce, &[], &mut buf[..plaintext_len])
+            .expect("encryption cannot fail");
+        buf[plaintext_len..].copy_from_slice(&tag);
+        inc_nonce(&mut self.our_nonce);
+    }
+
+    fn decrypt_in_place(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
+        let plaintext_len = buf.len() - AEAD_TAG_SIZE;
+        let nonce = GenericArray::from_slice(&self.their_nonce);
+        let (ct, tag_bytes) = buf.split_at_mut(plaintext_len);
+        let tag = GenericArray::from_slice(tag_bytes);
+        self.aead
+            .decrypt_in_place_detached(nonce, &[], ct, tag)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "AEAD decryption failed"))?;
+        inc_nonce(&mut self.their_nonce);
+        Ok(plaintext_len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chacha20poly1305::{ChaCha20Poly1305, KeyInit};
+
+    use super::*;
+
+    fn test_cipher_pair() -> (SeqCipher, SeqCipher) {
+        let key = [0x42u8; 32];
+        let aead1 = ChaCha20Poly1305::new(GenericArray::from_slice(&key));
+        let aead2 = ChaCha20Poly1305::new(GenericArray::from_slice(&key));
+        let mut c1 = SeqCipher {
+            aead: aead1,
+            our_nonce: [0u8; AEAD_NONCE_SIZE],
+            their_nonce: [0u8; AEAD_NONCE_SIZE],
+        };
+        let mut c2 = SeqCipher {
+            aead: aead2,
+            our_nonce: [0u8; AEAD_NONCE_SIZE],
+            their_nonce: [0u8; AEAD_NONCE_SIZE],
+        };
+        // flip nonces like the handshake does
+        c2.our_nonce[AEAD_NONCE_SIZE - 1] ^= 0x80;
+        c1.their_nonce[AEAD_NONCE_SIZE - 1] ^= 0x80;
+        (c1, c2)
+    }
+
+    #[test]
+    fn inc_nonce_increments() {
+        let mut nonce = [0u8; AEAD_NONCE_SIZE];
+        inc_nonce(&mut nonce);
+        assert_eq!(u64::from_le_bytes(nonce[..8].try_into().unwrap()), 1);
+        inc_nonce(&mut nonce);
+        assert_eq!(u64::from_le_bytes(nonce[..8].try_into().unwrap()), 2);
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let (mut c1, mut c2) = test_cipher_pair();
+        let plaintext = b"hello world";
+        let mut buf = vec![0u8; plaintext.len() + AEAD_TAG_SIZE];
+        buf[..plaintext.len()].copy_from_slice(plaintext);
+
+        c1.encrypt_in_place(&mut buf);
+        // ciphertext should differ from plaintext
+        assert_ne!(&buf[..plaintext.len()], plaintext.as_slice());
+
+        let pt_len = c2.decrypt_in_place(&mut buf).unwrap();
+        assert_eq!(&buf[..pt_len], plaintext.as_slice());
+    }
+
+    #[test]
+    fn sequential_nonces() {
+        let (mut c1, mut c2) = test_cipher_pair();
+
+        for i in 0u8..5 {
+            let msg = [i; 16];
+            let mut buf = vec![0u8; msg.len() + AEAD_TAG_SIZE];
+            buf[..msg.len()].copy_from_slice(&msg);
+
+            c1.encrypt_in_place(&mut buf);
+            let pt_len = c2.decrypt_in_place(&mut buf).unwrap();
+            assert_eq!(&buf[..pt_len], &msg);
+        }
+    }
+
+    #[test]
+    fn decrypt_wrong_nonce_fails() {
+        let (mut c1, _c2) = test_cipher_pair();
+        let plaintext = b"secret";
+        let mut buf = vec![0u8; plaintext.len() + AEAD_TAG_SIZE];
+        buf[..plaintext.len()].copy_from_slice(plaintext);
+
+        c1.encrypt_in_place(&mut buf);
+
+        // decrypting with c1 (wrong nonce direction) should fail
+        let result = c1.decrypt_in_place(&mut buf);
+        assert!(result.is_err());
+    }
 }

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod frame;
+pub(crate) mod handshake;

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod frame;

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,2 +1,99 @@
 pub mod frame;
-pub(crate) mod handshake;
+pub mod handshake;
+pub mod mux;
+
+use std::io;
+use std::sync::LazyLock;
+use thiserror::Error;
+
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::handshake::{ConnSettings, HandshakeError, accept_handshake, initiate_handshake};
+use crate::mux::{Mux, new_mux};
+
+// Re-export key public types.
+pub use crate::mux::{MuxError, Stream};
+
+const OUR_VERSION: u8 = 3;
+
+/// Minimum peer version we accept.
+const MIN_VERSION: u8 = 3;
+
+/// Anonymous Ed25519 signing key (derived from all-zero seed).
+static ANON_SIGNING_KEY: LazyLock<SigningKey> =
+    LazyLock::new(|| SigningKey::from_bytes(&[0u8; 32]));
+
+/// Anonymous Ed25519 verifying key (corresponding to the anonymous signing key).
+static ANON_VERIFYING_KEY: LazyLock<VerifyingKey> =
+    LazyLock::new(|| ANON_SIGNING_KEY.verifying_key());
+
+#[derive(Debug, Error)]
+pub enum DialError {
+    #[error("failed to write our version to peer: {0}")]
+    WriteVersion(io::Error),
+    #[error("failed to read peer version: {0}")]
+    ReadVersion(io::Error),
+    #[error("handshake failed: {0}")]
+    Handshake(#[from] HandshakeError),
+    #[error("invalid peer version: {0}")]
+    PeerVersion(u8),
+}
+
+fn validate_peer_version(v: u8) -> Result<(), DialError> {
+    if v < MIN_VERSION {
+        return Err(DialError::PeerVersion(v));
+    }
+    Ok(())
+}
+
+/// Perform the mux handshake as the initiating (dialing) peer.
+pub async fn dial<T: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
+    mut conn: T,
+    their_key: &VerifyingKey,
+) -> Result<Mux, DialError> {
+    // Version exchange: dialer writes first, then reads.
+    conn.write_u8(OUR_VERSION)
+        .await
+        .map_err(DialError::WriteVersion)?;
+    let their_version = conn.read_u8().await.map_err(DialError::ReadVersion)?;
+    validate_peer_version(their_version)?;
+
+    let settings = ConnSettings::default();
+    let (cipher, merged) = initiate_handshake(&mut conn, their_key, settings).await?;
+    Ok(new_mux(conn, cipher, merged, 0))
+}
+
+/// Perform the mux handshake as the accepting (listening) peer.
+pub async fn accept<T: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
+    mut conn: T,
+    our_key: &SigningKey,
+) -> Result<Mux, DialError> {
+    // Version exchange: acceptor reads first, then writes.
+    let their_version = conn.read_u8().await.map_err(DialError::ReadVersion)?;
+    validate_peer_version(their_version)?;
+    conn.write_u8(OUR_VERSION)
+        .await
+        .map_err(DialError::WriteVersion)?;
+
+    let settings = ConnSettings::default();
+    let (cipher, merged) = accept_handshake(&mut conn, our_key, settings).await?;
+    // Acceptor uses odd stream IDs to avoid collisions with dialer
+    Ok(new_mux(conn, cipher, merged, 1))
+}
+
+/// Dial without identity verification (anonymous mode).
+/// The counterparty must reciprocate with [`accept_anonymous`].
+pub async fn dial_anonymous<T: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
+    conn: T,
+) -> Result<Mux, DialError> {
+    dial(conn, &ANON_VERIFYING_KEY).await
+}
+
+/// Accept without identity verification (anonymous mode).
+/// The counterparty must initiate with [`dial_anonymous`].
+pub async fn accept_anonymous<T: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
+    conn: T,
+) -> Result<Mux, DialError> {
+    accept(conn, &ANON_SIGNING_KEY).await
+}

--- a/mux/src/mux.rs
+++ b/mux/src/mux.rs
@@ -13,8 +13,8 @@ use tokio::time;
 use tokio_util::sync::PollSender;
 
 use crate::frame::{
-    FLAG_ERROR, FLAG_FIRST, FLAG_LAST, FrameHeader, ID_KEEPALIVE, ID_LOWEST_STREAM,
-    PacketReader, PacketReaderError, PacketWriter, append_frame,
+    FLAG_ERROR, FLAG_FIRST, FLAG_LAST, FrameHeader, ID_KEEPALIVE, ID_LOWEST_STREAM, PacketReader,
+    PacketReaderError, PacketWriter, append_frame,
 };
 use crate::handshake::{ConnSettings, SeqCipher};
 

--- a/mux/src/mux.rs
+++ b/mux/src/mux.rs
@@ -58,18 +58,15 @@ pub enum MuxError {
     PeerError(String),
 }
 
+/// Required because [`AsyncRead`] and [`AsyncWrite`] trait methods return `io::Result`.
 impl From<MuxError> for io::Error {
     fn from(e: MuxError) -> Self {
-        match e {
-            MuxError::ClosedConn | MuxError::ClosedStream => {
-                io::Error::new(io::ErrorKind::ConnectionAborted, e)
-            }
-            MuxError::PeerClosedStream | MuxError::PeerClosedConn => {
-                io::Error::new(io::ErrorKind::ConnectionReset, e)
-            }
-            MuxError::Io(ref msg) => io::Error::new(io::ErrorKind::Other, msg.clone()),
-            _ => io::Error::new(io::ErrorKind::Other, e),
-        }
+        let kind = match &e {
+            MuxError::ClosedConn | MuxError::ClosedStream => io::ErrorKind::ConnectionAborted,
+            MuxError::PeerClosedStream | MuxError::PeerClosedConn => io::ErrorKind::ConnectionReset,
+            _ => io::ErrorKind::Other,
+        };
+        io::Error::new(kind, e)
     }
 }
 

--- a/mux/src/mux.rs
+++ b/mux/src/mux.rs
@@ -478,12 +478,11 @@ async fn read_loop<R: AsyncRead + Unpin>(
         let (h, payload) = match reader.next_frame(&mut frame_buf).await {
             Ok((h, p)) => (h, p.to_vec()),
             Err(e) => {
-                let err =
-                    if is_conn_close_error(&io::Error::other(e.to_string())) {
-                        MuxError::PeerClosedConn
-                    } else {
-                        MuxError::Io(e.to_string())
-                    };
+                let err = if is_conn_close_error(&io::Error::other(e.to_string())) {
+                    MuxError::PeerClosedConn
+                } else {
+                    MuxError::Io(e.to_string())
+                };
                 set_fatal_error(&registry, err);
                 return;
             }

--- a/mux/src/mux.rs
+++ b/mux/src/mux.rs
@@ -1,0 +1,897 @@
+use std::collections::HashMap;
+use std::io;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::{Mutex as TokioMutex, mpsc, oneshot};
+use tokio::time;
+use tokio_util::sync::PollSender;
+
+use crate::frame::{
+    FLAG_ERROR, FLAG_FIRST, FLAG_LAST, FrameHeader, ID_KEEPALIVE, ID_LOWEST_STREAM, PacketReader,
+    PacketWriter, append_frame,
+};
+use crate::handshake::{ConnSettings, SeqCipher};
+
+/// Grace period before removing a closed stream from tracking.
+const CLOSING_STREAM_CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Maximum frames to accept for a closed stream before treating it as a flood.
+const MAX_CLOSED_FRAMES: u16 = 1000;
+
+/// Maximum concurrent streams.
+const MAX_STREAMS: usize = 1 << 20;
+
+/// Backpressure limit for write commands queued to the write loop.
+const WRITE_CHANNEL_CAPACITY: usize = 10;
+
+/// Backpressure limit for incoming streams waiting to be accepted.
+const ACCEPT_CHANNEL_CAPACITY: usize = 256;
+
+/// Errors relating to stream or mux shutdown.
+#[derive(Debug, Clone, Error)]
+pub enum MuxError {
+    #[error("underlying connection was closed")]
+    ClosedConn,
+    #[error("stream was gracefully closed")]
+    ClosedStream,
+    #[error("peer closed stream gracefully")]
+    PeerClosedStream,
+    #[error("peer closed underlying connection")]
+    PeerClosedConn,
+    #[error("too many frames received for closed stream")]
+    StreamFlood,
+    #[error("frame received for unknown stream")]
+    UnknownStream,
+    #[error("exceeded concurrent stream limit")]
+    TooManyStreams,
+    #[error("peer sent invalid frame ID: {0}")]
+    InvalidFrameId(u32),
+    #[error("{0}")]
+    Io(String),
+    #[error("peer error: {0}")]
+    PeerError(String),
+}
+
+impl From<MuxError> for io::Error {
+    fn from(e: MuxError) -> Self {
+        match e {
+            MuxError::ClosedConn | MuxError::ClosedStream => {
+                io::Error::new(io::ErrorKind::ConnectionAborted, e)
+            }
+            MuxError::PeerClosedStream | MuxError::PeerClosedConn => {
+                io::Error::new(io::ErrorKind::ConnectionReset, e)
+            }
+            MuxError::Io(ref msg) => io::Error::new(io::ErrorKind::Other, msg.clone()),
+            _ => io::Error::new(io::ErrorKind::Other, e),
+        }
+    }
+}
+
+fn is_conn_close_error(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::UnexpectedEof
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::BrokenPipe
+    )
+}
+
+struct WriteFrame {
+    header: FrameHeader,
+    payload: Vec<u8>,
+}
+
+enum WriteCmd {
+    Frame(WriteFrame),
+    Shutdown(oneshot::Sender<()>),
+}
+
+/// Per-stream handle held by the read loop to deliver data and signal closure.
+struct StreamHandle {
+    data_tx: mpsc::Sender<Vec<u8>>,
+    close_err: Arc<StdMutex<Option<MuxError>>>,
+}
+
+struct ClosingStreamEntry {
+    frame_count: u16,
+    closed: Instant,
+}
+
+struct StreamRegistry {
+    streams: HashMap<u32, StreamHandle>,
+    closing: HashMap<u32, ClosingStreamEntry>,
+}
+
+struct TaskHandles {
+    read_handle: tokio::task::JoinHandle<()>,
+    write_handle: tokio::task::JoinHandle<()>,
+}
+
+// ---------------------------------------------------------------------------
+// Mux
+// ---------------------------------------------------------------------------
+
+/// A Mux multiplexes multiple duplex [`Stream`]s onto a single connection.
+pub struct Mux {
+    write_tx: mpsc::Sender<WriteCmd>,
+    accept_rx: TokioMutex<mpsc::Receiver<Stream>>,
+    next_id: AtomicU32,
+    registry: Arc<StdMutex<StreamRegistry>>,
+    settings: ConnSettings,
+    tasks: TokioMutex<Option<TaskHandles>>,
+}
+
+impl Mux {
+    /// Wait for and return the next peer-initiated stream.
+    pub async fn accept_stream(&self) -> Result<Stream, MuxError> {
+        let mut rx = self.accept_rx.lock().await;
+        rx.recv().await.ok_or(MuxError::ClosedConn)
+    }
+
+    /// Create a new locally-initiated stream. No I/O is performed; the peer
+    /// will not be aware of the new stream until data is written.
+    pub fn dial_stream(&self) -> Result<Stream, MuxError> {
+        let mut reg = self.registry.lock().unwrap();
+
+        if self.write_tx.is_closed() {
+            return Err(MuxError::ClosedConn);
+        }
+
+        let id = self.next_id.fetch_add(2, Ordering::Relaxed);
+        // Wraparound when nextID grows too large
+        if id >= u32::MAX >> 2 {
+            let parity = id & 1;
+            self.next_id
+                .store(ID_LOWEST_STREAM + parity, Ordering::Relaxed);
+        }
+
+        let (data_tx, data_rx) = mpsc::channel(1);
+        let close_err = Arc::new(StdMutex::new(None));
+        reg.streams.insert(
+            id,
+            StreamHandle {
+                data_tx,
+                close_err: close_err.clone(),
+            },
+        );
+
+        let write_tx = self.write_tx.clone();
+        Ok(Stream {
+            id,
+            data_rx,
+            close_err,
+            poll_sender: PollSender::new(write_tx.clone()),
+            write_tx,
+            registry: self.registry.clone(),
+            settings: self.settings,
+            read_buf: Vec::new(),
+            established: false,
+            closed: false,
+            read_deadline: None,
+            write_deadline: None,
+        })
+    }
+
+    /// Close the mux, flushing any buffered writes first.
+    pub async fn close(self) -> Result<(), MuxError> {
+        // Send shutdown command to write loop and wait for it to flush
+        let (tx, rx) = oneshot::channel();
+        let _ = self.write_tx.send(WriteCmd::Shutdown(tx)).await;
+        let _ = rx.await;
+
+        // Set fatal error on all streams
+        set_fatal_error(&self.registry, MuxError::ClosedConn);
+
+        // Wait for tasks to complete
+        if let Some(handles) = self.tasks.lock().await.take() {
+            handles.read_handle.abort();
+            handles.write_handle.abort();
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stream
+// ---------------------------------------------------------------------------
+
+/// A Stream is a duplex connection multiplexed over a single connection.
+pub struct Stream {
+    id: u32,
+    data_rx: mpsc::Receiver<Vec<u8>>,
+    close_err: Arc<StdMutex<Option<MuxError>>>,
+    write_tx: mpsc::Sender<WriteCmd>,
+    poll_sender: PollSender<WriteCmd>,
+    registry: Arc<StdMutex<StreamRegistry>>,
+    settings: ConnSettings,
+    read_buf: Vec<u8>,
+    established: bool,
+    closed: bool,
+    read_deadline: Option<time::Instant>,
+    write_deadline: Option<time::Instant>,
+}
+
+impl Stream {
+    /// Set both read and write deadlines.
+    pub fn set_deadline(&mut self, t: Option<time::Instant>) {
+        self.read_deadline = t;
+        self.write_deadline = t;
+    }
+
+    /// Set the read deadline.
+    pub fn set_read_deadline(&mut self, t: Option<time::Instant>) {
+        self.read_deadline = t;
+    }
+
+    /// Set the write deadline.
+    pub fn set_write_deadline(&mut self, t: Option<time::Instant>) {
+        self.write_deadline = t;
+    }
+
+    /// Gracefully close this stream. Sends FLAG_LAST to the peer.
+    pub async fn close(&mut self) -> Result<(), MuxError> {
+        if self.closed {
+            return Ok(());
+        }
+        self.closed = true;
+
+        // Send flagLast frame
+        let h = FrameHeader {
+            id: self.id,
+            length: 0,
+            flags: FLAG_LAST,
+        };
+        let result = self
+            .write_tx
+            .send(WriteCmd::Frame(WriteFrame {
+                header: h,
+                payload: Vec::new(),
+            }))
+            .await;
+
+        // Move from streams to closing in the registry
+        {
+            let mut reg = self.registry.lock().unwrap();
+            reg.streams.remove(&self.id);
+            reg.closing.insert(
+                self.id,
+                ClosingStreamEntry {
+                    frame_count: 0,
+                    closed: Instant::now(),
+                },
+            );
+        }
+
+        match result {
+            Ok(()) => Ok(()),
+            Err(_) => {
+                // Write loop is gone; check if it's a known close
+                let err = self.close_err.lock().unwrap().clone();
+                match err {
+                    Some(MuxError::PeerClosedConn) | Some(MuxError::ClosedConn) | None => Ok(()),
+                    Some(e) => Err(e),
+                }
+            }
+        }
+    }
+
+    /// Check for a sticky close error.
+    fn check_close_err(&self) -> Option<MuxError> {
+        self.close_err.lock().unwrap().clone()
+    }
+}
+
+impl AsyncRead for Stream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+
+        // Drain leftover read_buf first
+        if !this.read_buf.is_empty() {
+            let n = buf.remaining().min(this.read_buf.len());
+            buf.put_slice(&this.read_buf[..n]);
+            this.read_buf.drain(..n);
+            return Poll::Ready(Ok(()));
+        }
+
+        // Check deadline
+        if let Some(deadline) = this.read_deadline {
+            if time::Instant::now() >= deadline {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "read deadline exceeded",
+                )));
+            }
+        }
+
+        // Poll for next data from read loop
+        match this.data_rx.poll_recv(cx) {
+            Poll::Ready(Some(data)) => {
+                let n = buf.remaining().min(data.len());
+                buf.put_slice(&data[..n]);
+                if n < data.len() {
+                    this.read_buf = data[n..].to_vec();
+                }
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(None) => {
+                // Channel closed — check why
+                match this.check_close_err() {
+                    Some(MuxError::PeerClosedStream) | None => {
+                        // EOF
+                        Poll::Ready(Ok(()))
+                    }
+                    Some(e) => Poll::Ready(Err(e.into())),
+                }
+            }
+            Poll::Pending => {
+                // If we have a deadline, register a timer to wake us
+                if let Some(deadline) = this.read_deadline {
+                    let waker = cx.waker().clone();
+                    tokio::spawn(async move {
+                        time::sleep_until(deadline).await;
+                        waker.wake();
+                    });
+                }
+                Poll::Pending
+            }
+        }
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+
+        if this.closed {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                MuxError::ClosedStream,
+            )));
+        }
+
+        // Check deadline
+        if let Some(deadline) = this.write_deadline {
+            if time::Instant::now() >= deadline {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "write deadline exceeded",
+                )));
+            }
+        }
+
+        // Reserve capacity on the write channel
+        match this.poll_sender.poll_reserve(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(_)) => {
+                let err = this.check_close_err().unwrap_or(MuxError::ClosedConn);
+                return Poll::Ready(Err(err.into()));
+            }
+            Poll::Pending => {
+                if let Some(deadline) = this.write_deadline {
+                    let waker = cx.waker().clone();
+                    tokio::spawn(async move {
+                        time::sleep_until(deadline).await;
+                        waker.wake();
+                    });
+                }
+                return Poll::Pending;
+            }
+        }
+
+        let max_payload = this.settings.max_payload_size();
+        let n = buf.len().min(max_payload);
+
+        let mut flags = 0u16;
+        if !this.established {
+            flags |= FLAG_FIRST;
+            this.established = true;
+        }
+
+        let frame = WriteCmd::Frame(WriteFrame {
+            header: FrameHeader {
+                id: this.id,
+                length: n as u16,
+                flags,
+            },
+            payload: buf[..n].to_vec(),
+        });
+
+        match this.poll_sender.send_item(frame) {
+            Ok(()) => Poll::Ready(Ok(n)),
+            Err(_) => {
+                let err = this.check_close_err().unwrap_or(MuxError::ClosedConn);
+                Poll::Ready(Err(err.into()))
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        this.closed = true;
+        Poll::Ready(Ok(()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// read_loop
+// ---------------------------------------------------------------------------
+
+/// Actions determined by the read loop under the lock, executed outside the lock.
+enum ReadAction {
+    /// Send data to an existing stream.
+    SendData {
+        tx: mpsc::Sender<Vec<u8>>,
+        payload: Vec<u8>,
+    },
+    /// A new stream was created; send it to the accept channel, then optionally
+    /// deliver initial payload data.
+    NewStream {
+        stream: Stream,
+        data_tx: Option<mpsc::Sender<Vec<u8>>>,
+        payload: Vec<u8>,
+    },
+    /// Fatal error — terminate the read loop.
+    Fatal(MuxError),
+    /// Frame was handled inline (closing stream, keepalive, etc.) — continue.
+    Continue,
+}
+
+async fn read_loop<R: AsyncRead + Unpin>(
+    mut reader: PacketReader<R, SeqCipher>,
+    accept_tx: mpsc::Sender<Stream>,
+    write_tx: mpsc::Sender<WriteCmd>,
+    registry: Arc<StdMutex<StreamRegistry>>,
+    settings: ConnSettings,
+) {
+    let mut frame_buf = vec![0u8; settings.max_payload_size()];
+
+    loop {
+        let (h, payload) = match reader.next_frame(&mut frame_buf).await {
+            Ok((h, p)) => (h, p.to_vec()),
+            Err(e) => {
+                let err =
+                    if is_conn_close_error(&io::Error::new(io::ErrorKind::Other, e.to_string())) {
+                        MuxError::PeerClosedConn
+                    } else {
+                        MuxError::Io(e.to_string())
+                    };
+                set_fatal_error(&registry, err);
+                return;
+            }
+        };
+
+        if h.id == ID_KEEPALIVE {
+            continue;
+        }
+        if h.id < ID_LOWEST_STREAM {
+            set_fatal_error(&registry, MuxError::InvalidFrameId(h.id));
+            return;
+        }
+
+        // Determine action under the lock
+        let action = {
+            let mut reg = registry.lock().unwrap();
+
+            if let Some(handle) = reg.streams.get(&h.id) {
+                if h.flags & FLAG_LAST != 0 {
+                    // Peer closing this stream
+                    let err = if h.flags & FLAG_ERROR != 0 {
+                        MuxError::PeerError(String::from_utf8_lossy(&payload).into_owned())
+                    } else {
+                        MuxError::PeerClosedStream
+                    };
+                    *handle.close_err.lock().unwrap() = Some(err);
+                    reg.streams.remove(&h.id);
+                    reg.closing.remove(&h.id);
+                    ReadAction::Continue
+                } else {
+                    ReadAction::SendData {
+                        tx: handle.data_tx.clone(),
+                        payload,
+                    }
+                }
+            } else if h.flags & FLAG_FIRST != 0 {
+                if reg.streams.len() >= MAX_STREAMS {
+                    ReadAction::Fatal(MuxError::TooManyStreams)
+                } else {
+                    let (data_tx, data_rx) = mpsc::channel(1);
+                    let close_err = Arc::new(StdMutex::new(None));
+                    reg.streams.insert(
+                        h.id,
+                        StreamHandle {
+                            data_tx: data_tx.clone(),
+                            close_err: close_err.clone(),
+                        },
+                    );
+
+                    let stream_write_tx = write_tx.clone();
+                    let stream = Stream {
+                        id: h.id,
+                        data_rx,
+                        close_err,
+                        poll_sender: PollSender::new(stream_write_tx.clone()),
+                        write_tx: stream_write_tx,
+                        registry: registry.clone(),
+                        settings,
+                        read_buf: Vec::new(),
+                        established: true,
+                        closed: false,
+                        read_deadline: None,
+                        write_deadline: None,
+                    };
+
+                    let initial_tx = if !payload.is_empty() {
+                        Some(data_tx)
+                    } else {
+                        None
+                    };
+
+                    ReadAction::NewStream {
+                        stream,
+                        data_tx: initial_tx,
+                        payload,
+                    }
+                }
+            } else {
+                // Unknown stream
+                if let Some(cs) = reg.closing.get_mut(&h.id) {
+                    cs.frame_count += 1;
+                    if cs.frame_count >= MAX_CLOSED_FRAMES {
+                        ReadAction::Fatal(MuxError::StreamFlood)
+                    } else {
+                        ReadAction::Continue
+                    }
+                } else {
+                    ReadAction::Fatal(MuxError::UnknownStream)
+                }
+            }
+        }; // MutexGuard dropped here
+
+        // Execute action outside the lock
+        match action {
+            ReadAction::SendData { tx, payload } => {
+                if tx.send(payload).await.is_err() {
+                    // Stream was dropped locally — treat as closed
+                    continue;
+                }
+            }
+            ReadAction::NewStream {
+                stream,
+                data_tx,
+                payload,
+            } => {
+                if accept_tx.send(stream).await.is_err() {
+                    return; // mux shutting down
+                }
+                if let Some(tx) = data_tx {
+                    if tx.send(payload).await.is_err() {
+                        continue; // stream was closed
+                    }
+                }
+            }
+            ReadAction::Fatal(err) => {
+                set_fatal_error(&registry, err);
+                return;
+            }
+            ReadAction::Continue => {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// write_loop
+// ---------------------------------------------------------------------------
+
+async fn write_loop<W: AsyncWrite + Unpin>(
+    mut writer: PacketWriter<W, SeqCipher>,
+    mut cmd_rx: mpsc::Receiver<WriteCmd>,
+    registry: Arc<StdMutex<StreamRegistry>>,
+    settings: ConnSettings,
+) {
+    let keepalive_interval = settings.max_timeout - settings.max_timeout / 4;
+    let mut keepalive_timer = time::interval(keepalive_interval);
+    // Skip the immediate first tick
+    keepalive_timer.reset();
+
+    let mut cleanup_timer = time::interval(time::Duration::from(CLOSING_STREAM_CLEANUP_INTERVAL));
+    cleanup_timer.reset();
+
+    let max_frame_size = settings.max_frame_size();
+    let mut write_buf: Vec<u8> = Vec::with_capacity(max_frame_size * 10);
+
+    loop {
+        write_buf.clear();
+
+        // Wait for at least one frame, a keepalive tick, or a cleanup tick
+        tokio::select! {
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    Some(WriteCmd::Frame(f)) => {
+                        append_frame(&mut write_buf, f.header, &f.payload);
+                    }
+                    Some(WriteCmd::Shutdown(reply)) => {
+                        let _ = reply.send(());
+                        return;
+                    }
+                    None => return,
+                }
+            }
+            _ = keepalive_timer.tick() => {
+                append_frame(
+                    &mut write_buf,
+                    FrameHeader { id: ID_KEEPALIVE, length: 0, flags: 0 },
+                    &[],
+                );
+            }
+            _ = cleanup_timer.tick() => {
+                let mut reg = registry.lock().unwrap();
+                let now = Instant::now();
+                reg.closing.retain(|_, cs| now.duration_since(cs.closed) < CLOSING_STREAM_CLEANUP_INTERVAL);
+                continue;
+            }
+        }
+
+        // Drain additional pending frames (non-blocking)
+        loop {
+            match cmd_rx.try_recv() {
+                Ok(WriteCmd::Frame(f)) => {
+                    append_frame(&mut write_buf, f.header, &f.payload);
+                    if write_buf.len() >= max_frame_size * 8 {
+                        break;
+                    }
+                }
+                Ok(WriteCmd::Shutdown(reply)) => {
+                    pad_and_write(&mut write_buf, max_frame_size, &mut writer)
+                        .await
+                        .ok();
+                    let _ = reply.send(());
+                    return;
+                }
+                Err(_) => break,
+            }
+        }
+
+        // Pad to packet boundary, encrypt, and write
+        if let Err(e) = pad_and_write(&mut write_buf, max_frame_size, &mut writer).await {
+            let err = if is_conn_close_error(&e) {
+                MuxError::PeerClosedConn
+            } else {
+                MuxError::Io(e.to_string())
+            };
+            set_fatal_error(&registry, err);
+            return;
+        }
+
+        // Reset keepalive timer after any successful write
+        keepalive_timer.reset();
+    }
+}
+
+async fn pad_and_write<W: AsyncWrite + Unpin>(
+    buf: &mut Vec<u8>,
+    max_frame_size: usize,
+    writer: &mut PacketWriter<W, SeqCipher>,
+) -> Result<(), io::Error> {
+    if buf.is_empty() {
+        return Ok(());
+    }
+    // Pad to packet boundary (max_frame_size = packet_size - AEAD_TAG_SIZE)
+    let remainder = buf.len() % max_frame_size;
+    if remainder != 0 {
+        let padding = max_frame_size - remainder;
+        buf.resize(buf.len() + padding, 0);
+    }
+    writer.write_encrypted(buf).await
+}
+
+fn set_fatal_error(registry: &Arc<StdMutex<StreamRegistry>>, err: MuxError) {
+    let mut reg = registry.lock().unwrap();
+    for (_, handle) in reg.streams.drain() {
+        *handle.close_err.lock().unwrap() = Some(err.clone());
+        // handle.data_tx is dropped here, closing the channel
+    }
+}
+
+pub(crate) fn new_mux<T: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
+    conn: T,
+    cipher: SeqCipher,
+    settings: ConnSettings,
+    id_offset: u32,
+) -> Mux {
+    let (read_half, write_half) = tokio::io::split(conn);
+
+    // Clone cipher: one for reading (decrypt), one for writing (encrypt)
+    let read_cipher = cipher.clone();
+    let write_cipher = cipher;
+
+    let packet_reader = PacketReader::new(read_half, read_cipher, settings.packet_size as usize);
+    let packet_writer = PacketWriter::new(write_half, write_cipher, settings.packet_size as usize);
+
+    let (write_tx, write_rx) = mpsc::channel::<WriteCmd>(WRITE_CHANNEL_CAPACITY);
+    let (accept_tx, accept_rx) = mpsc::channel::<Stream>(ACCEPT_CHANNEL_CAPACITY);
+    let registry = Arc::new(StdMutex::new(StreamRegistry {
+        streams: HashMap::new(),
+        closing: HashMap::new(),
+    }));
+
+    let read_registry = registry.clone();
+    let read_write_tx = write_tx.clone();
+    let read_handle = tokio::spawn(async move {
+        read_loop(
+            packet_reader,
+            accept_tx,
+            read_write_tx,
+            read_registry,
+            settings,
+        )
+        .await;
+    });
+
+    let write_registry = registry.clone();
+    let write_handle = tokio::spawn(async move {
+        write_loop(packet_writer, write_rx, write_registry, settings).await;
+    });
+
+    Mux {
+        write_tx,
+        accept_rx: TokioMutex::new(accept_rx),
+        next_id: AtomicU32::new(ID_LOWEST_STREAM + id_offset),
+        registry,
+        settings,
+        tasks: TokioMutex::new(Some(TaskHandles {
+            read_handle,
+            write_handle,
+        })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Creates a pair of connected Mux instances using anonymous handshake
+    /// over a local TCP connection.
+    async fn new_testing_pair() -> (super::Mux, super::Mux) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let accept_fut = tokio::spawn(async move {
+            let (conn, _) = listener.accept().await.unwrap();
+            crate::accept_anonymous(conn).await.unwrap()
+        });
+
+        let dial_conn = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let dial_mux = crate::dial_anonymous(dial_conn).await.unwrap();
+        let accept_mux = accept_fut.await.unwrap();
+
+        (dial_mux, accept_mux)
+    }
+
+    #[tokio::test]
+    async fn basic_echo() {
+        let (dial_mux, accept_mux) = new_testing_pair().await;
+
+        // Server: accept streams and echo back
+        let accept_handle = tokio::spawn(async move {
+            let mut stream = accept_mux.accept_stream().await.unwrap();
+            let mut buf = vec![0u8; 1024];
+            let n = stream.read(&mut buf).await.unwrap();
+            stream.write_all(&buf[..n]).await.unwrap();
+            stream.close().await.unwrap();
+            accept_mux.close().await.unwrap();
+        });
+
+        // Client: write, read echo, close
+        let mut stream = dial_mux.dial_stream().unwrap();
+        let msg = b"hello, mux!";
+        stream.write_all(msg).await.unwrap();
+
+        let mut buf = vec![0u8; 1024];
+        let n = stream.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], msg);
+
+        stream.close().await.unwrap();
+        dial_mux.close().await.unwrap();
+        accept_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn many_streams() {
+        let (dial_mux, accept_mux) = new_testing_pair().await;
+        let num_streams = 100;
+
+        // Server: accept streams and echo back
+        let accept_handle = tokio::spawn(async move {
+            for _ in 0..num_streams {
+                let mut stream = accept_mux.accept_stream().await.unwrap();
+                tokio::spawn(async move {
+                    let mut buf = vec![0u8; 1024];
+                    let n = stream.read(&mut buf).await.unwrap();
+                    stream.write_all(&buf[..n]).await.unwrap();
+                    stream.close().await.unwrap();
+                });
+            }
+            // Wait a bit for all streams to finish, then close
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            accept_mux.close().await.unwrap();
+        });
+
+        // Client: open many streams concurrently
+        let mut handles = Vec::new();
+        for i in 0..num_streams {
+            let mut stream = dial_mux.dial_stream().unwrap();
+            handles.push(tokio::spawn(async move {
+                let msg = format!("stream {i}");
+                stream.write_all(msg.as_bytes()).await.unwrap();
+                let mut buf = vec![0u8; 1024];
+                let n = stream.read(&mut buf).await.unwrap();
+                assert_eq!(&buf[..n], msg.as_bytes());
+                stream.close().await.unwrap();
+            }));
+        }
+
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        dial_mux.close().await.unwrap();
+        accept_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn deadline_read() {
+        let (dial_mux, accept_mux) = new_testing_pair().await;
+
+        // Server: accept stream but never write anything
+        let accept_handle = tokio::spawn(async move {
+            let _stream = accept_mux.accept_stream().await.unwrap();
+            // Hold the stream open but don't write
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            accept_mux.close().await.unwrap();
+        });
+
+        let mut stream = dial_mux.dial_stream().unwrap();
+        // Write something so the stream is established
+        stream.write_all(b"hello").await.unwrap();
+
+        // Set a short read deadline
+        stream.set_read_deadline(Some(
+            tokio::time::Instant::now() + std::time::Duration::from_millis(50),
+        ));
+
+        // Read should timeout
+        let mut buf = vec![0u8; 1024];
+        let result = stream.read(&mut buf).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+
+        // Clear deadline — set to None
+        stream.set_read_deadline(None);
+
+        stream.close().await.unwrap();
+        dial_mux.close().await.unwrap();
+        accept_handle.await.unwrap();
+    }
+}

--- a/mux/tests/interop.rs
+++ b/mux/tests/interop.rs
@@ -1,0 +1,281 @@
+//! Cross-language interoperability tests between the Rust mux implementation
+//! and the Go reference implementation.
+//!
+//! These tests require the Go interop helper binary to be built first:
+//!   cd testutil/go-interop && go build -o interop .
+//!
+//! The helper binary supports two modes:
+//! - `echo-server PORT` — accept one anonymous mux connection and echo all streams
+//! - `echo-client ADDR NUM_STREAMS MSG_SIZE` — dial anonymous mux, send/verify echo
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const GO_BINARY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/testutil/go-interop/interop");
+
+/// Spawns the Go echo-server and waits for it to print "READY <port>".
+/// Returns the child process and the port it's listening on.
+fn spawn_go_echo_server() -> (Child, u16) {
+    let mut child = Command::new(GO_BINARY)
+        .args(["echo-server", "0"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn Go interop binary — did you run `go build -o interop .` in testutil/interop/?");
+
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .expect("failed to read READY line from Go echo-server");
+
+    let port: u16 = line
+        .strip_prefix("READY ")
+        .expect("expected 'READY <port>' from Go echo-server")
+        .trim()
+        .parse()
+        .expect("invalid port number from Go echo-server");
+
+    // Re-attach stdout so it's not dropped (keeping the pipe open)
+    // We don't need it anymore, but dropping it could cause SIGPIPE in the child.
+    // Actually, we consumed it. That's fine — the child's stdout is now detached.
+
+    (child, port)
+}
+
+// ============================================================================
+// Test 1: Go server, Rust client
+// ============================================================================
+
+#[tokio::test]
+async fn go_server_rust_client_basic_echo() {
+    let (mut child, port) = spawn_go_echo_server();
+    let addr = format!("127.0.0.1:{port}");
+
+    let conn = tokio::net::TcpStream::connect(&addr).await.unwrap();
+    let mux = mux::dial_anonymous(conn).await.unwrap();
+
+    let mut stream = mux.dial_stream().unwrap();
+    let msg = b"hello from rust to go!";
+    stream.write_all(msg).await.unwrap();
+
+    let mut buf = vec![0u8; 1024];
+    let n = stream.read(&mut buf).await.unwrap();
+    assert_eq!(&buf[..n], msg);
+
+    stream.close().await.unwrap();
+    mux.close().await.unwrap();
+
+    // Give the Go process a moment to shut down gracefully
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _ = child.kill();
+    child.wait().ok();
+}
+
+#[tokio::test]
+async fn go_server_rust_client_many_streams() {
+    let (mut child, port) = spawn_go_echo_server();
+    let addr = format!("127.0.0.1:{port}");
+
+    let conn = tokio::net::TcpStream::connect(&addr).await.unwrap();
+    let mux = mux::dial_anonymous(conn).await.unwrap();
+
+    let num_streams = 50;
+    let mut handles = Vec::new();
+
+    for i in 0..num_streams {
+        let mut stream = mux.dial_stream().unwrap();
+        handles.push(tokio::spawn(async move {
+            let msg = format!("rust→go stream {i} with some padding data to fill the frame");
+            stream.write_all(msg.as_bytes()).await.unwrap();
+
+            let mut buf = vec![0u8; 1024];
+            let n = stream.read(&mut buf).await.unwrap();
+            assert_eq!(
+                &buf[..n],
+                msg.as_bytes(),
+                "stream {i}: echo mismatch"
+            );
+
+            stream.close().await.unwrap();
+        }));
+    }
+
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    mux.close().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _ = child.kill();
+    child.wait().ok();
+}
+
+#[tokio::test]
+async fn go_server_rust_client_large_payload() {
+    let (mut child, port) = spawn_go_echo_server();
+    let addr = format!("127.0.0.1:{port}");
+
+    let conn = tokio::net::TcpStream::connect(&addr).await.unwrap();
+    let mux = mux::dial_anonymous(conn).await.unwrap();
+
+    let mut stream = mux.dial_stream().unwrap();
+
+    // Send a payload larger than one mux packet
+    let msg: Vec<u8> = (0..10_000).map(|i| (i % 256) as u8).collect();
+    stream.write_all(&msg).await.unwrap();
+
+    // Read it all back
+    let mut buf = vec![0u8; msg.len()];
+    stream.read_exact(&mut buf).await.unwrap();
+    assert_eq!(buf, msg);
+
+    stream.close().await.unwrap();
+    mux.close().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let _ = child.kill();
+    child.wait().ok();
+}
+
+// ============================================================================
+// Test 2: Rust server, Go client
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rust_server_go_client_basic_echo() {
+    // Start Rust echo server
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let server_handle = tokio::spawn(async move {
+        let (conn, _) = listener.accept().await.unwrap();
+        let mux = mux::accept_anonymous(conn).await.unwrap();
+
+        // Accept and echo streams until the mux closes
+        loop {
+            match mux.accept_stream().await {
+                Ok(mut stream) => {
+                    tokio::spawn(async move {
+                        let mut buf = vec![0u8; 65536];
+                        loop {
+                            match stream.read(&mut buf).await {
+                                Ok(0) => break,
+                                Ok(n) => {
+                                    if stream.write_all(&buf[..n]).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                        let _ = stream.close().await;
+                    });
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = mux.close().await;
+    });
+
+    // Spawn Go echo-client (blocking call runs on a separate thread thanks to multi_thread)
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(GO_BINARY)
+            .args([
+                "echo-client",
+                &format!("127.0.0.1:{port}"),
+                "1",    // 1 stream
+                "256",  // 256-byte message
+            ])
+            .output()
+            .expect("failed to spawn Go echo-client")
+    })
+    .await
+    .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "Go echo-client failed (exit={}):\nstdout: {stdout}\nstderr: {stderr}",
+        output.status
+    );
+    assert!(
+        stdout.contains("PASS"),
+        "Go echo-client did not report PASS:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // Server task will end when the Go client disconnects
+    let _ = tokio::time::timeout(Duration::from_secs(5), server_handle).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rust_server_go_client_many_streams() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let server_handle = tokio::spawn(async move {
+        let (conn, _) = listener.accept().await.unwrap();
+        let mux = mux::accept_anonymous(conn).await.unwrap();
+
+        loop {
+            match mux.accept_stream().await {
+                Ok(mut stream) => {
+                    tokio::spawn(async move {
+                        let mut buf = vec![0u8; 65536];
+                        loop {
+                            match stream.read(&mut buf).await {
+                                Ok(0) => break,
+                                Ok(n) => {
+                                    if stream.write_all(&buf[..n]).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                        let _ = stream.close().await;
+                    });
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = mux.close().await;
+    });
+
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(GO_BINARY)
+            .args([
+                "echo-client",
+                &format!("127.0.0.1:{port}"),
+                "50",    // 50 concurrent streams
+                "1024",  // 1KB messages
+            ])
+            .output()
+            .expect("failed to spawn Go echo-client")
+    })
+    .await
+    .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "Go echo-client failed (exit={}):\nstdout: {stdout}\nstderr: {stderr}",
+        output.status
+    );
+    assert!(
+        stdout.contains("PASS"),
+        "Go echo-client did not report PASS:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let _ = tokio::time::timeout(Duration::from_secs(5), server_handle).await;
+}

--- a/mux/tests/interop.rs
+++ b/mux/tests/interop.rs
@@ -96,11 +96,7 @@ async fn go_server_rust_client_many_streams() {
 
             let mut buf = vec![0u8; 1024];
             let n = stream.read(&mut buf).await.unwrap();
-            assert_eq!(
-                &buf[..n],
-                msg.as_bytes(),
-                "stream {i}: echo mismatch"
-            );
+            assert_eq!(&buf[..n], msg.as_bytes(), "stream {i}: echo mismatch");
 
             stream.close().await.unwrap();
         }));
@@ -190,8 +186,8 @@ async fn rust_server_go_client_basic_echo() {
             .args([
                 "echo-client",
                 &format!("127.0.0.1:{port}"),
-                "1",    // 1 stream
-                "256",  // 256-byte message
+                "1",   // 1 stream
+                "256", // 256-byte message
             ])
             .output()
             .expect("failed to spawn Go echo-client")
@@ -255,8 +251,8 @@ async fn rust_server_go_client_many_streams() {
             .args([
                 "echo-client",
                 &format!("127.0.0.1:{port}"),
-                "50",    // 50 concurrent streams
-                "1024",  // 1KB messages
+                "50",   // 50 concurrent streams
+                "1024", // 1KB messages
             ])
             .output()
             .expect("failed to spawn Go echo-client")

--- a/mux/testutil/go-interop/.gitignore
+++ b/mux/testutil/go-interop/.gitignore
@@ -1,0 +1,1 @@
+interop

--- a/mux/testutil/go-interop/go.mod
+++ b/mux/testutil/go-interop/go.mod
@@ -1,0 +1,13 @@
+module interop
+
+go 1.25
+
+toolchain go1.25.5
+
+require go.sia.tech/mux v1.3.0
+
+require (
+	golang.org/x/crypto v0.47.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+	lukechampine.com/frand v1.5.1 // indirect
+)

--- a/mux/testutil/go-interop/go.mod
+++ b/mux/testutil/go-interop/go.mod
@@ -4,10 +4,10 @@ go 1.25
 
 toolchain go1.25.5
 
-require go.sia.tech/mux v1.3.0
+require go.sia.tech/mux v1.4.0
 
 require (
-	golang.org/x/crypto v0.47.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 	lukechampine.com/frand v1.5.1 // indirect
 )

--- a/mux/testutil/go-interop/go.sum
+++ b/mux/testutil/go-interop/go.sum
@@ -1,8 +1,14 @@
 go.sia.tech/mux v1.3.0 h1:hgR34IEkqvfBKUJkAzGi31OADeW2y7D6Bmy/Jcbop9c=
 go.sia.tech/mux v1.3.0/go.mod h1:I46++RD4beqA3cW9Xm9SwXbezwPqLvHhVs9HLpDtt58=
+go.sia.tech/mux v1.4.0 h1:LgsLHtn7l+25MwrgaPaUCaS8f2W2/tfvHIdXps04sVo=
+go.sia.tech/mux v1.4.0/go.mod h1:iNFi9ifFb2XhuD+LF4t2HBb4Mvgq/zIPKqwXU/NlqHA=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 lukechampine.com/frand v1.5.1 h1:fg0eRtdmGFIxhP5zQJzM1lFDbD6CUfu/f+7WgAZd5/w=
 lukechampine.com/frand v1.5.1/go.mod h1:4VstaWc2plN4Mjr10chUD46RAVGWhpkZ5Nja8+Azp0Q=

--- a/mux/testutil/go-interop/go.sum
+++ b/mux/testutil/go-interop/go.sum
@@ -1,0 +1,8 @@
+go.sia.tech/mux v1.3.0 h1:hgR34IEkqvfBKUJkAzGi31OADeW2y7D6Bmy/Jcbop9c=
+go.sia.tech/mux v1.3.0/go.mod h1:I46++RD4beqA3cW9Xm9SwXbezwPqLvHhVs9HLpDtt58=
+golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+lukechampine.com/frand v1.5.1 h1:fg0eRtdmGFIxhP5zQJzM1lFDbD6CUfu/f+7WgAZd5/w=
+lukechampine.com/frand v1.5.1/go.mod h1:4VstaWc2plN4Mjr10chUD46RAVGWhpkZ5Nja8+Azp0Q=

--- a/mux/testutil/go-interop/main.go
+++ b/mux/testutil/go-interop/main.go
@@ -1,0 +1,177 @@
+// Go helper binary for the Rust mux interop tests (mux/tests/interop.rs).
+//
+// Build:
+//
+//	cd mux/testutil/go-interop && go build -o interop .
+//
+// The compiled binary must be at mux/testutil/go-interop/interop — the Rust
+// tests locate it via CARGO_MANIFEST_DIR and will fail if it is missing.
+// Once built, the Rust test harness spawns it automatically; there is
+// nothing else to do.
+//
+// Modes:
+//
+//	interop echo-server PORT    — accept one anonymous mux connection, echo all streams
+//	interop echo-client ADDR N SIZE — dial anonymous mux, send/verify echo on N streams
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+
+	"go.sia.tech/mux"
+)
+
+func echoServer(port int) error {
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	defer l.Close()
+
+	// Print the actual port (useful when port=0)
+	fmt.Printf("READY %d\n", l.Addr().(*net.TCPAddr).Port)
+
+	conn, err := l.Accept()
+	if err != nil {
+		return fmt.Errorf("accept tcp: %w", err)
+	}
+	defer conn.Close()
+
+	m, err := mux.AcceptAnonymous(conn)
+	if err != nil {
+		return fmt.Errorf("accept mux: %w", err)
+	}
+	defer m.Close()
+
+	// Accept streams and echo until the mux is closed
+	for {
+		stream, err := m.AcceptStream()
+		if err != nil {
+			// Mux closed by peer — normal shutdown
+			return nil
+		}
+		go func() {
+			defer stream.Close()
+			io.Copy(stream, stream)
+		}()
+	}
+}
+
+func echoClient(addr string, numStreams int, msgSize int) error {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("dial tcp: %w", err)
+	}
+	defer conn.Close()
+
+	m, err := mux.DialAnonymous(conn)
+	if err != nil {
+		return fmt.Errorf("dial mux: %w", err)
+	}
+	defer m.Close()
+
+	type result struct {
+		streamID int
+		err      error
+	}
+	results := make(chan result, numStreams)
+
+	for i := 0; i < numStreams; i++ {
+		stream := m.DialStream()
+		go func(id int) {
+			defer stream.Close()
+
+			// Build test message
+			msg := make([]byte, msgSize)
+			for j := range msg {
+				msg[j] = byte(id + j)
+			}
+
+			// Write
+			if _, err := stream.Write(msg); err != nil {
+				results <- result{id, fmt.Errorf("write: %w", err)}
+				return
+			}
+
+			// Read echo back
+			buf := make([]byte, msgSize)
+			if _, err := io.ReadFull(stream, buf); err != nil {
+				results <- result{id, fmt.Errorf("read: %w", err)}
+				return
+			}
+
+			// Verify
+			for j := range msg {
+				if buf[j] != msg[j] {
+					results <- result{id, fmt.Errorf("byte %d: got %d, want %d", j, buf[j], msg[j])}
+					return
+				}
+			}
+
+			results <- result{id, nil}
+		}(i)
+	}
+
+	for i := 0; i < numStreams; i++ {
+		r := <-results
+		if r.err != nil {
+			return fmt.Errorf("stream %d: %w", r.streamID, r.err)
+		}
+	}
+
+	fmt.Println("PASS")
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: interop <echo-server PORT|echo-client ADDR NUM_STREAMS MSG_SIZE>\n")
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "echo-server":
+		port := 0
+		if len(os.Args) > 2 {
+			var err error
+			port, err = strconv.Atoi(os.Args[2])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid port: %s\n", os.Args[2])
+				os.Exit(1)
+			}
+		}
+		if err := echoServer(port); err != nil {
+			fmt.Fprintf(os.Stderr, "echo-server error: %v\n", err)
+			os.Exit(1)
+		}
+
+	case "echo-client":
+		if len(os.Args) < 5 {
+			fmt.Fprintf(os.Stderr, "usage: interop echo-client ADDR NUM_STREAMS MSG_SIZE\n")
+			os.Exit(1)
+		}
+		addr := os.Args[2]
+		numStreams, err := strconv.Atoi(os.Args[3])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid num_streams: %s\n", os.Args[3])
+			os.Exit(1)
+		}
+		msgSize, err := strconv.Atoi(os.Args[4])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid msg_size: %s\n", os.Args[4])
+			os.Exit(1)
+		}
+		if err := echoClient(addr, numStreams, msgSize); err != nil {
+			fmt.Fprintf(os.Stderr, "echo-client error: %v\n", err)
+			os.Exit(1)
+		}
+
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This pull request adds a new crate within the workspace called mux. This is a port of the v3 mux protocol from [Go codebase](https://github.com/SiaFoundation/mux). 

The indexd crate is not wired up to use this yet. Currently, you can run `cargo run -p mux --example rpc_settings -- 127.0.0.1:9984 ed25519:4351516175d035523a5c047c70be882106a795966343b2ba60bb58d586b07d3b` to dial a host and fetch its price settings.

The integration tests require that a go binary is compiled. I added this to the appropriate github action, so the tests will run correctly.
`cd mux/testutil/go-interop && go build -o interop .`

