### PR TITLE
Update knope

### DIFF
--- a/.changeset/adds_go_interoperability_tests_for_mux_crate_adds_an_example_to_mux_create.md
+++ b/.changeset/adds_go_interoperability_tests_for_mux_crate_adds_an_example_to_mux_create.md
@@ -1,5 +1,0 @@
----
-sia_mux: minor
----
-
-# Adds Go interoperability tests for mux crate; Adds an example to mux create;

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Knope
-        uses: knope-dev/action@1ba8f6acf146130c3f5b196465018aa9f553381a
+        uses: knope-dev/action@v8055388a38df33f0603050415ac3d8175d6b566f
       - name: Prepare Release
         run: knope prepare-release --verbose
       - name: Create Pull Request

--- a/knope.toml
+++ b/knope.toml
@@ -1,3 +1,6 @@
+[changes]
+ignore_conventional_commits = true
+
 [packages.sia_core]
 versioned_files = [
     "sia_core/Cargo.toml",
@@ -46,7 +49,6 @@ type = "CreateChangeFile"
 
 [[workflows]]
 name = "prepare-release"
-ignore_conventional_commits = true
 
 [[workflows.steps]]
 type = "PrepareRelease"


### PR DESCRIPTION
Migrates our `Knope.toml` to the new `[changes]` config and updates the CI version. Fixes an issue with conventional commits being included in the changelog forever.