### PR TITLE
Generic transport

### DIFF
--- a/.changeset/generic_transport.md
+++ b/.changeset/generic_transport.md
@@ -1,0 +1,16 @@
+---
+indexd_ffi: minor
+sia_sdk_derive: minor
+indexd: minor
+sia_sdk: minor
+---
+
+# Generic transport
+
+#275 by @Alrighttt
+
+The SDK was hardcoded to the QUIC transport (quic::Client). This change makes it possible to add new transport implementations (e.g. siamux, WebTransport) by implementing the RHP4Client trait, without modifying the Downloader, Uploader, or SDK internals.
+
+This is a prerequisite for siamux support and WebTransport support. 
+
+Adds https://crates.io/crates/async-trait as a dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
 name = "indexd"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "base64",
  "blake2",
  "blake2b_simd",

--- a/indexd/Cargo.toml
+++ b/indexd/Cargo.toml
@@ -37,6 +37,7 @@ chrono = { version = "0.4.44", features = ["serde"] }
 blake2 = "0.10.6"
 hkdf = "0.12.4"
 base64 = "0.22.1"
+async-trait = "0.1.89"
 
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["async_tokio"] }

--- a/indexd/src/builder.rs
+++ b/indexd/src/builder.rs
@@ -36,7 +36,7 @@ pub struct ApprovedState {
 /// A builder for creating an SDK instance.
 pub struct Builder<S> {
     state: S,
-    client: Client,
+    client: Arc<dyn AppClient>,
 }
 
 /// Errors that can occur during the SDK building process.
@@ -72,7 +72,7 @@ impl Builder<DisconnectedState> {
         let client = Client::new(indexer_url)?;
         Ok(Self {
             state: DisconnectedState,
-            client,
+            client: Arc::new(client),
         })
     }
 

--- a/indexd/src/builder.rs
+++ b/indexd/src/builder.rs
@@ -10,7 +10,7 @@ use sia::types::Hash256;
 use thiserror::Error;
 use url::Url;
 
-use crate::app_client::{self, Client, RegisterAppRequest};
+use crate::app_client::{self, AppClient, Client, RegisterAppRequest};
 use crate::object_encryption::derive;
 use crate::{SDK, quic};
 

--- a/indexd/src/lib.rs
+++ b/indexd/src/lib.rs
@@ -66,7 +66,7 @@ pub struct SDK {
 impl SDK {
     /// Creates a new SDK instance.
     async fn new(
-        api_client: app_client::Client,
+        api_client: Arc<dyn AppClient>,
         app_key: Arc<PrivateKey>,
         tls_config: rustls::ClientConfig,
     ) -> Result<Self, BuilderError> {
@@ -80,7 +80,7 @@ impl SDK {
         let uploader = Uploader::new(hosts.clone(), transport.clone(), app_key.clone());
         Ok(Self {
             app_key,
-            api_client: Arc::new(api_client),
+            api_client,
             downloader,
             uploader,
         })

--- a/indexd/src/lib.rs
+++ b/indexd/src/lib.rs
@@ -10,7 +10,7 @@ pub use slabs::*;
 mod hosts;
 pub use hosts::*;
 
-use crate::app_client::{Account, ObjectsCursor};
+use crate::app_client::{Account, AppClient, ObjectsCursor};
 use sia::rhp::Host;
 use sia::types::Hash256;
 use thiserror::Error;

--- a/indexd/src/lib.rs
+++ b/indexd/src/lib.rs
@@ -59,7 +59,7 @@ pub enum Error {
 pub struct SDK {
     app_key: Arc<PrivateKey>,
     api_client: Arc<dyn AppClient>,
-    downloader: Downloader<quic::Client>,
+    downloader: Downloader,
     uploader: Uploader<quic::Client>,
 }
 
@@ -76,7 +76,8 @@ impl SDK {
 
         let transport = quic::Client::new(tls_config, hosts.clone())?;
 
-        let downloader = Downloader::new(hosts.clone(), transport.clone(), app_key.clone());
+        let downloader =
+            Downloader::new(hosts.clone(), Arc::new(transport.clone()), app_key.clone());
         let uploader = Uploader::new(hosts.clone(), transport.clone(), app_key.clone());
         Ok(Self {
             app_key,

--- a/indexd/src/lib.rs
+++ b/indexd/src/lib.rs
@@ -60,7 +60,7 @@ pub struct SDK {
     app_key: Arc<PrivateKey>,
     api_client: Arc<dyn AppClient>,
     downloader: Downloader,
-    uploader: Uploader<quic::Client>,
+    uploader: Uploader,
 }
 
 impl SDK {
@@ -78,7 +78,7 @@ impl SDK {
 
         let downloader =
             Downloader::new(hosts.clone(), Arc::new(transport.clone()), app_key.clone());
-        let uploader = Uploader::new(hosts.clone(), transport.clone(), app_key.clone());
+        let uploader = Uploader::new(hosts.clone(), Arc::new(transport), app_key.clone());
         Ok(Self {
             app_key,
             api_client,

--- a/indexd/src/lib.rs
+++ b/indexd/src/lib.rs
@@ -58,7 +58,7 @@ pub enum Error {
 #[derive(Clone)]
 pub struct SDK {
     app_key: Arc<PrivateKey>,
-    api_client: app_client::Client,
+    api_client: Arc<dyn AppClient>,
     downloader: Downloader<quic::Client>,
     uploader: Uploader<quic::Client>,
 }
@@ -80,7 +80,7 @@ impl SDK {
         let uploader = Uploader::new(hosts.clone(), transport.clone(), app_key.clone());
         Ok(Self {
             app_key,
-            api_client,
+            api_client: Arc::new(api_client),
             downloader,
             uploader,
         })

--- a/indexd/src/mock.rs
+++ b/indexd/src/mock.rs
@@ -10,6 +10,8 @@ use sia::types::{Currency, Hash256};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::sleep;
 
+use async_trait::async_trait;
+
 use crate::rhp4::{self, RHP4Client};
 use crate::{
     DownloadError, DownloadOptions, Downloader, Hosts, Object, PackedUpload, UploadError,
@@ -51,7 +53,8 @@ impl MockRHP4Client {
     }
 }
 
-impl RHP4Client for Arc<MockRHP4Client> {
+#[async_trait]
+impl RHP4Client for MockRHP4Client {
     async fn host_prices(&self, _: PublicKey, _: bool) -> Result<HostPrices, rhp4::Error> {
         Ok(HostPrices {
             contract_price: Currency::zero(),
@@ -130,7 +133,7 @@ impl RHP4Client for Arc<MockRHP4Client> {
 }
 
 pub struct MockUploader {
-    uploader: Uploader<Arc<MockRHP4Client>>,
+    uploader: Uploader,
 }
 
 impl MockUploader {
@@ -154,7 +157,7 @@ impl MockUploader {
 }
 
 pub struct MockDownloader {
-    downloader: Downloader<Arc<MockRHP4Client>>,
+    downloader: Downloader,
 }
 
 impl MockDownloader {

--- a/indexd/src/quic.rs
+++ b/indexd/src/quic.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::Utc;
 use core::fmt::Debug;
@@ -460,6 +461,7 @@ impl Client {
     }
 }
 
+#[async_trait]
 impl RHP4Client for Client {
     async fn host_prices(
         &self,

--- a/indexd/src/rhp4.rs
+++ b/indexd/src/rhp4.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use bytes::Bytes;
 use sia::encoding;
 use sia::rhp::{self, HostPrices};
@@ -31,24 +32,21 @@ pub enum Error {
 }
 
 /// Trait defining the operations that can be performed on a host.
-pub(crate) trait RHP4Client {
-    fn host_prices(
-        &self,
-        host_key: PublicKey,
-        refresh: bool,
-    ) -> impl Future<Output = Result<HostPrices, Error>> + Send;
-    fn write_sector(
+#[async_trait]
+pub(crate) trait RHP4Client: Send + Sync {
+    async fn host_prices(&self, host_key: PublicKey, refresh: bool) -> Result<HostPrices, Error>;
+    async fn write_sector(
         &self,
         host_key: PublicKey,
         account_key: &PrivateKey,
         sector: Bytes,
-    ) -> impl Future<Output = Result<Hash256, Error>> + Send;
-    fn read_sector(
+    ) -> Result<Hash256, Error>;
+    async fn read_sector(
         &self,
         host_key: PublicKey,
         account_key: &PrivateKey,
         root: Hash256,
         offset: usize,
         length: usize,
-    ) -> impl Future<Output = Result<Bytes, Error>> + Send;
+    ) -> Result<Bytes, Error>;
 }

--- a/indexd/src/upload.rs
+++ b/indexd/src/upload.rs
@@ -185,17 +185,14 @@ impl PackedUpload {
 }
 
 #[derive(Clone)]
-pub(crate) struct Uploader<T: RHP4Client> {
+pub(crate) struct Uploader {
     app_key: Arc<PrivateKey>,
     hosts: Hosts,
-    transport: T,
+    transport: Arc<dyn RHP4Client>,
 }
 
-impl<T> Uploader<T>
-where
-    T: RHP4Client + Send + Sync + Clone + 'static,
-{
-    pub fn new(hosts: Hosts, transport: T, app_key: Arc<PrivateKey>) -> Self {
+impl Uploader {
+    pub fn new(hosts: Hosts, transport: Arc<dyn RHP4Client>, app_key: Arc<PrivateKey>) -> Self {
         Uploader {
             app_key,
             hosts,
@@ -204,7 +201,7 @@ where
     }
 
     async fn upload_shard(
-        transport: T,
+        transport: Arc<dyn RHP4Client>,
         hosts: HostQueue,
         host_key: PublicKey,
         account_key: Arc<PrivateKey>,
@@ -241,7 +238,7 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn upload_slab_shard(
         permit: OwnedSemaphorePermit,
-        transport: T,
+        transport: Arc<dyn RHP4Client>,
         hosts: HostQueue,
         account_key: Arc<PrivateKey>,
         data: Bytes,
@@ -305,7 +302,7 @@ where
     }
 
     async fn upload_slabs<R: AsyncRead + Unpin + Send + 'static>(
-        transport: T,
+        transport: Arc<dyn RHP4Client>,
         hosts: Hosts,
         app_key: Arc<PrivateKey>,
         r: R,


### PR DESCRIPTION
The SDK was hardcoded to the QUIC transport (quic::Client). This change makes it possible to add new transport implementations (e.g. siamux, WebTransport) by implementing the RHP4Client trait, without modifying the Downloader, Uploader, or SDK internals.

This is a prerequisite for siamux support and WebTransport support. 

Adds https://crates.io/crates/async-trait as a dependency.