### PR TITLE
Return a reader from download

### DIFF
--- a/.changeset/download_returns_async_read.md
+++ b/.changeset/download_returns_async_read.md
@@ -1,0 +1,14 @@
+---
+sia_storage: major
+sia_storage_ffi: major
+---
+
+# Download returns an AsyncRead
+
+`SDK::download` now returns a `Download` handle implementing `AsyncRead`
+instead of taking a writer. Callers pull data with `tokio::io::copy` or any
+other `AsyncRead` consumer.
+
+The `sia_storage_ffi` `SDK::download` now returns a `Download` object with
+`read()` and `close()` methods instead of taking a foreign `Writer`. The
+`Writer` foreign trait has been removed.

--- a/sia_storage/Cargo.toml
+++ b/sia_storage/Cargo.toml
@@ -38,6 +38,7 @@ base64 = "0.22.1"
 ed25519-dalek = "2.2.0"
 web-time = "1"
 getrandom = "0.4"
+tokio-util = { version = "0.7.18", features = ["rt"] }
 
 # --- Native-only dependencies ---
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/sia_storage/README.md
+++ b/sia_storage/README.md
@@ -57,7 +57,8 @@ let object = sdk.upload(Object::default(), reader, UploadOptions::default()).awa
 sdk.pin_object(&object).await?;
 
 // Download
-sdk.download(&mut writer, &object, DownloadOptions::default()).await?;
+let mut reader = sdk.download(&object, DownloadOptions::default());
+tokio::io::copy(&mut reader, &mut writer).await?;
 ```
 
 ## Key management

--- a/sia_storage/README.md
+++ b/sia_storage/README.md
@@ -57,7 +57,7 @@ let object = sdk.upload(Object::default(), reader, UploadOptions::default()).awa
 sdk.pin_object(&object).await?;
 
 // Download
-let mut reader = sdk.download(&object, DownloadOptions::default());
+let mut reader = sdk.download(&object, DownloadOptions::default())?;
 tokio::io::copy(&mut reader, &mut writer).await?;
 ```
 

--- a/sia_storage/benches/upload.rs
+++ b/sia_storage/benches/upload.rs
@@ -109,13 +109,15 @@ fn upload_benchmark(c: &mut Criterion) {
         &object,
         |b, object| {
             b.to_async(&runtime).iter(|| async {
-                let mut reader = downloader.download(
-                    object,
-                    DownloadOptions {
-                        max_inflight: 30,
-                        ..Default::default()
-                    },
-                ).unwrap();
+                let mut reader = downloader
+                    .download(
+                        object,
+                        DownloadOptions {
+                            max_inflight: 30,
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap();
                 tokio::io::copy(&mut reader, &mut sink())
                     .await
                     .expect("download to complete");
@@ -128,13 +130,15 @@ fn upload_benchmark(c: &mut Criterion) {
         &object,
         |b, object| {
             b.to_async(&runtime).iter(|| async {
-                let mut reader = downloader.download(
-                    object,
-                    DownloadOptions {
-                        max_inflight: 10,
-                        ..Default::default()
-                    },
-                ).unwrap();
+                let mut reader = downloader
+                    .download(
+                        object,
+                        DownloadOptions {
+                            max_inflight: 10,
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap();
                 tokio::io::copy(&mut reader, &mut sink())
                     .await
                     .expect("download to complete");
@@ -147,7 +151,9 @@ fn upload_benchmark(c: &mut Criterion) {
         &object,
         |b, object| {
             b.to_async(&runtime).iter(|| async {
-                let mut reader = downloader.download(object, DownloadOptions::default()).unwrap();
+                let mut reader = downloader
+                    .download(object, DownloadOptions::default())
+                    .unwrap();
                 tokio::io::copy(&mut reader, &mut sink())
                     .await
                     .expect("download to complete");
@@ -167,7 +173,9 @@ fn upload_benchmark(c: &mut Criterion) {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
-                    let mut reader = downloader.download(&object, DownloadOptions::default()).unwrap();
+                    let mut reader = downloader
+                        .download(&object, DownloadOptions::default())
+                        .unwrap();
                     let mut buf = [0u8; 1];
                     reader.read(&mut buf).await.expect("read to succeed");
                     total += start.elapsed();
@@ -185,13 +193,15 @@ fn upload_benchmark(c: &mut Criterion) {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
-                    let mut reader = downloader.download(
-                        &object,
-                        DownloadOptions {
-                            length: Some(64),
-                            ..Default::default()
-                        },
-                    ).unwrap();
+                    let mut reader = downloader
+                        .download(
+                            &object,
+                            DownloadOptions {
+                                length: Some(64),
+                                ..Default::default()
+                            },
+                        )
+                        .unwrap();
                     let mut buf = [0u8; 1];
                     reader.read(&mut buf).await.expect("read to succeed");
                     total += start.elapsed();

--- a/sia_storage/benches/upload.rs
+++ b/sia_storage/benches/upload.rs
@@ -8,50 +8,8 @@ use sia_storage::mock::{MockDownloader, MockHosts, MockUploader};
 use sia_storage::{AppKey, DownloadOptions, Host, Object, UploadOptions};
 use std::io::Cursor;
 use std::sync::Arc;
-use tokio::io::{AsyncWrite, sink};
+use tokio::io::{AsyncReadExt, sink};
 use tokio::runtime;
-
-struct TtfbWriter {
-    start: std::time::Instant,
-    ttfb: Option<std::time::Duration>,
-}
-
-impl TtfbWriter {
-    fn new(start: std::time::Instant) -> Self {
-        Self { start, ttfb: None }
-    }
-
-    fn ttfb(&self) -> Option<std::time::Duration> {
-        self.ttfb
-    }
-}
-
-impl AsyncWrite for TtfbWriter {
-    fn poll_write(
-        mut self: std::pin::Pin<&mut Self>,
-        _: &mut std::task::Context<'_>,
-        buf: &[u8],
-    ) -> std::task::Poll<std::io::Result<usize>> {
-        if self.ttfb.is_none() {
-            self.ttfb = Some(self.start.elapsed());
-        }
-        std::task::Poll::Ready(Ok(buf.len()))
-    }
-
-    fn poll_flush(
-        self: std::pin::Pin<&mut Self>,
-        _: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
-        std::task::Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(
-        self: std::pin::Pin<&mut Self>,
-        _: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<std::io::Result<()>> {
-        std::task::Poll::Ready(Ok(()))
-    }
-}
 
 async fn upload_object(uploader: Arc<MockUploader>, input: Bytes, opts: UploadOptions) -> Object {
     let r = Cursor::new(input);
@@ -151,15 +109,14 @@ fn upload_benchmark(c: &mut Criterion) {
         &object,
         |b, object| {
             b.to_async(&runtime).iter(|| async {
-                downloader
-                    .download(
-                        &mut sink(),
-                        object,
-                        DownloadOptions {
-                            max_inflight: 30,
-                            ..Default::default()
-                        },
-                    )
+                let mut reader = downloader.download(
+                    object,
+                    DownloadOptions {
+                        max_inflight: 30,
+                        ..Default::default()
+                    },
+                );
+                tokio::io::copy(&mut reader, &mut sink())
                     .await
                     .expect("download to complete");
             });
@@ -171,15 +128,14 @@ fn upload_benchmark(c: &mut Criterion) {
         &object,
         |b, object| {
             b.to_async(&runtime).iter(|| async {
-                downloader
-                    .download(
-                        &mut sink(),
-                        object,
-                        DownloadOptions {
-                            max_inflight: 10,
-                            ..Default::default()
-                        },
-                    )
+                let mut reader = downloader.download(
+                    object,
+                    DownloadOptions {
+                        max_inflight: 10,
+                        ..Default::default()
+                    },
+                );
+                tokio::io::copy(&mut reader, &mut sink())
                     .await
                     .expect("download to complete");
             });
@@ -191,8 +147,8 @@ fn upload_benchmark(c: &mut Criterion) {
         &object,
         |b, object| {
             b.to_async(&runtime).iter(|| async {
-                downloader
-                    .download(&mut sink(), object, DownloadOptions::default())
+                let mut reader = downloader.download(object, DownloadOptions::default());
+                tokio::io::copy(&mut reader, &mut sink())
                     .await
                     .expect("download to complete");
             });
@@ -210,12 +166,11 @@ fn upload_benchmark(c: &mut Criterion) {
             async move {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
-                    let mut w = TtfbWriter::new(std::time::Instant::now());
-                    downloader
-                        .download(&mut w, &object, DownloadOptions::default())
-                        .await
-                        .expect("download to complete");
-                    total += w.ttfb().unwrap_or_else(|| w.start.elapsed());
+                    let start = std::time::Instant::now();
+                    let mut reader = downloader.download(&object, DownloadOptions::default());
+                    let mut buf = [0u8; 1];
+                    reader.read(&mut buf).await.expect("read to succeed");
+                    total += start.elapsed();
                 }
                 total
             }
@@ -229,19 +184,17 @@ fn upload_benchmark(c: &mut Criterion) {
             async move {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
-                    let mut w = TtfbWriter::new(std::time::Instant::now());
-                    downloader
-                        .download(
-                            &mut w,
-                            &object,
-                            DownloadOptions {
-                                length: Some(64),
-                                ..Default::default()
-                            },
-                        )
-                        .await
-                        .expect("download to complete");
-                    total += w.ttfb().unwrap_or_else(|| w.start.elapsed());
+                    let start = std::time::Instant::now();
+                    let mut reader = downloader.download(
+                        &object,
+                        DownloadOptions {
+                            length: Some(64),
+                            ..Default::default()
+                        },
+                    );
+                    let mut buf = [0u8; 1];
+                    reader.read(&mut buf).await.expect("read to succeed");
+                    total += start.elapsed();
                 }
                 total
             }

--- a/sia_storage/benches/upload.rs
+++ b/sia_storage/benches/upload.rs
@@ -115,7 +115,7 @@ fn upload_benchmark(c: &mut Criterion) {
                         max_inflight: 30,
                         ..Default::default()
                     },
-                );
+                ).unwrap();
                 tokio::io::copy(&mut reader, &mut sink())
                     .await
                     .expect("download to complete");
@@ -134,7 +134,7 @@ fn upload_benchmark(c: &mut Criterion) {
                         max_inflight: 10,
                         ..Default::default()
                     },
-                );
+                ).unwrap();
                 tokio::io::copy(&mut reader, &mut sink())
                     .await
                     .expect("download to complete");
@@ -147,7 +147,7 @@ fn upload_benchmark(c: &mut Criterion) {
         &object,
         |b, object| {
             b.to_async(&runtime).iter(|| async {
-                let mut reader = downloader.download(object, DownloadOptions::default());
+                let mut reader = downloader.download(object, DownloadOptions::default()).unwrap();
                 tokio::io::copy(&mut reader, &mut sink())
                     .await
                     .expect("download to complete");
@@ -167,7 +167,7 @@ fn upload_benchmark(c: &mut Criterion) {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
-                    let mut reader = downloader.download(&object, DownloadOptions::default());
+                    let mut reader = downloader.download(&object, DownloadOptions::default()).unwrap();
                     let mut buf = [0u8; 1];
                     reader.read(&mut buf).await.expect("read to succeed");
                     total += start.elapsed();
@@ -191,7 +191,7 @@ fn upload_benchmark(c: &mut Criterion) {
                             length: Some(64),
                             ..Default::default()
                         },
-                    );
+                    ).unwrap();
                     let mut buf = [0u8; 1];
                     reader.read(&mut buf).await.expect("read to succeed");
                     total += start.elapsed();

--- a/sia_storage/examples/benchmark.rs
+++ b/sia_storage/examples/benchmark.rs
@@ -223,7 +223,9 @@ async fn main() {
     println!("Downloading object...");
     let start = Instant::now();
     let mut verifier = SeededVerifier::new(seed, args.size);
-    let mut reader = sdk.download(&obj, DownloadOptions::default());
+    let mut reader = sdk
+        .download(&obj, DownloadOptions::default())
+        .expect("failed to start download");
     copy(&mut reader, &mut verifier)
         .await
         .expect("failed to copy data");

--- a/sia_storage/examples/benchmark.rs
+++ b/sia_storage/examples/benchmark.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use sia_storage::{AppMetadata, Builder, DownloadOptions, Object, UploadOptions};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, copy};
 
 #[derive(Parser)]
 struct Args {
@@ -223,9 +223,10 @@ async fn main() {
     println!("Downloading object...");
     let start = Instant::now();
     let mut verifier = SeededVerifier::new(seed, args.size);
-    sdk.download(&mut verifier, &obj, DownloadOptions::default())
+    let mut reader = sdk.download(&obj, DownloadOptions::default());
+    copy(&mut reader, &mut verifier)
         .await
-        .expect("failed to download object");
+        .expect("failed to copy data");
     let download_duration = start.elapsed();
     println!(
         "Object uploaded ID: {}\tSize: {}\tEncoded: {}\tElapsed: {:?}\tThroughput: {}\tEncoded Throughput: {}",

--- a/sia_storage/src/app_client.rs
+++ b/sia_storage/src/app_client.rs
@@ -1287,7 +1287,7 @@ mod tests {
                 &ephemeral_key,
                 &AppMetadata {
                     id: app_id,
-                    name: "name",
+                    name: "name".into(),
                     description: "description",
                     service_url: "https://service.com",
                     logo_url: Some("https://logo.com"),

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -408,12 +408,39 @@ impl Download {
         }
     }
 
+    /// Returns the next decoded chunk of data. Returns an empty `Vec` on EOF.
+    /// Chunks are typically up to 256 KiB.
+    ///
+    /// This is primarily intended for FFI bindings to enable zero-copy
+    /// transfer of an owned `Vec<u8>`. For general use, prefer the
+    /// [AsyncRead] implementation.
+    #[doc(hidden)]
+    pub async fn read_chunk(&mut self) -> Result<Vec<u8>, DownloadError> {
+        // If a previous AsyncRead poll left a partial buffer, drain it first
+        // so callers mixing read_chunk and poll_read don't lose data.
+        if !self.buf.is_empty() {
+            return Ok(std::mem::take(&mut self.buf).to_vec());
+        }
+        let Some(chunk_handle) = self.queue.pop_front() else {
+            return Ok(Vec::new()); // EOF
+        };
+        let mut result = chunk_handle.await??;
+        self.spawn_next();
+        self.cipher.apply_keystream(&mut result); // decrypt
+        Ok(result)
+    }
+
     pub(crate) fn new(
         object: &Object,
         hosts: Hosts<Client>,
         account_key: Arc<AppKey>,
         options: DownloadOptions,
-    ) -> Self {
+    ) -> Result<Self, DownloadError> {
+        if options.max_inflight == 0 {
+            return Err(DownloadError::Custom(
+                "max_inflight must be greater than 0".to_string(),
+            ));
+        }
         let object_size = object.size();
         let cipher = object.cipher(options.offset);
         let available = object_size.saturating_sub(options.offset);
@@ -431,7 +458,7 @@ impl Download {
         for _ in 0..options.max_inflight {
             download.spawn_next();
         }
-        download
+        Ok(download)
     }
 }
 
@@ -496,7 +523,8 @@ mod test {
                 hosts.clone(),
                 app_key.clone(),
                 DownloadOptions::default(),
-            );
+            )
+            .unwrap();
             tokio::io::copy(&mut download, &mut recovered_data)
                 .await
                 .unwrap();

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -1,20 +1,22 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::VecDeque;
 use std::fmt::Debug;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Poll, ready};
 
-use crate::encryption::{EncryptionKey, encrypt_recovered_shards};
+use crate::encryption::{Chacha20Cipher, EncryptionKey, encrypt_recovered_shards};
 use crate::erasure_coding::{self, ErasureCoder};
 use crate::hosts::{Hosts, RPCError};
-use crate::rhp4::Transport;
-use crate::time::{Duration, Elapsed, Instant, sleep};
+use crate::rhp4::{Client, Transport};
+use crate::time::{Duration, Elapsed, sleep};
 use crate::{AppKey, Object, Sector, Slab};
-use bytes::{Bytes, BytesMut};
-use log::debug;
+use bytes::{Buf, Bytes, BytesMut};
+use chacha20::cipher::StreamCipher;
 use sia_core::rhp4::SEGMENT_SIZE;
 use thiserror::Error;
-use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tokio::sync::Semaphore;
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::task::JoinSet;
+use tokio_util::task::AbortOnDropHandle;
 
 /// Errors that can occur during a download.
 #[derive(Debug, Error)]
@@ -288,15 +290,15 @@ impl<T: Transport> SlabRecovery<SlabDecoded, T> {
 /// note: this is pulled out for now to enable easier testing. In the future, when
 /// we can mock the SDK, this should be moved directly into the Download method.
 /// Iterator-like state for splitting slabs into chunks.
-struct ChunkIter<'a, const N: usize> {
-    slabs: &'a [Slab],
+struct ChunkIter<const N: usize> {
+    slabs: Vec<Slab>,
     slab_idx: usize,
     offset: u64,
     remaining: u64,
 }
 
-impl<'a, const N: usize> ChunkIter<'a, N> {
-    fn new(slabs: &'a [Slab], offset: u64, length: u64) -> Self {
+impl<const N: usize> ChunkIter<N> {
+    fn new(slabs: Vec<Slab>, offset: u64, length: u64) -> Self {
         let mut slab_idx = 0;
         let mut offset = offset;
         while slab_idx < slabs.len() {
@@ -316,7 +318,7 @@ impl<'a, const N: usize> ChunkIter<'a, N> {
     }
 }
 
-impl<'a, const N: usize> Iterator for ChunkIter<'a, N> {
+impl<const N: usize> Iterator for ChunkIter<N> {
     type Item = Slab;
 
     fn next(&mut self) -> Option<Slab> {
@@ -343,197 +345,119 @@ impl<'a, const N: usize> Iterator for ChunkIter<'a, N> {
     }
 }
 
-pub(crate) async fn download_object<W: AsyncWrite + Unpin, T: Transport>(
-    hosts: Hosts<T>,
+const CHUNK_SIZE: usize = 1 << 18; // 256 KiB
+
+pub struct Download {
+    hosts: Hosts<Client>,
     account_key: Arc<AppKey>,
-    w: &mut W,
-    object: &Object,
-    options: DownloadOptions,
-) -> Result<(), DownloadError> {
-    if options.max_inflight == 0 {
-        return Err(DownloadError::Custom(
-            "max_inflight must be greater than 0".to_string(),
-        ));
+    cipher: Chacha20Cipher,
+
+    // download state
+    buf: Bytes,
+    queue: VecDeque<AbortOnDropHandle<Result<Vec<u8>, DownloadError>>>,
+    chunk_iter: ChunkIter<CHUNK_SIZE>,
+}
+
+impl AsyncRead for Download {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        if !self.buf.is_empty() {
+            self.drain_buf(buf);
+            return Poll::Ready(Ok(()));
+        }
+
+        if let Some(chunk_handle) = self.queue.front_mut() {
+            let mut result =
+                ready!(Pin::new(chunk_handle).poll(cx))?.map_err(std::io::Error::other)?;
+            self.queue.pop_front();
+            self.spawn_next();
+            self.cipher.apply_keystream(&mut result); // decrypt
+            self.buf = Bytes::from(result);
+            self.drain_buf(buf);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Download {
+    fn drain_buf(&mut self, buf: &mut tokio::io::ReadBuf<'_>) {
+        let to_copy = std::cmp::min(buf.remaining(), self.buf.len());
+        buf.put_slice(&self.buf[..to_copy]);
+        self.buf.advance(to_copy);
     }
 
-    const CHUNK_SIZE: usize = 1 << 18; // 256 KiB
-
-    let object_size = object.size();
-    if options.offset >= object_size || options.length == Some(0) {
-        return Ok(());
-    }
-
-    let mut w = object.writer(w, options.offset);
-    let available = object_size.saturating_sub(options.offset);
-    let remaining = options.length.unwrap_or(available).min(available);
-    let mut chunks = ChunkIter::<CHUNK_SIZE>::new(object.slabs(), options.offset, remaining)
-        .enumerate()
-        .peekable();
-
-    // recover the first chunk synchronously for fast TTFB
-    if let Some((chunk_index, slab)) = chunks.next() {
-        let start = Instant::now();
-        SlabRecovery::new(hosts.clone(), account_key.clone(), slab)?
-            .recover_shards()
-            .await?
-            .decode()?
-            .write(&mut w)
-            .await?;
-        debug!(
-            "successfully recovered slab for chunk {chunk_index} in {:?}",
-            start.elapsed()
-        );
-    }
-
-    let semaphore = Arc::new(Semaphore::new(options.max_inflight));
-    let mut chunk_tasks: JoinSet<Result<(usize, SlabRecovery<_, T>), DownloadError>> =
-        JoinSet::new();
-    let mut completed_chunks: BTreeMap<usize, SlabRecovery<_, T>> = BTreeMap::new();
-    let mut next_write_chunk = chunks.peek().map(|(index, _)| *index).unwrap_or_default(); // the next chunk index to write to the output
-    loop {
-        tokio::select! {
-            Some(res) = chunk_tasks.join_next() => {
-                let (chunk_index, slab_recovery) = res??;
-                if chunk_index == next_write_chunk {
-                    slab_recovery.write(&mut w).await?;
-                    next_write_chunk += 1;
-                    while let Some(recovered_chunk) = completed_chunks.remove(&next_write_chunk) {
-                        recovered_chunk.write(&mut w).await?;
-                        next_write_chunk += 1;
-                    }
-                } else {
-                    completed_chunks.insert(chunk_index, slab_recovery);
-                }
-            },
-            permit = semaphore.clone().acquire_owned(), if chunks.peek().is_some() => {
-                let permit = permit?;
-                let (chunk_index, slab) = chunks.next().expect("peeked Some but got None");
-
-                let hosts = hosts.clone();
-                let account_key = account_key.clone();
-                join_set_spawn!(chunk_tasks, async move {
-                    let _permit = permit; // hold the permit for the duration of the task
-                    let start = Instant::now();
-                    let result = async {
-                        SlabRecovery::new(hosts, account_key, slab)
-                            .unwrap()
-                            .recover_shards()
-                            .await?
-                            .decode()
-                    }.await
-                    .inspect_err(|e| debug!("failed to recover slab for chunk {chunk_index}: {e}"))?;
-                    debug!("successfully recovered slab for chunk {chunk_index} in {:?}", start.elapsed());
-                    Ok((chunk_index, result))
-                });
-            },
-            else => break,
+    fn spawn_next(&mut self) {
+        if let Some(chunk_slab) = self.chunk_iter.next() {
+            let hosts = self.hosts.clone();
+            let account_key = self.account_key.clone();
+            self.queue
+                .push_back(AbortOnDropHandle::new(maybe_spawn!(async move {
+                    let len = chunk_slab.length as usize;
+                    let mut buf = Vec::with_capacity(len);
+                    SlabRecovery::new(hosts, account_key, chunk_slab)?
+                        .recover_shards()
+                        .await?
+                        .decode()?
+                        .write(&mut buf)
+                        .await?;
+                    Ok(buf)
+                })));
         }
     }
-    if !completed_chunks.is_empty() {
-        panic!(
-            "{} chunks remaining but no tasks in flight",
-            completed_chunks.len()
-        );
+
+    pub(crate) fn new(
+        object: &Object,
+        hosts: Hosts<Client>,
+        account_key: Arc<AppKey>,
+        options: DownloadOptions,
+    ) -> Self {
+        let object_size = object.size();
+        let cipher = object.cipher(options.offset);
+        let available = object_size.saturating_sub(options.offset);
+        let remaining = options.length.unwrap_or(available).min(available);
+        let slabs = object.slabs().to_vec();
+        let chunk_iter = ChunkIter::new(slabs, options.offset, remaining);
+        let mut download = Self {
+            hosts,
+            account_key,
+            cipher,
+            buf: Bytes::new(),
+            queue: VecDeque::with_capacity(options.max_inflight),
+            chunk_iter,
+        };
+        for _ in 0..options.max_inflight {
+            download.spawn_next();
+        }
+        download
     }
-    w.flush().await?;
-    Ok(())
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::collections::HashMap;
     use std::io::Cursor;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     use bytes::BytesMut;
-    use chrono::Utc;
     use rand::Rng;
-    use sia_core::rhp4::{HostPrices, SECTOR_SIZE};
-    use sia_core::signing::{PrivateKey, Signature};
+    use sia_core::rhp4::SECTOR_SIZE;
+    use sia_core::signing::PrivateKey;
     use sia_core::types::v2::NetAddress;
-    use sia_core::types::{Currency, Hash256};
 
     use crate::compat::run_local;
     use crate::hosts::Hosts;
-    use crate::mock::MockRHP4Transport;
-    use crate::rhp4::{self, HostEndpoint, Transport};
     use crate::upload::Uploader;
     use crate::{Host, UploadOptions};
-
-    /// A mock RHP client with decreasing delays for read RPCs to simulate
-    /// out-of-order chunk completion.
-    #[derive(Clone)]
-    struct OOORHPClient {
-        sector_data: Arc<Mutex<HashMap<Hash256, Bytes>>>,
-        sector_delays: Arc<Mutex<HashMap<Hash256, Duration>>>,
-    }
-
-    impl Transport for OOORHPClient {
-        async fn host_prices(&self, _: &HostEndpoint) -> Result<HostPrices, rhp4::Error> {
-            Ok(HostPrices {
-                contract_price: Currency::zero(),
-                collateral: Currency::zero(),
-                ingress_price: Currency::zero(),
-                egress_price: Currency::zero(),
-                storage_price: Currency::zero(),
-                free_sector_price: Currency::zero(),
-                tip_height: 1,
-                signature: Signature::default(),
-                valid_until: Utc::now() + chrono::Duration::days(1),
-            })
-        }
-
-        async fn write_sector(
-            &self,
-            _: &HostEndpoint,
-            _: HostPrices,
-            _: &PrivateKey,
-            sector: Bytes,
-        ) -> Result<Hash256, rhp4::Error> {
-            let sector_root = sia_core::rhp4::sector_root(&sector);
-            let mut sectors = self.sector_data.lock().unwrap();
-            sectors.insert(sector_root, sector);
-            let mut sector_delays = self.sector_delays.lock().unwrap();
-            sector_delays.insert(sector_root, Duration::from_millis(500));
-            Ok(sector_root)
-        }
-
-        async fn read_sector(
-            &self,
-            _: &HostEndpoint,
-            _: HostPrices,
-            _: &PrivateKey,
-            root: Hash256,
-            offset: usize,
-            length: usize,
-        ) -> Result<Bytes, rhp4::Error> {
-            let delay = {
-                let mut sector_delays = self.sector_delays.lock().unwrap();
-                if let Some(delay) = sector_delays.get(&root) {
-                    let delay = *delay;
-                    sector_delays.insert(root, delay / 2); // reads get faster each time so that chunks are more likely to finish out-of-order
-                    delay
-                } else {
-                    panic!("sector not found");
-                }
-            };
-            sleep(delay).await;
-            let sectors = self.sector_data.lock().unwrap();
-            let sector = sectors.get(&root).expect("sector not found").clone();
-            Ok(Bytes::copy_from_slice(&sector[offset..offset + length]))
-        }
-    }
 
     cross_target_tests! {
         async fn test_out_of_order_download() { run_local(async {
             let upload_options = UploadOptions::default();
             let slab_size = upload_options.data_shards as usize * SECTOR_SIZE;
 
-            let transport = OOORHPClient {
-                sector_data: Arc::new(Mutex::new(HashMap::new())),
-                sector_delays: Arc::new(Mutex::new(HashMap::new())),
-            };
+            let transport = Client::new();
             let hosts = Hosts::new(transport.clone());
             hosts.update(
                 (0..60)
@@ -556,6 +480,10 @@ mod test {
             let data = data.freeze();
             let app_key = Arc::new(AppKey::import(rand::random()));
 
+            // configure decreasing per-sector read delays to force out-of-order
+            // chunk completion during download
+            transport.set_initial_read_delay(Duration::from_millis(500));
+
             let uploader = Uploader::new(hosts.clone(), app_key.clone());
             let obj = uploader
                 .upload(Object::default(), Cursor::new(data.clone()), UploadOptions::default())
@@ -563,16 +491,15 @@ mod test {
                 .unwrap();
 
             let mut recovered_data = Vec::with_capacity(slab_size);
-            let mut w = Cursor::new(&mut recovered_data);
-            download_object(
+            let mut download = Download::new(
+                &obj,
                 hosts.clone(),
                 app_key.clone(),
-                &mut w,
-                &obj,
                 DownloadOptions::default(),
-            )
-            .await
-            .unwrap();
+            );
+            tokio::io::copy(&mut download, &mut recovered_data)
+                .await
+                .unwrap();
 
             assert_eq!(data, recovered_data);
         }).await }
@@ -581,7 +508,7 @@ mod test {
             let upload_options = UploadOptions::default();
             let slab_size = upload_options.data_shards as usize * SECTOR_SIZE;
 
-            let transport = MockRHP4Transport::new();
+            let transport = Client::new();
             let hosts = Hosts::new(transport.clone());
             hosts.update(
                 (0..60)

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -60,6 +60,10 @@ pub enum DownloadError {
     /// A custom error.
     #[error("custom error: {0}")]
     Custom(String),
+
+    /// The download previously errored and can no longer be read from.
+    #[error("download errored")]
+    Errored,
 }
 
 /// Options for configuring a download.
@@ -356,6 +360,12 @@ pub struct Download {
     buf: Bytes,
     queue: VecDeque<AbortOnDropHandle<Result<Vec<u8>, DownloadError>>>,
     chunk_iter: ChunkIter<CHUNK_SIZE>,
+    // sticky error
+    //
+    // note: in Go we would store the error and return it, but that would
+    // require all the enum variants to be Clone which is not the case, so
+    // a generic variant is returned after the first error.
+    errored: bool,
 }
 
 impl AsyncRead for Download {
@@ -364,14 +374,27 @@ impl AsyncRead for Download {
         cx: &mut std::task::Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
+        if self.errored {
+            return Poll::Ready(Err(std::io::Error::other(DownloadError::Errored)));
+        }
+
         if !self.buf.is_empty() {
             self.drain_buf(buf);
             return Poll::Ready(Ok(()));
         }
 
         if let Some(chunk_handle) = self.queue.front_mut() {
-            let mut result =
-                ready!(Pin::new(chunk_handle).poll(cx))?.map_err(std::io::Error::other)?;
+            let mut result = match ready!(Pin::new(chunk_handle).poll(cx)) {
+                Ok(Ok(data)) => data,
+                Ok(Err(e)) => {
+                    self.set_err();
+                    return Poll::Ready(Err(std::io::Error::other(e)));
+                }
+                Err(e) => {
+                    self.set_err();
+                    return Poll::Ready(Err(std::io::Error::other(e)));
+                }
+            };
             self.queue.pop_front();
             self.spawn_next();
             self.cipher.apply_keystream(&mut result); // decrypt
@@ -387,6 +410,14 @@ impl Download {
         let to_copy = std::cmp::min(buf.remaining(), self.buf.len());
         buf.put_slice(&self.buf[..to_copy]);
         self.buf.advance(to_copy);
+    }
+
+    /// Marks the download as errored and aborts all in-flight chunk tasks.
+    /// Subsequent reads will return [DownloadError::Errored].
+    fn set_err(&mut self) {
+        self.errored = true;
+        self.buf = Bytes::new();
+        self.queue.clear();
     }
 
     fn spawn_next(&mut self) {
@@ -409,13 +440,16 @@ impl Download {
     }
 
     /// Returns the next decoded chunk of data. Returns an empty `Vec` on EOF.
-    /// Chunks are typically up to 256 KiB.
+    /// Chunks are up to 256 KiB.
     ///
     /// This is primarily intended for FFI bindings to enable zero-copy
     /// transfer of an owned `Vec<u8>`. For general use, prefer the
     /// [AsyncRead] implementation.
     #[doc(hidden)]
     pub async fn read_chunk(&mut self) -> Result<Vec<u8>, DownloadError> {
+        if self.errored {
+            return Err(DownloadError::Errored);
+        }
         // If a previous AsyncRead poll left a partial buffer, drain it first
         // so callers mixing read_chunk and poll_read don't lose data.
         if !self.buf.is_empty() {
@@ -424,7 +458,17 @@ impl Download {
         let Some(chunk_handle) = self.queue.pop_front() else {
             return Ok(Vec::new()); // EOF
         };
-        let mut result = chunk_handle.await??;
+        let mut result = match chunk_handle.await {
+            Ok(Ok(data)) => data,
+            Ok(Err(e)) => {
+                self.set_err();
+                return Err(e);
+            }
+            Err(e) => {
+                self.set_err();
+                return Err(e.into());
+            }
+        };
         self.spawn_next();
         self.cipher.apply_keystream(&mut result); // decrypt
         Ok(result)
@@ -454,6 +498,7 @@ impl Download {
             buf: Bytes::new(),
             queue: VecDeque::with_capacity(options.max_inflight),
             chunk_iter,
+            errored: false,
         };
         for _ in 0..options.max_inflight {
             download.spawn_next();

--- a/sia_storage/src/encryption.rs
+++ b/sia_storage/src/encryption.rs
@@ -8,8 +8,8 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelI
 use serde::{Deserialize, Serialize};
 use sia_core::encoding::{SiaDecodable, SiaDecode, SiaEncodable, SiaEncode};
 use std::pin::Pin;
-use std::task::{Context, Poll, ready};
-use tokio::io::{AsyncRead, AsyncWrite};
+use std::task::{Context, Poll};
+use tokio::io::AsyncRead;
 use zeroize::ZeroizeOnDrop;
 
 /// A 256-bit symmetric encryption key used to encrypt and decrypt slab data.
@@ -136,94 +136,7 @@ impl<R: AsyncRead + Unpin> AsyncRead for CipherReader<R> {
     }
 }
 
-pub(crate) struct CipherWriter<W: AsyncWrite> {
-    inner: W,
-    cipher: Chacha20Cipher,
-    buf: Vec<u8>,
-    // offset into buf where unwritten encrypted data begins
-    buf_pos: usize,
-}
-
-impl<W: AsyncWrite + Unpin> CipherWriter<W> {
-    pub fn new(inner: W, key: EncryptionKey, offset: u64) -> Self {
-        Self {
-            inner,
-            cipher: Chacha20Cipher::new(key, offset),
-            buf: Vec::new(),
-            buf_pos: 0,
-        }
-    }
-
-    fn poll_drain(&mut self, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        while self.buf_pos < self.buf.len() {
-            let n = ready!(Pin::new(&mut self.inner).poll_write(cx, &self.buf[self.buf_pos..]))?;
-            if n == 0 {
-                return Poll::Ready(Err(std::io::Error::new(
-                    std::io::ErrorKind::WriteZero,
-                    "write zero",
-                )));
-            }
-            self.buf_pos += n;
-        }
-        self.buf.clear();
-        self.buf_pos = 0;
-        Poll::Ready(Ok(()))
-    }
-}
-
-impl<W: AsyncWrite + Unpin> AsyncWrite for CipherWriter<W> {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        let this = self.get_mut();
-
-        ready!(this.poll_drain(cx))?;
-
-        // Encrypt new data into the buffer. Once apply_keystream is called the
-        // cipher has advanced, so this data is committed — we must report it as
-        // accepted regardless of whether the inner write completes immediately.
-        this.buf.resize(buf.len(), 0);
-        this.buf_pos = 0;
-        this.buf.copy_from_slice(buf);
-        this.cipher.apply_keystream(&mut this.buf);
-
-        match Pin::new(&mut this.inner).poll_write(cx, &this.buf) {
-            Poll::Ready(Ok(0)) => {
-                return Poll::Ready(Err(std::io::Error::new(
-                    std::io::ErrorKind::WriteZero,
-                    "write zero",
-                )));
-            }
-            Poll::Ready(Ok(n)) => {
-                this.buf_pos = n;
-                if this.buf_pos == this.buf.len() {
-                    this.buf.clear();
-                    this.buf_pos = 0;
-                }
-            }
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-            // apply_keystream has been called we must commit and report all the data as accepted even if the inner writer isn't ready yet
-            _ => {}
-        }
-        Poll::Ready(Ok(buf.len()))
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        let this = self.get_mut();
-        ready!(this.poll_drain(cx))?;
-        Pin::new(&mut this.inner).poll_flush(cx)
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        let this = self.get_mut();
-        ready!(this.poll_drain(cx))?;
-        Pin::new(&mut this.inner).poll_shutdown(cx)
-    }
-}
-
-struct Chacha20Cipher {
+pub(crate) struct Chacha20Cipher {
     inner: XChaCha20,
     key: EncryptionKey,
     nonce: [u8; 24],
@@ -293,7 +206,7 @@ impl StreamCipher for Chacha20Cipher {
 
 #[cfg(test)]
 mod test {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::AsyncReadExt;
 
     use sia_core::rhp4::SECTOR_SIZE;
 
@@ -318,66 +231,6 @@ mod test {
         shards.iter_mut().enumerate().for_each(|(i, shard)| {
             encrypt_shard(key, shard_start + i as u8, offset, shard);
         });
-    }
-
-    /// A writer that accepts at most `max_bytes_per_write` bytes per poll_write
-    /// call, simulating short writes from a slow or buffered inner writer.
-    struct ShortWriter {
-        inner: Vec<u8>,
-        max_bytes_per_write: usize,
-    }
-
-    impl AsyncWrite for ShortWriter {
-        fn poll_write(
-            mut self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<std::io::Result<usize>> {
-            let n = buf.len().min(self.max_bytes_per_write);
-            self.inner.extend_from_slice(&buf[..n]);
-            Poll::Ready(Ok(n))
-        }
-
-        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-
-        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-    }
-
-    /// A writer that returns Poll::Pending on every other poll_write call,
-    /// simulating an async file writer whose internal spawn_blocking task
-    /// hasn't completed yet.
-    struct PendingWriter {
-        inner: Vec<u8>,
-        call_count: usize,
-    }
-
-    impl AsyncWrite for PendingWriter {
-        fn poll_write(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<std::io::Result<usize>> {
-            self.call_count += 1;
-            if self.call_count % 2 == 1 {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            } else {
-                self.inner.extend_from_slice(buf);
-                Poll::Ready(Ok(buf.len()))
-            }
-        }
-
-        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-
-        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
     }
 
     cross_target_tests! {
@@ -419,7 +272,7 @@ mod test {
         assert_eq!(shards[1], vec![4, 5, 6]);
     }
 
-    async fn test_cipher_reader_writer() {
+    async fn test_cipher_reader_roundtrip() {
         let key = EncryptionKey::from([1u8; 32]);
         let data = b"lorem ipsum dolor sit amet, consectetur adipiscing elit";
 
@@ -429,9 +282,9 @@ mod test {
             reader.read_exact(&mut cipher_text).await.unwrap();
             assert_ne!(cipher_text, data);
 
-            let mut writer = CipherWriter::new(Vec::new(), key.clone(), offset);
-            writer.write_all(&cipher_text).await.unwrap();
-            let plaintext = writer.inner;
+            let mut reader = CipherReader::new(cipher_text.as_slice(), key.clone(), offset);
+            let mut plaintext = vec![0u8; data.len()];
+            reader.read_exact(&mut plaintext).await.unwrap();
             assert_eq!(plaintext, data);
         }
     }
@@ -466,91 +319,11 @@ mod test {
             let mut ciphertext = vec![0u8; data.len()];
             reader.read_exact(&mut ciphertext).await.unwrap();
 
-            let mut writer = CipherWriter::new(Vec::new(), key.clone(), offset);
-            writer.write_all(&ciphertext).await.unwrap();
-            let plaintext = writer.inner;
+            let mut reader = CipherReader::new(ciphertext.as_slice(), key.clone(), offset);
+            let mut plaintext = vec![0u8; data.len()];
+            reader.read_exact(&mut plaintext).await.unwrap();
 
             assert_eq!(plaintext, data, "roundtrip failed at offset {offset}");
-        }
-    }
-    /// Tests that CipherWriter produces correct output when the inner writer
-    /// only accepts a few bytes at a time (short writes).
-    async fn test_cipher_writer_short_writes() {
-        let key = random_key();
-        let mut data = vec![0u8; 4096];
-        random_bytes(&mut data);
-
-        // Encrypt with CipherReader
-        let mut reader = CipherReader::new(data.as_slice(), key.clone(), 0);
-        let mut ciphertext = vec![0u8; data.len()];
-        reader.read_exact(&mut ciphertext).await.unwrap();
-
-        // Decrypt with CipherWriter wrapping a ShortWriter that only accepts
-        // small chunks, forcing write_all to retry with remaining bytes.
-        for max_bytes in [1, 7, 13, 31, 64, 100, 512] {
-            let short = ShortWriter {
-                inner: Vec::new(),
-                max_bytes_per_write: max_bytes,
-            };
-            let mut writer = CipherWriter::new(short, key.clone(), 0);
-            writer.write_all(&ciphertext).await.unwrap();
-            writer.flush().await.unwrap();
-            assert_eq!(
-                writer.inner.inner, data,
-                "short write failed with max_bytes={max_bytes}"
-            );
-        }
-    }
-
-    /// Tests that CipherWriter produces correct output when the inner writer
-    /// returns Poll::Pending on alternating calls, simulating tokio::fs::File
-    /// behavior that caused the original decryption bug.
-    async fn test_cipher_writer_pending_writes() {
-        let key = random_key();
-        let mut data = vec![0u8; 4096];
-        random_bytes(&mut data);
-
-        // Encrypt
-        let mut reader = CipherReader::new(data.as_slice(), key.clone(), 0);
-        let mut ciphertext = vec![0u8; data.len()];
-        reader.read_exact(&mut ciphertext).await.unwrap();
-
-        // Decrypt through a writer that returns Pending every other call
-        let pending = PendingWriter {
-            inner: Vec::new(),
-            call_count: 0,
-        };
-        let mut writer = CipherWriter::new(pending, key.clone(), 0);
-        writer.write_all(&ciphertext).await.unwrap();
-        writer.flush().await.unwrap();
-        assert_eq!(writer.inner.inner, data);
-    }
-
-    /// Tests that CipherWriter handles combined short writes + Pending at
-    /// various offsets (exercises nonce rotation under adversarial I/O).
-    async fn test_cipher_writer_short_writes_with_offset() {
-        const MAX_BYTES_PER_NONCE: u64 = u32::MAX as u64 * 64;
-
-        let key = random_key();
-        let mut data = vec![0u8; 4096];
-        random_bytes(&mut data);
-
-        for offset in [0, 64, 2048, MAX_BYTES_PER_NONCE - 64, MAX_BYTES_PER_NONCE] {
-            let mut reader = CipherReader::new(data.as_slice(), key.clone(), offset);
-            let mut ciphertext = vec![0u8; data.len()];
-            reader.read_exact(&mut ciphertext).await.unwrap();
-
-            let short = ShortWriter {
-                inner: Vec::new(),
-                max_bytes_per_write: 37, // prime-sized to misalign with blocks
-            };
-            let mut writer = CipherWriter::new(short, key.clone(), offset);
-            writer.write_all(&ciphertext).await.unwrap();
-            writer.flush().await.unwrap();
-            assert_eq!(
-                writer.inner.inner, data,
-                "short write + offset failed at offset={offset}"
-            );
         }
     }
     }

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -669,9 +669,8 @@ impl HostQueue {
 
 #[cfg(test)]
 mod test {
+    use crate::rhp4::Client;
     use sia_core::signing::PrivateKey;
-
-    use crate::mock::MockRHP4Transport;
 
     use super::*;
 
@@ -828,7 +827,7 @@ mod test {
     }
 
     async fn test_upload_queue() {
-        let hosts_manager = Hosts::new(MockRHP4Transport::new());
+        let hosts_manager = Hosts::new(Client::new());
 
         let hk1 = random_pubkey();
         let hk2 = random_pubkey();

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -33,7 +33,8 @@
 //! sdk.pin_object(&object).await?;
 //!
 //! // Download
-//! sdk.download(&mut writer, &object, DownloadOptions::default()).await?;
+//! let mut reader = sdk.download(&object, DownloadOptions::default());
+//! tokio::io::copy(&mut reader, &mut writer).await?;
 //! ```
 //!
 //! # Key management
@@ -67,10 +68,9 @@ use std::sync::Arc;
 use log::{debug, warn};
 use serde::Serialize;
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::AsyncRead;
 
 use crate::app_client::SlabPinParams;
-use crate::download::download_object;
 pub use crate::hosts::Host;
 use crate::hosts::Hosts;
 use crate::rhp4::{Client, HostEndpoint};
@@ -90,9 +90,10 @@ pub use app_client::Error as AppApiError;
 pub use builder::{
     ApprovedState, Builder, BuilderError, DisconnectedState, RequestingApprovalState,
 };
-pub use download::{DownloadError, DownloadOptions};
+pub use download::{Download, DownloadError, DownloadOptions};
 pub use encryption::EncryptionKey;
 pub use hosts::{QueueError, RPCError};
+pub use rhp4::Client as Transport;
 pub use slabs::{Object, ObjectEvent, PinnedSlab, SealedObject, SealedObjectError, Sector, Slab};
 pub use upload::{PackedUpload, UploadError, UploadOptions};
 
@@ -452,14 +453,12 @@ impl SDK {
         self.uploader.upload_packed(options)
     }
 
-    /// Downloads an object using the provided writer and options.
-    pub async fn download<W: AsyncWrite + Unpin>(
-        &self,
-        w: &mut W,
-        object: &Object,
-        options: DownloadOptions,
-    ) -> Result<(), DownloadError> {
-        download_object(self.hosts.clone(), self.app_key.clone(), w, object, options).await
+    /// Returns a [Download] handle that streams the object's data. The handle
+    /// implements [tokio::io::AsyncRead] — pipe it into any writer with
+    /// [tokio::io::copy] or read chunks directly. In-flight chunk recovery is
+    /// cancelled when the handle is dropped.
+    pub fn download(&self, object: &Object, options: DownloadOptions) -> Download {
+        Download::new(object, self.hosts.clone(), self.app_key.clone(), options)
     }
 
     /// Retrieves a list of hosts from the indexer matching the provided query
@@ -644,14 +643,15 @@ pub fn validate_recovery_phrase(phrase: &str) -> Result<(), SeedError> {
 #[cfg(test)]
 mod test {
     use crate::compat::run_local;
+    use crate::download::Download;
     use crate::hosts::QueueError;
     use bytes::{Bytes, BytesMut};
     use sia_core::rhp4::SECTOR_SIZE;
     use sia_core::signing::PrivateKey;
     use sia_core::types::v2::NetAddress;
     use std::io::Cursor;
+    use tokio::io::copy;
 
-    use crate::mock::MockRHP4Transport;
     use crate::time::Duration;
 
     use super::*;
@@ -677,7 +677,7 @@ mod test {
     cross_target_tests! {
         async fn test_upload_download_packed() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let hosts = Hosts::new(MockRHP4Transport::new());
+            let hosts = Hosts::new(Client::new());
             hosts.update(
                 (0..60)
                     .map(|_| Host {
@@ -734,26 +734,26 @@ mod test {
             assert_eq!(objects[1].size(), 13);
 
             let mut output = BytesMut::zeroed(13);
-            download_object(
+            let mut download = Download::new(
+                &objects[0],
                 hosts.clone(),
                 app_key.clone(),
-                &mut Cursor::new(&mut output[..]),
-                    &objects[0],
-                    DownloadOptions::default(),
-                )
+                DownloadOptions::default(),
+            );
+            copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
 
             assert_eq!(output.freeze(), input.clone());
 
             let mut output = BytesMut::zeroed(13);
-            download_object(
+            let mut download = Download::new(
+                &objects[1],
                 hosts.clone(),
                 app_key.clone(),
-                &mut Cursor::new(&mut output[..]),
-                    &objects[1],
-                    DownloadOptions::default(),
-                )
+                DownloadOptions::default(),
+            );
+            copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
 
@@ -762,7 +762,7 @@ mod test {
 
         async fn test_upload_download_packed_spanning() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let hosts = Hosts::new(MockRHP4Transport::new());
+            let hosts = Hosts::new(Client::new());
             hosts.update(
                 (0..60)
                     .map(|_| Host {
@@ -820,26 +820,26 @@ mod test {
             assert_eq!(objects[1].slabs()[1].length, 18 + 13);
 
             let mut output = BytesMut::zeroed(objects[0].size() as usize);
-            download_object(
+            let mut download = Download::new(
+                &objects[0],
                 hosts.clone(),
                 app_key.clone(),
-                &mut Cursor::new(&mut output[..]),
-                    &objects[0],
-                    DownloadOptions::default(),
-                )
+                DownloadOptions::default(),
+            );
+            copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
 
             assert_eq!(output.freeze(), small_input);
 
             let mut output = BytesMut::zeroed(objects[1].size() as usize);
-            download_object(
+            let mut download = Download::new(
+                &objects[1],
                 hosts.clone(),
                 app_key.clone(),
-                &mut Cursor::new(&mut output[..]),
-                    &objects[1],
-                    DownloadOptions::default(),
-                )
+                DownloadOptions::default(),
+            );
+            copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
 
@@ -848,7 +848,7 @@ mod test {
 
     async fn test_upload_download_packed_exact() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let hosts = Hosts::new(MockRHP4Transport::new());
+            let hosts = Hosts::new(Client::new());
             hosts.update(
                 (0..60)
                     .map(|_| Host {
@@ -890,13 +890,13 @@ mod test {
             assert_eq!(objects[0].slabs()[0].length, SLAB_SIZE as u32);
 
             let mut output = BytesMut::zeroed(objects[0].size() as usize);
-            download_object(
+            let mut download = Download::new(
+                &objects[0],
                 hosts.clone(),
                 app_key.clone(),
-                &mut Cursor::new(&mut output[..]),
-                    &objects[0],
-                    DownloadOptions::default(),
-                )
+                DownloadOptions::default(),
+            );
+            copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
 
@@ -904,73 +904,62 @@ mod test {
         }).await }
 
     async fn test_upload_download() { run_local(async {
-            let app_key = Arc::new(AppKey::import(random_seed()));
-            let hosts = Hosts::new(MockRHP4Transport::new());
-            hosts.update(
-                (0..60)
-                    .map(|_| Host {
-                        public_key: PrivateKey::from_seed(&random_seed()).public_key(),
-                        addresses: vec![NetAddress {
-                            protocol: sia_core::types::v2::Protocol::QUIC,
-                            address: "localhost:1234".to_string(),
-                        }],
-                        country_code: "US".to_string(),
-                        latitude: 0.0,
-                        longitude: 0.0,
-                        good_for_upload: true,
-                    })
-                    .collect(),
-                true,
-            );
+        let app_key = Arc::new(AppKey::import(random_seed()));
+        let hosts = Hosts::new(Client::new());
+        hosts.update(
+            (0..60)
+                .map(|_| Host {
+                    public_key: PrivateKey::from_seed(&random_seed()).public_key(),
+                    addresses: vec![NetAddress {
+                        protocol: sia_core::types::v2::Protocol::QUIC,
+                        address: "localhost:1234".to_string(),
+                    }],
+                    country_code: "US".to_string(),
+                    latitude: 0.0,
+                    longitude: 0.0,
+                    good_for_upload: true,
+                })
+                .collect(),
+            true,
+        );
 
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
+        let uploader = Uploader::new(hosts.clone(), app_key.clone());
+        let input: Bytes = Bytes::from("Hello, world!");
 
+        let object = uploader
+            .upload(Object::default(), Cursor::new(input.clone()), UploadOptions::default())
+            .await
+            .expect("upload to complete");
 
-            let input: Bytes = Bytes::from("Hello, world!");
+        assert_eq!(object.slabs().len(), 1);
+        assert_eq!(object.size(), 13);
 
-            let object = uploader
-                .upload(Object::default(), Cursor::new(input.clone()), UploadOptions::default())
-                .await
-                .expect("upload to complete");
+        let mut output = BytesMut::zeroed(object.size() as usize);
+        let mut download = Download::new(&object, hosts.clone(), app_key.clone(), DownloadOptions::default());
 
-            assert_eq!(object.slabs().len(), 1);
-            assert_eq!(object.size(), 13);
+        copy(&mut download, &mut Cursor::new(&mut output[..]))
+            .await
+            .expect("download to complete");
 
-            let mut output = BytesMut::zeroed(object.size() as usize);
-            download_object(
-                hosts.clone(),
-                app_key.clone(),
-                &mut Cursor::new(&mut output[..]),
-                    &object,
-                    DownloadOptions::default(),
-                )
-                .await
-                .expect("download to complete");
+        assert_eq!(output.freeze(), input.clone());
 
-            assert_eq!(output.freeze(), input.clone());
+        let range = 7..13;
+        let mut output = BytesMut::zeroed(range.end - range.start);
+        let mut download = Download::new(&object, hosts.clone(), app_key.clone(), DownloadOptions {
+            offset: range.start as u64,
+            length: Some((range.end - range.start) as u64),
+            ..Default::default()
+        });
+        copy(&mut download, &mut Cursor::new(&mut output[..]))
+            .await
+            .expect("download to complete");
 
-            let range = 7..13;
-            let mut output = BytesMut::zeroed(range.end - range.start);
-            download_object(
-                hosts.clone(),
-                app_key.clone(),
-                &mut Cursor::new(&mut output[..]),
-                    &object,
-                    DownloadOptions {
-                        offset: range.start as u64,
-                        length: Some((range.end - range.start) as u64),
-                        ..Default::default()
-                    },
-                )
-                .await
-                .expect("download to complete");
-
-            assert_eq!(output.freeze(), input.slice(range));
-        }).await }
+        assert_eq!(output.freeze(), input.slice(range));
+    }).await }
 
         async fn test_upload_append() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let hosts = Hosts::new(MockRHP4Transport::new());
+            let hosts = Hosts::new(Client::new());
             hosts.update(
                 (0..60)
                     .map(|_| Host {
@@ -1010,15 +999,15 @@ mod test {
 
             // download the full object and verify concatenation
             let mut output = BytesMut::zeroed(expected.len());
-            download_object(
+            let mut download = Download::new(
+                &object,
                 hosts.clone(),
                 app_key.clone(),
-                &mut Cursor::new(&mut output[..]),
-                &object,
                 DownloadOptions::default(),
-            )
-            .await
-            .expect("download to complete");
+            );
+            copy(&mut download, &mut Cursor::new(&mut output[..]))
+                .await
+                .expect("download to complete");
 
             assert_eq!(output.freeze(), expected);
         }).await }
@@ -1029,7 +1018,7 @@ mod test {
             const SEGMENT_SIZE: u64 = 64; // leaf size
 
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let hosts = Hosts::new(MockRHP4Transport::new());
+            let hosts = Hosts::new(Client::new());
             hosts.update(
                 (0..60)
                     .map(|_| Host {
@@ -1089,19 +1078,17 @@ mod test {
 
             for (offset, length) in cases {
                 let mut output = Vec::with_capacity(length as usize);
-                download_object(
+                let mut download = Download::new(
+                    &object,
                     hosts.clone(),
                     app_key.clone(),
-                    &mut output,
-                    &object,
                     DownloadOptions {
                         offset,
                         length: Some(length),
                         ..Default::default()
                     },
-                )
-                .await
-                .unwrap();
+                );
+                copy(&mut download, &mut output).await.unwrap();
 
                 let clamped_length = if offset >= data_size {
                     0
@@ -1121,7 +1108,7 @@ mod test {
 
     async fn test_download_slow_hosts() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let mock_transport = MockRHP4Transport::new();
+            let mock_transport = Client::new();
             let hosts = Hosts::new(mock_transport.clone());
 
             // Create 30 hosts and track their public keys
@@ -1164,13 +1151,13 @@ mod test {
             );
 
             let mut output = BytesMut::zeroed(object.size() as usize);
-            download_object(
+            let mut download = Download::new(
+                &object,
                 hosts.clone(),
                 app_key.clone(),
-                &mut Cursor::new(&mut output[..]),
-                    &object,
-                    DownloadOptions::default(),
-                )
+                DownloadOptions::default(),
+            );
+            copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
 
@@ -1179,7 +1166,7 @@ mod test {
 
     async fn test_upload_no_hosts() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let hosts = Hosts::new(MockRHP4Transport::new());
+            let hosts = Hosts::new(Client::new());
             let uploader = Uploader::new(hosts.clone(), app_key.clone());
 
             let input: Bytes = Bytes::from("Hello, world!");
@@ -1200,7 +1187,7 @@ mod test {
         /// This mirrors Go's TestUpload "slow" subtest.
     async fn test_upload_slow_host() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let mock_transport = MockRHP4Transport::new();
+            let mock_transport = Client::new();
             let hosts = Hosts::new(mock_transport.clone());
 
             // Create 30 hosts and track their public keys
@@ -1247,7 +1234,7 @@ mod test {
         // Upload should succeed even if all initial hosts are slow
     async fn test_upload_all_hosts_slow() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let mock_transport = MockRHP4Transport::new();
+            let mock_transport = Client::new();
             let hosts = Hosts::new(mock_transport.clone());
 
             // Create 30 hosts and track their public keys
@@ -1288,7 +1275,7 @@ mod test {
 
     async fn test_upload_not_enough_hosts_good_for_upload() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
-            let hosts = Hosts::new(MockRHP4Transport::new());
+            let hosts = Hosts::new(Client::new());
             // Create 30 hosts: 10 good for upload, 20 not good for upload
             let host_keys: Vec<_> = (0..30)
                 .map(|_| PrivateKey::from_seed(&random_seed()).public_key())

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -33,7 +33,7 @@
 //! sdk.pin_object(&object).await?;
 //!
 //! // Download
-//! let mut reader = sdk.download(&object, DownloadOptions::default());
+//! let mut reader = sdk.download(&object, DownloadOptions::default())?;
 //! tokio::io::copy(&mut reader, &mut writer).await?;
 //! ```
 //!
@@ -93,7 +93,6 @@ pub use builder::{
 pub use download::{Download, DownloadError, DownloadOptions};
 pub use encryption::EncryptionKey;
 pub use hosts::{QueueError, RPCError};
-pub use rhp4::Client as Transport;
 pub use slabs::{Object, ObjectEvent, PinnedSlab, SealedObject, SealedObjectError, Sector, Slab};
 pub use upload::{PackedUpload, UploadError, UploadOptions};
 
@@ -457,7 +456,11 @@ impl SDK {
     /// implements [tokio::io::AsyncRead] — pipe it into any writer with
     /// [tokio::io::copy] or read chunks directly. In-flight chunk recovery is
     /// cancelled when the handle is dropped.
-    pub fn download(&self, object: &Object, options: DownloadOptions) -> Download {
+    pub fn download(
+        &self,
+        object: &Object,
+        options: DownloadOptions,
+    ) -> Result<Download, DownloadError> {
         Download::new(object, self.hosts.clone(), self.app_key.clone(), options)
     }
 
@@ -739,7 +742,8 @@ mod test {
                 hosts.clone(),
                 app_key.clone(),
                 DownloadOptions::default(),
-            );
+            )
+            .unwrap();
             copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
@@ -752,7 +756,8 @@ mod test {
                 hosts.clone(),
                 app_key.clone(),
                 DownloadOptions::default(),
-            );
+            )
+            .unwrap();
             copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
@@ -825,7 +830,8 @@ mod test {
                 hosts.clone(),
                 app_key.clone(),
                 DownloadOptions::default(),
-            );
+            )
+            .unwrap();
             copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
@@ -838,7 +844,8 @@ mod test {
                 hosts.clone(),
                 app_key.clone(),
                 DownloadOptions::default(),
-            );
+            )
+            .unwrap();
             copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
@@ -895,7 +902,8 @@ mod test {
                 hosts.clone(),
                 app_key.clone(),
                 DownloadOptions::default(),
-            );
+            )
+            .unwrap();
             copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
@@ -935,7 +943,7 @@ mod test {
         assert_eq!(object.size(), 13);
 
         let mut output = BytesMut::zeroed(object.size() as usize);
-        let mut download = Download::new(&object, hosts.clone(), app_key.clone(), DownloadOptions::default());
+        let mut download = Download::new(&object, hosts.clone(), app_key.clone(), DownloadOptions::default()).unwrap();
 
         copy(&mut download, &mut Cursor::new(&mut output[..]))
             .await
@@ -949,7 +957,7 @@ mod test {
             offset: range.start as u64,
             length: Some((range.end - range.start) as u64),
             ..Default::default()
-        });
+        }).unwrap();
         copy(&mut download, &mut Cursor::new(&mut output[..]))
             .await
             .expect("download to complete");
@@ -1004,7 +1012,8 @@ mod test {
                 hosts.clone(),
                 app_key.clone(),
                 DownloadOptions::default(),
-            );
+            )
+            .unwrap();
             copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");
@@ -1087,7 +1096,8 @@ mod test {
                         length: Some(length),
                         ..Default::default()
                     },
-                );
+                )
+                .unwrap();
                 copy(&mut download, &mut output).await.unwrap();
 
                 let clamped_length = if offset >= data_size {
@@ -1156,7 +1166,8 @@ mod test {
                 hosts.clone(),
                 app_key.clone(),
                 DownloadOptions::default(),
-            );
+            )
+            .unwrap();
             copy(&mut download, &mut Cursor::new(&mut output[..]))
                 .await
                 .expect("download to complete");

--- a/sia_storage/src/mock.rs
+++ b/sia_storage/src/mock.rs
@@ -1,139 +1,17 @@
-use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
-use crate::AppKey;
-use bytes::Bytes;
-use chrono::Utc;
-use sia_core::rhp4::HostPrices;
-use sia_core::signing::{PrivateKey, PublicKey, Signature};
-use sia_core::types::{Currency, Hash256};
-use tokio::io::{AsyncRead, AsyncWrite};
+use sia_core::signing::PublicKey;
+use tokio::io::AsyncRead;
 
-use crate::download::download_object;
+use crate::download::Download;
 use crate::hosts::Hosts;
-use crate::rhp4::{Error as RHP4Error, HostEndpoint, Transport};
-use crate::time::{Duration, sleep};
+use crate::rhp4::Client;
+use crate::time::Duration;
 use crate::upload::Uploader;
-use crate::{DownloadError, DownloadOptions, Object, PackedUpload, UploadError, UploadOptions};
-
-#[derive(Clone)]
-pub(crate) struct MockRHP4Transport {
-    sectors: Arc<RwLock<HashMap<PublicKey, HashMap<Hash256, Bytes>>>>,
-    slow_hosts: Arc<RwLock<HashSet<PublicKey>>>,
-    slow_delay: Arc<RwLock<Duration>>,
-}
-
-impl MockRHP4Transport {
-    pub fn new() -> Self {
-        Self {
-            sectors: Arc::new(RwLock::new(HashMap::new())),
-            slow_hosts: Arc::new(RwLock::new(HashSet::new())),
-            slow_delay: Arc::new(RwLock::new(Duration::ZERO)),
-        }
-    }
-
-    pub fn clear(&self) {
-        self.sectors.write().unwrap().clear();
-    }
-
-    /// Sets the given hosts as "slow" - they will sleep for the specified duration
-    /// before completing any write_sector or read_sector operation.
-    pub fn set_slow_hosts(&self, hosts: impl IntoIterator<Item = PublicKey>, delay: Duration) {
-        let mut slow = self.slow_hosts.write().unwrap();
-        slow.clear();
-        slow.extend(hosts);
-        *self.slow_delay.write().unwrap() = delay;
-    }
-
-    /// Clears all slow host settings.
-    pub fn reset_slow_hosts(&self) {
-        self.slow_hosts.write().unwrap().clear();
-        *self.slow_delay.write().unwrap() = Duration::ZERO;
-    }
-}
-
-impl Transport for MockRHP4Transport {
-    async fn host_prices(&self, _: &HostEndpoint) -> Result<HostPrices, RHP4Error> {
-        Ok(HostPrices {
-            contract_price: Currency::zero(),
-            collateral: Currency::zero(),
-            ingress_price: Currency::zero(),
-            egress_price: Currency::zero(),
-            storage_price: Currency::zero(),
-            free_sector_price: Currency::zero(),
-            tip_height: 1,
-            signature: Signature::default(),
-            valid_until: Utc::now() + chrono::Duration::days(1),
-        })
-    }
-
-    async fn write_sector(
-        &self,
-        host: &HostEndpoint,
-        _: HostPrices,
-        _: &PrivateKey,
-        sector: Bytes,
-    ) -> Result<Hash256, RHP4Error> {
-        // Check if this host is configured as slow
-        let slow_delay = {
-            let slow_hosts = self.slow_hosts.read().unwrap();
-            if slow_hosts.contains(&host.public_key) {
-                Some(*self.slow_delay.read().unwrap())
-            } else {
-                None
-            }
-        };
-        if let Some(delay) = slow_delay {
-            sleep(delay).await;
-        }
-
-        sleep(Duration::from_millis(3)).await; // simulate network latency ~ 10Gbps
-        let sector_root = sia_core::rhp4::sector_root(&sector);
-        let mut sectors = self.sectors.write().unwrap();
-        let host_sectors = sectors.entry(host.public_key).or_default();
-        host_sectors.insert(sector_root, sector);
-        Ok(sector_root)
-    }
-
-    async fn read_sector(
-        &self,
-        host: &HostEndpoint,
-        _: HostPrices,
-        _: &PrivateKey,
-        root: Hash256,
-        offset: usize,
-        length: usize,
-    ) -> Result<Bytes, RHP4Error> {
-        // Check if this host is configured as slow
-        let slow_delay = {
-            let slow_hosts = self.slow_hosts.read().unwrap();
-            if slow_hosts.contains(&host.public_key) {
-                Some(*self.slow_delay.read().unwrap())
-            } else {
-                None
-            }
-        };
-        if let Some(delay) = slow_delay {
-            sleep(delay).await;
-        }
-
-        let sector = {
-            let sectors = self.sectors.read().unwrap();
-            let host_sectors = sectors
-                .get(&host.public_key)
-                .ok_or_else(|| RHP4Error::Transport("host not found".to_string()))?;
-            let sector = host_sectors
-                .get(&root)
-                .ok_or_else(|| RHP4Error::Transport("sector not found".to_string()))?;
-            Bytes::copy_from_slice(&sector[offset..offset + length])
-        };
-        sleep(Duration::from_nanos(sector.len() as u64 * 8 / 10)).await; // simulate network latency ~ 10Gbps
-        Ok(sector)
-    }
-}
+use crate::{AppKey, DownloadOptions, Object, PackedUpload, UploadError, UploadOptions};
 
 pub struct MockUploader {
-    uploader: Uploader<MockRHP4Transport>,
+    uploader: Uploader<Client>,
 }
 
 impl MockUploader {
@@ -167,35 +45,32 @@ impl MockDownloader {
         Self { hosts, app_key }
     }
 
-    pub async fn download<W: AsyncWrite + Send + Sync + Unpin>(
+    pub fn download(
         &self,
-        w: &mut W,
         object: &Object,
         options: DownloadOptions,
-    ) -> Result<(), DownloadError> {
-        download_object(
+    ) -> impl tokio::io::AsyncRead + Unpin {
+        Download::new(
+            object,
             self.hosts.inner.clone(),
             self.app_key.clone(),
-            w,
-            object,
             options,
         )
-        .await
     }
 }
 
 #[derive(Clone)]
 pub struct MockHosts {
-    transport: MockRHP4Transport,
-    inner: Hosts<MockRHP4Transport>,
+    transport: Client,
+    pub(crate) inner: Hosts<Client>,
 }
 
 impl MockHosts {
     pub fn new() -> Self {
-        let transport = MockRHP4Transport::new();
+        let transport = Client::new();
         let hosts = Hosts::new(transport.clone());
         Self {
-            transport: transport,
+            transport,
             inner: hosts,
         }
     }
@@ -217,5 +92,11 @@ impl MockHosts {
     /// Clears all slow host settings.
     pub fn reset_slow_hosts(&self) {
         self.transport.reset_slow_hosts();
+    }
+}
+
+impl Default for MockHosts {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/sia_storage/src/mock.rs
+++ b/sia_storage/src/mock.rs
@@ -8,7 +8,9 @@ use crate::hosts::Hosts;
 use crate::rhp4::Client;
 use crate::time::Duration;
 use crate::upload::Uploader;
-use crate::{AppKey, DownloadError, DownloadOptions, Object, PackedUpload, UploadError, UploadOptions};
+use crate::{
+    AppKey, DownloadError, DownloadOptions, Object, PackedUpload, UploadError, UploadOptions,
+};
 
 pub struct MockUploader {
     uploader: Uploader<Client>,

--- a/sia_storage/src/mock.rs
+++ b/sia_storage/src/mock.rs
@@ -8,7 +8,7 @@ use crate::hosts::Hosts;
 use crate::rhp4::Client;
 use crate::time::Duration;
 use crate::upload::Uploader;
-use crate::{AppKey, DownloadOptions, Object, PackedUpload, UploadError, UploadOptions};
+use crate::{AppKey, DownloadError, DownloadOptions, Object, PackedUpload, UploadError, UploadOptions};
 
 pub struct MockUploader {
     uploader: Uploader<Client>,
@@ -49,7 +49,7 @@ impl MockDownloader {
         &self,
         object: &Object,
         options: DownloadOptions,
-    ) -> impl tokio::io::AsyncRead + Unpin {
+    ) -> Result<impl tokio::io::AsyncRead + Unpin, DownloadError> {
         Download::new(
             object,
             self.hosts.inner.clone(),

--- a/sia_storage/src/rhp4.rs
+++ b/sia_storage/src/rhp4.rs
@@ -9,17 +9,23 @@ use thiserror::Error;
 
 use crate::time::Elapsed;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(test, feature = "mock", target_arch = "wasm32")))]
 mod siamux;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(test, feature = "mock", target_arch = "wasm32")))]
 pub use siamux::Client;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(not(test), not(feature = "mock"), target_arch = "wasm32"))]
 mod web_transport;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(not(test), not(feature = "mock"), target_arch = "wasm32"))]
 pub use web_transport::Client;
+
+#[cfg(any(test, feature = "mock"))]
+mod mock;
+
+#[cfg(any(test, feature = "mock"))]
+pub use mock::Client;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -47,14 +53,13 @@ pub enum Error {
 
 /// A host endpoint contains the information needed to connect to a host.
 // dead code until WebTransport client is implemented
-#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) struct HostEndpoint {
     pub public_key: PublicKey,
     pub addresses: Vec<NetAddress>,
 }
 
 /// Trait defining the operations that can be performed on a host.
-pub(crate) trait Transport: Clone + MaybeSendSync + 'static {
+pub(crate) trait Transport: Clone + Unpin + MaybeSendSync + 'static {
     fn host_prices(
         &self,
         host: &HostEndpoint,

--- a/sia_storage/src/rhp4/mock.rs
+++ b/sia_storage/src/rhp4/mock.rs
@@ -1,0 +1,167 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock};
+
+use bytes::Bytes;
+use chrono::Utc;
+use sia_core::rhp4::HostPrices;
+use sia_core::signing::{PrivateKey, PublicKey, Signature};
+use sia_core::types::{Currency, Hash256};
+
+use super::{Error as RHP4Error, HostEndpoint, Transport};
+use crate::time::{Duration, sleep};
+
+#[derive(Clone)]
+pub struct Client {
+    sectors: Arc<RwLock<HashMap<PublicKey, HashMap<Hash256, Bytes>>>>,
+    slow_hosts: Arc<RwLock<HashSet<PublicKey>>>,
+    slow_delay: Arc<RwLock<Duration>>,
+    /// Per-sector read delay. After each read, the delay is halved. Used to
+    /// simulate out-of-order chunk completion.
+    read_delays: Arc<RwLock<HashMap<Hash256, Duration>>>,
+    initial_read_delay: Arc<RwLock<Option<Duration>>>,
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Client {
+    pub fn new() -> Self {
+        Self {
+            sectors: Arc::new(RwLock::new(HashMap::new())),
+            slow_hosts: Arc::new(RwLock::new(HashSet::new())),
+            slow_delay: Arc::new(RwLock::new(Duration::ZERO)),
+            read_delays: Arc::new(RwLock::new(HashMap::new())),
+            initial_read_delay: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Sets an initial per-sector read delay. After each read, the per-sector
+    /// delay is halved. Used to simulate out-of-order chunk completion.
+    /// Sectors written after this is set will start with `delay`.
+    pub fn set_initial_read_delay(&self, delay: Duration) {
+        *self.initial_read_delay.write().unwrap() = Some(delay);
+    }
+
+    pub fn clear(&self) {
+        self.sectors.write().unwrap().clear();
+    }
+
+    /// Sets the given hosts as "slow" - they will sleep for the specified duration
+    /// before completing any write_sector or read_sector operation.
+    pub fn set_slow_hosts(&self, hosts: impl IntoIterator<Item = PublicKey>, delay: Duration) {
+        let mut slow = self.slow_hosts.write().unwrap();
+        slow.clear();
+        slow.extend(hosts);
+        *self.slow_delay.write().unwrap() = delay;
+    }
+
+    /// Clears all slow host settings.
+    pub fn reset_slow_hosts(&self) {
+        self.slow_hosts.write().unwrap().clear();
+        *self.slow_delay.write().unwrap() = Duration::ZERO;
+    }
+}
+
+impl Transport for Client {
+    async fn host_prices(&self, _: &HostEndpoint) -> Result<HostPrices, RHP4Error> {
+        Ok(HostPrices {
+            contract_price: Currency::zero(),
+            collateral: Currency::zero(),
+            ingress_price: Currency::zero(),
+            egress_price: Currency::zero(),
+            storage_price: Currency::zero(),
+            free_sector_price: Currency::zero(),
+            tip_height: 1,
+            signature: Signature::default(),
+            valid_until: Utc::now() + chrono::Duration::days(1),
+        })
+    }
+
+    async fn write_sector(
+        &self,
+        host: &HostEndpoint,
+        _: HostPrices,
+        _: &PrivateKey,
+        sector: Bytes,
+    ) -> Result<Hash256, RHP4Error> {
+        if host.addresses.is_empty() {
+            return Err(RHP4Error::Transport("host has no addresses".to_string()));
+        }
+        // Check if this host is configured as slow
+        let slow_delay = {
+            let slow_hosts = self.slow_hosts.read().unwrap();
+            if slow_hosts.contains(&host.public_key) {
+                Some(*self.slow_delay.read().unwrap())
+            } else {
+                None
+            }
+        };
+        if let Some(delay) = slow_delay {
+            sleep(delay).await;
+        }
+
+        sleep(Duration::from_millis(3)).await; // simulate network latency ~ 10Gbps
+        let sector_root = sia_core::rhp4::sector_root(&sector);
+        let mut sectors = self.sectors.write().unwrap();
+        let host_sectors = sectors.entry(host.public_key).or_default();
+        host_sectors.insert(sector_root, sector);
+        if let Some(delay) = *self.initial_read_delay.read().unwrap() {
+            self.read_delays.write().unwrap().insert(sector_root, delay);
+        }
+        Ok(sector_root)
+    }
+
+    async fn read_sector(
+        &self,
+        host: &HostEndpoint,
+        _: HostPrices,
+        _: &PrivateKey,
+        root: Hash256,
+        offset: usize,
+        length: usize,
+    ) -> Result<Bytes, RHP4Error> {
+        if host.addresses.is_empty() {
+            return Err(RHP4Error::Transport("host has no addresses".to_string()));
+        }
+        // Check if this host is configured as slow
+        let slow_delay = {
+            let slow_hosts = self.slow_hosts.read().unwrap();
+            if slow_hosts.contains(&host.public_key) {
+                Some(*self.slow_delay.read().unwrap())
+            } else {
+                None
+            }
+        };
+        if let Some(delay) = slow_delay {
+            sleep(delay).await;
+        }
+
+        // per-sector decreasing delay (used to simulate out-of-order chunk completion)
+        let read_delay = {
+            let mut delays = self.read_delays.write().unwrap();
+            delays.get(&root).copied().map(|delay| {
+                delays.insert(root, delay / 2);
+                delay
+            })
+        };
+        if let Some(delay) = read_delay {
+            sleep(delay).await;
+        }
+
+        let sector = {
+            let sectors = self.sectors.read().unwrap();
+            let host_sectors = sectors
+                .get(&host.public_key)
+                .ok_or_else(|| RHP4Error::Transport("host not found".to_string()))?;
+            let sector = host_sectors
+                .get(&root)
+                .ok_or_else(|| RHP4Error::Transport("sector not found".to_string()))?;
+            Bytes::copy_from_slice(&sector[offset..offset + length])
+        };
+        sleep(Duration::from_nanos(sector.len() as u64 * 8 / 10)).await; // simulate network latency ~ 10Gbps
+        Ok(sector)
+    }
+}

--- a/sia_storage/src/slabs.rs
+++ b/sia_storage/src/slabs.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use sia_core::rhp4::SECTOR_SIZE;
 
 use crate::AppKey;
-use crate::encryption::{CipherReader, CipherWriter, EncryptionKey};
+use crate::encryption::{Chacha20Cipher, CipherReader, EncryptionKey};
 use serde_with::base64::Base64;
 use serde_with::{DefaultOnNull, serde_as};
 use sia_core::blake2::{Blake2b256, Digest};
@@ -11,7 +11,7 @@ use sia_core::encoding::{self, SiaDecodable, SiaDecode, SiaEncodable, SiaEncode}
 use sia_core::signing::{PublicKey, Signature};
 use sia_core::types::Hash256;
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::AsyncRead;
 
 use crate::object_encryption::{
     DecryptError, open_data_key, open_metadata, open_metadata_key, seal_data_key, seal_metadata,
@@ -381,9 +381,9 @@ impl Object {
         CipherReader::new(r, self.data_key.clone(), offset)
     }
 
-    /// Returns a writer that encrypts data on-the-fly using the object's encryption key.
-    pub(crate) fn writer<W: AsyncWrite + Unpin>(&self, w: W, offset: u64) -> CipherWriter<W> {
-        CipherWriter::new(w, self.data_key.clone(), offset)
+    /// Returns a cipher that can be used to encrypt or decrypt data using the object's encryption key.
+    pub(crate) fn cipher(&self, offset: u64) -> Chacha20Cipher {
+        Chacha20Cipher::new(self.data_key.clone(), offset)
     }
 
     /// Returns the object's encryption key.

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -567,7 +567,7 @@ impl<T: Transport> Uploader<T> {
         let new_slabs =
             Self::upload_slabs(self.hosts.clone(), self.app_key.clone(), r, options).await?;
         let slabs = object.slabs_mut();
-        slabs.extend(new_slabs.into_iter());
+        slabs.extend(new_slabs);
         Ok(object)
     }
 

--- a/sia_storage_ffi/src/io.rs
+++ b/sia_storage_ffi/src/io.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll, ready};
 
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncRead, ReadBuf};
 
 type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 
@@ -111,80 +111,11 @@ impl AsyncRead for FFIReader {
     }
 }
 
-/// A foreign writer that can be used to transfer data across FFI boundaries.
-/// The data may be sent in multiple chunks. The implementation should handle
-/// buffering and writing the data as it is received.
-#[uniffi::export(with_foreign)]
-#[async_trait::async_trait]
-pub trait Writer: Send + Sync {
-    async fn write(&self, data: Vec<u8>) -> Result<(), IOError>;
-}
-
-/// Adapts a foreign Writer into an AsyncWrite by polling the write future directly.
-pub(crate) struct FFIWriter {
-    writer: Arc<dyn Writer>,
-    pending: Option<BoxFuture<Result<(), IOError>>>,
-}
-
-impl FFIWriter {
-    pub fn new(writer: Arc<dyn Writer>) -> Self {
-        Self {
-            writer,
-            pending: None,
-        }
-    }
-}
-
-impl AsyncWrite for FFIWriter {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        let this = self.get_mut();
-
-        // finish pending writes first
-        if let Some(fut) = this.pending.as_mut() {
-            match ready!(fut.as_mut().poll(cx)) {
-                Ok(()) => this.pending = None,
-                Err(e) => {
-                    this.pending = None;
-                    return Poll::Ready(Err(e.into()));
-                }
-            }
-        }
-
-        let n = buf.len();
-        let writer = this.writer.clone();
-        let data = buf.to_vec();
-        this.pending = Some(Box::pin(async move { writer.write(data).await }));
-        Poll::Ready(Ok(n))
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let this = self.get_mut();
-        if let Some(fut) = this.pending.as_mut() {
-            match ready!(fut.as_mut().poll(cx)) {
-                Ok(()) => this.pending = None,
-                Err(e) => {
-                    this.pending = None;
-                    return Poll::Ready(Err(e.into()));
-                }
-            }
-        }
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.poll_flush(cx)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::Mutex;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::AsyncReadExt;
 
     const CHUNK_SIZE: usize = 64;
 
@@ -213,31 +144,6 @@ mod tests {
         }
     }
 
-    #[derive(Debug)]
-    struct VecWriter {
-        data: Mutex<Vec<u8>>,
-    }
-
-    impl VecWriter {
-        fn new() -> Self {
-            Self {
-                data: Mutex::new(Vec::new()),
-            }
-        }
-
-        fn into_inner(self) -> Vec<u8> {
-            self.data.into_inner().unwrap()
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl Writer for VecWriter {
-        async fn write(&self, data: Vec<u8>) -> Result<(), IOError> {
-            self.data.lock().unwrap().extend_from_slice(&data);
-            Ok(())
-        }
-    }
-
     #[tokio::test]
     async fn test_ffi_reader() {
         let input: Vec<u8> = (0..=255).cycle().take(CHUNK_SIZE * 5 + 17).collect();
@@ -246,49 +152,6 @@ mod tests {
 
         let mut output = Vec::new();
         r.read_to_end(&mut output).await.unwrap();
-        assert_eq!(output, input);
-    }
-
-    #[tokio::test]
-    async fn test_ffi_writer() {
-        let input: Vec<u8> = (0..=255).cycle().take(CHUNK_SIZE * 5 + 17).collect();
-        let writer = Arc::new(VecWriter::new());
-        let mut w = FFIWriter::new(writer.clone());
-
-        for chunk in input.chunks(CHUNK_SIZE) {
-            w.write_all(chunk).await.unwrap();
-        }
-        w.shutdown().await.unwrap();
-        drop(w);
-
-        let output = Arc::try_unwrap(writer).unwrap().into_inner();
-        assert_eq!(output, input);
-    }
-
-    #[tokio::test]
-    async fn test_ffi_reader_writer_roundtrip() {
-        let input: Vec<u8> = (0..=255).cycle().take(CHUNK_SIZE * 10).collect();
-
-        // read the input through FFIReader
-        let reader = Arc::new(VecReader::new(input.clone()));
-        let mut r = FFIReader::new(reader);
-
-        // pipe it through FFIWriter
-        let writer = Arc::new(VecWriter::new());
-        let mut w = FFIWriter::new(writer.clone());
-
-        let mut buf = vec![0u8; CHUNK_SIZE];
-        loop {
-            let n = r.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break;
-            }
-            w.write_all(&buf[..n]).await.unwrap();
-        }
-        w.shutdown().await.unwrap();
-        drop(w);
-
-        let output = Arc::try_unwrap(writer).unwrap().into_inner();
         assert_eq!(output, input);
     }
 }

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -103,6 +103,9 @@ pub enum DownloadError {
 
     #[error("task error: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+
+    #[error("cancelled")]
+    Cancelled,
 }
 
 /// Metadata about an application connecting to the indexer.
@@ -720,7 +723,7 @@ impl Download {
         let cancel = self.cancel.clone();
         spawn(async move {
             tokio::select! {
-                _ = cancel.cancelled() => Ok(Vec::new()),
+                _ = cancel.cancelled() => Err(DownloadError::Cancelled),
                 result = async {
                     let mut guard = inner.lock().await;
                     let Some(reader) = guard.as_mut() else {

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -740,7 +740,7 @@ impl Download {
 
     /// Cancels the download and aborts any in-flight chunk recovery tasks.
     /// Interrupts an in-flight [Download::read] immediately. Subsequent reads
-    /// return an empty Vec.
+    /// return [DownloadError::Cancelled].
     pub async fn close(&self) {
         self.cancel.cancel();
         let inner = self.inner.clone();

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -1,7 +1,6 @@
 uniffi::setup_scaffolding!();
 
 use base64::prelude::*;
-use log::debug;
 use sia_core::encoding;
 use sia_core::rhp4::SECTOR_SIZE;
 use sia_core::signing::{PublicKey, Signature};
@@ -12,7 +11,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::SystemTime;
 use thiserror::Error;
-use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::io::AsyncReadExt;
 use tokio::runtime::{self, Runtime};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::task::AbortOnDropHandle;
@@ -704,6 +703,39 @@ impl PackedUpload {
     }
 }
 
+/// A download handle. Call [Download::read] repeatedly to receive chunks of
+/// decoded data. An empty chunk signals end of stream. All in-flight work is
+/// cancelled when the handle is dropped or [Download::close] is called.
+#[derive(uniffi::Object)]
+pub struct Download {
+    inner: tokio::sync::Mutex<Option<sia_storage::Download>>,
+}
+
+#[uniffi::export]
+impl Download {
+    /// Reads the next chunk of decoded data. Returns an empty Vec on EOF
+    /// or after [Download::close] has been called.
+    pub async fn read(&self) -> Result<Vec<u8>, DownloadError> {
+        const CHUNK_SIZE: usize = 1 << 19; // 512 KiB
+        let mut guard = self.inner.lock().await;
+        let Some(reader) = guard.as_mut() else {
+            return Ok(Vec::new());
+        };
+        let mut buf = vec![0u8; CHUNK_SIZE];
+        let n = AsyncReadExt::read(reader, &mut buf)
+            .await
+            .map_err(sia_storage::DownloadError::from)?;
+        buf.truncate(n);
+        Ok(buf)
+    }
+
+    /// Cancels the download and aborts any in-flight chunk recovery tasks.
+    /// Subsequent reads return an empty Vec.
+    pub async fn close(&self) {
+        self.inner.lock().await.take();
+    }
+}
+
 /// Provides options for an upload operation.
 #[derive(uniffi::Record)]
 pub struct UploadOptions {
@@ -881,34 +913,19 @@ impl SDK {
     }
 
     /// Initiates a download of the data referenced by the object, starting at `offset` and reading `length` bytes.
-    pub async fn download(
-        &self,
-        w: Arc<dyn Writer>,
-        object: Arc<PinnedObject>,
-        options: DownloadOptions,
-    ) -> Result<(), DownloadError> {
-        const CHUNK_SIZE: usize = 1 << 19; // 512KiB
-        let object = object.object();
-        let sdk = self.inner.clone();
-        let w = FFIWriter::new(w);
-        let mut w = BufWriter::with_capacity(CHUNK_SIZE, w);
-        spawn(async move {
-            sdk.download(
-                &mut w,
-                &object,
-                sia_storage::DownloadOptions {
-                    offset: options.offset,
-                    length: options.length,
-                    max_inflight: options.max_inflight as usize,
-                },
-            )
-            .await?;
-            if let Err(e) = w.shutdown().await {
-                debug!("error shutting down writer: {}", e);
-            }
-            Ok(())
-        })
-        .await?
+    /// Returns a [Download] handle that yields chunks via [Download::read].
+    pub fn download(&self, object: Arc<PinnedObject>, options: DownloadOptions) -> Download {
+        let r = self.inner.download(
+            &object.object(),
+            sia_storage::DownloadOptions {
+                offset: options.offset,
+                length: options.length,
+                max_inflight: options.max_inflight as usize,
+            },
+        );
+        Download {
+            inner: tokio::sync::Mutex::new(Some(r)),
+        }
     }
 
     /// Returns a list of all usable hosts.

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -11,7 +11,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::SystemTime;
 use thiserror::Error;
-use tokio::io::AsyncReadExt;
 use tokio::runtime::{self, Runtime};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::task::AbortOnDropHandle;
@@ -704,35 +703,46 @@ impl PackedUpload {
 }
 
 /// A download handle. Call [Download::read] repeatedly to receive chunks of
-/// decoded data. An empty chunk signals end of stream. All in-flight work is
+/// decoded data. An empty Vec signals end of stream. All in-flight work is
 /// cancelled when the handle is dropped or [Download::close] is called.
 #[derive(uniffi::Object)]
 pub struct Download {
-    inner: tokio::sync::Mutex<Option<sia_storage::Download>>,
+    inner: Arc<tokio::sync::Mutex<Option<sia_storage::Download>>>,
+    cancel: tokio_util::sync::CancellationToken,
 }
 
 #[uniffi::export]
 impl Download {
-    /// Reads the next chunk of decoded data. Returns an empty Vec on EOF
-    /// or after [Download::close] has been called.
+    /// Reads the next chunk of decoded data. Returns an empty Vec on EOF or
+    /// after [Download::close] has been called.
     pub async fn read(&self) -> Result<Vec<u8>, DownloadError> {
-        const CHUNK_SIZE: usize = 1 << 19; // 512 KiB
-        let mut guard = self.inner.lock().await;
-        let Some(reader) = guard.as_mut() else {
-            return Ok(Vec::new());
-        };
-        let mut buf = vec![0u8; CHUNK_SIZE];
-        let n = AsyncReadExt::read(reader, &mut buf)
-            .await
-            .map_err(sia_storage::DownloadError::from)?;
-        buf.truncate(n);
-        Ok(buf)
+        let inner = self.inner.clone();
+        let cancel = self.cancel.clone();
+        spawn(async move {
+            tokio::select! {
+                _ = cancel.cancelled() => Ok(Vec::new()),
+                result = async {
+                    let mut guard = inner.lock().await;
+                    let Some(reader) = guard.as_mut() else {
+                        return Ok(Vec::new());
+                    };
+                    Ok::<_, DownloadError>(reader.read_chunk().await?)
+                } => result,
+            }
+        })
+        .await?
     }
 
     /// Cancels the download and aborts any in-flight chunk recovery tasks.
-    /// Subsequent reads return an empty Vec.
+    /// Interrupts an in-flight [Download::read] immediately. Subsequent reads
+    /// return an empty Vec.
     pub async fn close(&self) {
-        self.inner.lock().await.take();
+        self.cancel.cancel();
+        let inner = self.inner.clone();
+        let _ = spawn(async move {
+            inner.lock().await.take();
+        })
+        .await;
     }
 }
 
@@ -914,18 +924,26 @@ impl SDK {
 
     /// Initiates a download of the data referenced by the object, starting at `offset` and reading `length` bytes.
     /// Returns a [Download] handle that yields chunks via [Download::read].
-    pub fn download(&self, object: Arc<PinnedObject>, options: DownloadOptions) -> Download {
-        let r = self.inner.download(
+    pub fn download(
+        &self,
+        object: Arc<PinnedObject>,
+        options: DownloadOptions,
+    ) -> Result<Download, DownloadError> {
+        // Enter the runtime so Download::new's spawned recovery tasks have a
+        // reactor in scope.
+        let _guard = RUNTIME.handle().enter();
+        let reader = self.inner.download(
             &object.object(),
             sia_storage::DownloadOptions {
                 offset: options.offset,
                 length: options.length,
                 max_inflight: options.max_inflight as usize,
             },
-        );
-        Download {
-            inner: tokio::sync::Mutex::new(Some(r)),
-        }
+        )?;
+        Ok(Download {
+            inner: Arc::new(tokio::sync::Mutex::new(Some(reader))),
+            cancel: tokio_util::sync::CancellationToken::new(),
+        })
     }
 
     /// Returns a list of all usable hosts.

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -716,8 +716,10 @@ pub struct Download {
 
 #[uniffi::export]
 impl Download {
-    /// Reads the next chunk of decoded data. Returns an empty Vec on EOF or
-    /// after [Download::close] has been called.
+    /// Reads the next chunk of decoded data.
+    ///
+    /// # Returns
+    /// An empty Vec on EOF or [DownloadError::Cancelled] if the download has been cancelled. Otherwise, returns a chunk of decoded data.
     pub async fn read(&self) -> Result<Vec<u8>, DownloadError> {
         let inner = self.inner.clone();
         let cancel = self.cancel.clone();


### PR DESCRIPTION
Changes download to return a reader instead of taking a writer to be more idiomatic and reduce copying in FFI libs.