### PR TITLE
Replace callbacks

### DIFF
--- a/.changeset/replaced_uploaddownload_progress_channels_with_callbacks.md
+++ b/.changeset/replaced_uploaddownload_progress_channels_with_callbacks.md
@@ -1,0 +1,8 @@
+---
+sia_storage_wasm: major
+sia_storage: major
+sia_storage_ffi: major
+sia_storage_napi: major
+---
+
+# Replaced upload/download progress channels with more detailed callbacks.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,12 +44,36 @@ jobs:
         run: cargo build --benches --features=mock
       - name: Test (native)
         run: cargo test --all-features
+
+  test-wasm-chrome:
+    runs-on: tenki-standard-medium-4c-8g
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Environment
+        run: |
+          rustup update stable
+          rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        shell: bash
+        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | bash
       - name: Test (wasm - sia_storage - chrome)
         # --lib skips compiling the native-only benchmark example
         run: cd sia_storage && wasm-pack test --release --headless --chrome -- --lib
         env:
           RUSTFLAGS: '--cfg=web_sys_unstable_apis'
           WASM_BINDGEN_TEST_TIMEOUT: '300'
+
+  test-wasm-firefox:
+    runs-on: tenki-standard-medium-4c-8g
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Environment
+        run: |
+          rustup update stable
+          rustup target add wasm32-unknown-unknown
+      - name: Install wasm-pack
+        shell: bash
+        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | bash
       - name: Install geckodriver
         run: curl -sL https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz | tar xz -C /usr/local/bin
       - name: Test (wasm - sia_storage - firefox)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: tenki-standard-autoscale
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@v5
       - name: Setup Go

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: tenki-standard-medium-4c-8g

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   prepare-release:
     if: "!contains(github.event.head_commit.message, 'chore: prepare releases')" # Skip merges from releases
-    runs-on: tenki-standard-autoscale
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release:
     if: github.head_ref == 'release' && github.event.pull_request.merged == true
-    runs-on: tenki-standard-autoscale
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@v5
         with:

--- a/sia_storage/src/builder.rs
+++ b/sia_storage/src/builder.rs
@@ -97,7 +97,7 @@ impl Builder<DisconnectedState> {
     }
 
     /// Attempts to connect using the provided app key.
-    /// If the app key is valid, returns Some([SDK]), otherwise returns None.
+    /// If the app key is valid, returns Some([Sdk]), otherwise returns None.
     ///
     /// If you receive None, call [Builder::request_connection] to request a new connection.
     ///

--- a/sia_storage/src/builder.rs
+++ b/sia_storage/src/builder.rs
@@ -13,7 +13,7 @@ use url::Url;
 use crate::app_client::{self, Client};
 use crate::object_encryption::derive;
 use crate::time::Duration;
-use crate::{AppID, AppKey, AppMetadata, SDK};
+use crate::{AppID, AppKey, AppMetadata, Sdk};
 
 /// The initial state of the SDK builder, before connecting to the indexd service.
 pub struct DisconnectedState;
@@ -103,12 +103,12 @@ impl Builder<DisconnectedState> {
     ///
     /// # Arguments
     /// * `app_key` - The application key used for authentication.
-    pub async fn connected(&self, app_key: &AppKey) -> Result<Option<SDK>, BuilderError> {
+    pub async fn connected(&self, app_key: &AppKey) -> Result<Option<Sdk>, BuilderError> {
         let connected = self.client.check_app_authenticated(&app_key.0).await?;
         if !connected {
             return Ok(None);
         }
-        let sdk = SDK::new(self.client.clone(), Arc::new(app_key.clone())).await?;
+        let sdk = Sdk::new(self.client.clone(), Arc::new(app_key.clone())).await?;
         Ok(Some(sdk))
     }
 
@@ -185,7 +185,7 @@ impl Builder<ApprovedState> {
     ///
     /// # Errors
     /// Returns [BuilderError] if the registration fails or the SDK cannot be created.
-    pub async fn register(self, mnemonic: &str) -> Result<SDK, BuilderError> {
+    pub async fn register(self, mnemonic: &str) -> Result<Sdk, BuilderError> {
         let private_key = derive_app_key(mnemonic, &self.app_meta.id, &self.state.user_secret)?;
         self.client
             .register_app(
@@ -194,7 +194,7 @@ impl Builder<ApprovedState> {
                 self.state.register_url.clone(),
             )
             .await?;
-        SDK::new(self.client, Arc::new(AppKey(private_key))).await
+        Sdk::new(self.client, Arc::new(AppKey(private_key))).await
     }
 }
 

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -344,7 +344,8 @@ impl<const N: usize> Iterator for ChunkIter<N> {
         if self.remaining == 0 {
             return None;
         }
-        let slab = &self.slabs[self.slab_idx];
+        let slab_index = self.slab_idx;
+        let slab = &self.slabs[slab_index];
         let slab_offset = slab.offset as u64 + self.offset;
         let slab_length = (slab.length as u64 - self.offset)
             .min(self.remaining)
@@ -362,7 +363,7 @@ impl<const N: usize> Iterator for ChunkIter<N> {
         chunk.length = slab_length as u32;
         Some(ChunkSlab {
             slab: chunk,
-            index: self.slab_idx,
+            index: slab_index,
         })
     }
 }
@@ -544,7 +545,7 @@ mod test {
     use crate::compat::run_local;
     use crate::hosts::Hosts;
     use crate::upload::Uploader;
-    use crate::{Host, UploadOptions};
+    use crate::{Host, ShardProgress, UploadOptions};
 
     cross_target_tests! {
         async fn test_out_of_order_download() { run_local(async {
@@ -670,5 +671,95 @@ mod test {
                 );
             }
         }).await }
+
+        async fn test_slab_recovery_progress_callback() { run_local(async {
+            let upload_options = UploadOptions::default();
+            let min_shards = upload_options.data_shards as usize;
+            let total_shards = min_shards + upload_options.parity_shards as usize;
+            let slab_size = min_shards * SECTOR_SIZE;
+            let num_slabs = 3;
+
+            let transport = Client::new();
+            let hosts = Hosts::new(transport.clone());
+            hosts.update(
+                (0..60)
+                    .map(|_| Host {
+                        public_key: PrivateKey::from_seed(&rand::random()).public_key(),
+                        addresses: vec![NetAddress {
+                            protocol: sia_core::types::v2::Protocol::QUIC,
+                            address: "localhost:1234".to_string(),
+                        }],
+                        country_code: "US".to_string(),
+                        latitude: 0.0,
+                        longitude: 0.0,
+                        good_for_upload: true,
+                    })
+                    .collect(),
+                true,
+            );
+            // upload enough data for multiple slabs
+            let data_size = slab_size * num_slabs;
+            let mut data = BytesMut::zeroed(data_size);
+            rand::rng().fill_bytes(&mut data);
+            let data = data.freeze();
+            let app_key = Arc::new(AppKey::import(rand::random()));
+
+            let uploader = Uploader::new(hosts.clone(), app_key.clone());
+            let obj = uploader
+                .upload(Object::default(), Cursor::new(data.clone()), upload_options)
+                .await
+                .unwrap();
+            assert_eq!(obj.slabs().len(), num_slabs);
+
+            // download with progress callback
+            let progress: Arc<std::sync::Mutex<Vec<ShardProgress>>> =
+                Arc::new(std::sync::Mutex::new(Vec::new()));
+            let progress_clone = progress.clone();
+            let opts = DownloadOptions::default()
+                .on_shard_downloaded(move |p: ShardProgress| {
+                    progress_clone.lock().unwrap().push(p);
+                });
+
+            let mut recovered_data = Vec::with_capacity(data_size);
+            let mut download = Download::new(&obj, hosts.clone(), app_key.clone(), opts).unwrap();
+            tokio::io::copy(&mut download, &mut recovered_data)
+                .await
+                .unwrap();
+            assert_eq!(data, recovered_data);
+
+            let events = progress.lock().unwrap();
+            // each slab is split into CHUNK_SIZE (256 KiB) chunks for download.
+            // each chunk recovers min_shards shards independently.
+            let chunks_per_slab = slab_size.div_ceil(CHUNK_SIZE);
+            let expected_total = chunks_per_slab * min_shards * num_slabs;
+            assert_eq!(
+                events.len(),
+                expected_total,
+                "expected {expected_total} progress callbacks ({chunks_per_slab} chunks × {min_shards} shards × {num_slabs} slabs), got {}",
+                events.len()
+            );
+
+            // count callbacks per slab, verify shard metadata
+            let mut per_slab: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+            for event in events.iter() {
+                assert!(event.shard_size > 0 && event.shard_size <= SECTOR_SIZE,
+                    "shard_size {} out of range", event.shard_size);
+                assert!(
+                    event.shard_index < total_shards,
+                    "shard_index {} out of range for total_shards {}",
+                    event.shard_index,
+                    total_shards
+                );
+                *per_slab.entry(event.slab_index).or_default() += 1;
+            }
+            // every slab should have at least one callback
+            for slab_idx in 0..num_slabs {
+                assert!(
+                    per_slab.contains_key(&slab_idx),
+                    "slab {slab_idx} had no progress callbacks"
+                );
+            }
+        }).await }
+
     }
 }

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -3,13 +3,12 @@ use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Poll, ready};
-use std::time::Instant;
 
 use crate::encryption::{Chacha20Cipher, EncryptionKey, encrypt_recovered_shards};
 use crate::erasure_coding::{self, ErasureCoder};
 use crate::hosts::{Hosts, RPCError};
 use crate::rhp4::{Client, Transport};
-use crate::time::{Duration, Elapsed, sleep};
+use crate::time::{Duration, Elapsed, Instant, sleep};
 use crate::{AppKey, DownloadOptions, Object, Sector, ShardProgress, ShardProgressCallback, Slab};
 use bytes::{Buf, Bytes, BytesMut};
 use chacha20::cipher::StreamCipher;

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -221,7 +221,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                         Ok((index, data, progress)) => {
                             shards[index] = Some(data);
                             recovered_shards += 1;
-                            if let Some(callback) = &shard_downloaded {
+                            if recovered_shards <= min_shards && let Some(callback) = &shard_downloaded {
                                 callback(progress);
                             }
                             if recovered_shards >= min_shards {

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -3,13 +3,14 @@ use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Poll, ready};
+use std::time::Instant;
 
 use crate::encryption::{Chacha20Cipher, EncryptionKey, encrypt_recovered_shards};
 use crate::erasure_coding::{self, ErasureCoder};
 use crate::hosts::{Hosts, RPCError};
 use crate::rhp4::{Client, Transport};
 use crate::time::{Duration, Elapsed, sleep};
-use crate::{AppKey, Object, Sector, Slab};
+use crate::{AppKey, DownloadOptions, Object, Sector, ShardProgress, ShardProgressCallback, Slab};
 use bytes::{Buf, Bytes, BytesMut};
 use chacha20::cipher::StreamCipher;
 use sia_core::rhp4::SEGMENT_SIZE;
@@ -66,26 +67,6 @@ pub enum DownloadError {
     Errored,
 }
 
-/// Options for configuring a download.
-pub struct DownloadOptions {
-    /// Maximum number of concurrent chunk downloads. Defaults to 80.
-    pub max_inflight: usize,
-    /// Byte offset to start downloading from.
-    pub offset: u64,
-    /// Number of bytes to download. If `None`, downloads the entire object.
-    pub length: Option<u64>,
-}
-
-impl Default for DownloadOptions {
-    fn default() -> Self {
-        Self {
-            max_inflight: 80, // ~20 MiB in memory
-            offset: 0,
-            length: None,
-        }
-    }
-}
-
 struct SectorTask {
     sector: Sector,
     shard_index: usize,
@@ -113,6 +94,7 @@ struct SlabRecovery<State, T: Transport> {
     client: Hosts<T>,
     account_key: Arc<AppKey>,
 
+    slab_index: usize,
     min_shards: u8,
     encryption_key: EncryptionKey,
     offset: usize,
@@ -122,20 +104,25 @@ struct SlabRecovery<State, T: Transport> {
 }
 
 impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
-    fn new(client: Hosts<T>, account_key: Arc<AppKey>, slab: Slab) -> Result<Self, DownloadError> {
-        if slab.min_shards == 0 {
+    fn new(
+        client: Hosts<T>,
+        account_key: Arc<AppKey>,
+        slab: ChunkSlab,
+    ) -> Result<Self, DownloadError> {
+        if slab.slab.min_shards == 0 {
             return Err(DownloadError::InvalidSlab(
                 "min_shards cannot be 0".to_string(),
             ));
-        } else if slab.min_shards as usize > slab.sectors.len() {
+        } else if slab.slab.min_shards as usize > slab.slab.sectors.len() {
             return Err(DownloadError::InvalidSlab(format!(
                 "min_shards {} cannot be greater than number of sectors {}",
-                slab.min_shards,
-                slab.sectors.len()
+                slab.slab.min_shards,
+                slab.slab.sectors.len()
             )));
         }
 
         let mut sectors = slab
+            .slab
             .sectors
             .iter()
             .enumerate()
@@ -148,10 +135,11 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         Ok(Self {
             client,
             account_key,
-            min_shards: slab.min_shards,
-            encryption_key: slab.encryption_key,
-            offset: slab.offset as usize,
-            length: slab.length as usize,
+            slab_index: slab.index,
+            min_shards: slab.slab.min_shards,
+            encryption_key: slab.slab.encryption_key,
+            offset: slab.slab.offset as usize,
+            length: slab.slab.length as usize,
             state: AwaitingRecovery { sectors },
         })
     }
@@ -160,9 +148,11 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         client: Hosts<T>,
         account_key: Arc<AppKey>,
         task: SectorTask,
+        slab_index: usize,
         sector_offset: usize,
         sector_length: usize,
-    ) -> Result<(usize, BytesMut), DownloadError> {
+    ) -> Result<(usize, BytesMut, ShardProgress), DownloadError> {
+        let start = Instant::now();
         let data = client
             .read_sector(
                 task.sector.host_key,
@@ -174,10 +164,24 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                 Duration::from_secs(60),
             )
             .await?;
-        Ok((task.shard_index, data.try_into_mut().unwrap())) // no other references to the data exist, so this is safe
+        let elapsed = start.elapsed();
+        Ok((
+            task.shard_index,
+            data.try_into_mut().unwrap(),
+            ShardProgress {
+                host_key: task.sector.host_key,
+                shard_size: sector_length,
+                shard_index: task.shard_index,
+                slab_index,
+                elapsed,
+            },
+        )) // no other references to the data exist, so this is safe
     }
 
-    async fn recover_shards(self) -> Result<SlabRecovery<ShardsRecovered, T>, DownloadError> {
+    async fn recover_shards(
+        self,
+        shard_downloaded: Option<ShardProgressCallback>,
+    ) -> Result<SlabRecovery<ShardsRecovered, T>, DownloadError> {
         let mut shard_tasks = JoinSet::new();
         let mut shards = vec![None; self.state.sectors.len()];
         let mut sectors = VecDeque::from(self.state.sectors);
@@ -203,6 +207,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                     client.clone(),
                     account_key.clone(),
                     task,
+                    self.slab_index,
                     shard_offset,
                     shard_length,
                 )
@@ -214,14 +219,18 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             tokio::select! {
                 Some(res) = shard_tasks.join_next() => {
                     match res? {
-                        Ok((index, data)) => {
+                        Ok((index, data, progress)) => {
                             shards[index] = Some(data);
                             recovered_shards += 1;
+                            if let Some(callback) = &shard_downloaded {
+                                callback(progress);
+                            }
                             if recovered_shards >= min_shards {
                                 return Ok(SlabRecovery {
                                     client,
                                     account_key,
                                     min_shards,
+                                    slab_index: self.slab_index,
                                     encryption_key,
                                     offset: self.offset,
                                     length: self.length,
@@ -236,14 +245,14 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                             if recovered_shards as usize + shard_tasks.len() + sectors.len() < min_shards as usize {
                                 return Err(DownloadError::NotEnoughShards(recovered_shards, min_shards));
                             } else if let Some(task) = sectors.pop_front() {
-                                join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, shard_offset, shard_length));
+                                join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, self.slab_index, shard_offset, shard_length));
                             }
                         }
                     }
                 },
                 _ = sleep(Duration::from_millis(500)), if !sectors.is_empty() => {
                     let task = sectors.pop_front().expect("sectors should not be empty");
-                    join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, shard_offset, shard_length));
+                    join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, self.slab_index, shard_offset, shard_length));
                 },
             }
         }
@@ -272,6 +281,7 @@ impl<T: Transport> SlabRecovery<ShardsRecovered, T> {
             client: self.client,
             account_key: self.account_key,
             min_shards: self.min_shards,
+            slab_index: self.slab_index,
             encryption_key: self.encryption_key,
             offset: self.offset,
             length: self.length,
@@ -286,6 +296,11 @@ impl<T: Transport> SlabRecovery<SlabDecoded, T> {
         ErasureCoder::write_data_shards(w, &self.state.data_shards, skip, self.length).await?;
         Ok(())
     }
+}
+
+struct ChunkSlab {
+    slab: Slab,
+    index: usize,
 }
 
 /// Downloads an object by recovering chunks of each slab in parallel and
@@ -323,9 +338,9 @@ impl<const N: usize> ChunkIter<N> {
 }
 
 impl<const N: usize> Iterator for ChunkIter<N> {
-    type Item = Slab;
+    type Item = ChunkSlab;
 
-    fn next(&mut self) -> Option<Slab> {
+    fn next(&mut self) -> Option<ChunkSlab> {
         if self.remaining == 0 {
             return None;
         }
@@ -345,7 +360,10 @@ impl<const N: usize> Iterator for ChunkIter<N> {
         let mut chunk = slab.clone();
         chunk.offset = slab_offset as u32;
         chunk.length = slab_length as u32;
-        Some(chunk)
+        Some(ChunkSlab {
+            slab: chunk,
+            index: self.slab_idx,
+        })
     }
 }
 
@@ -366,6 +384,8 @@ pub struct Download {
     // require all the enum variants to be Clone which is not the case, so
     // a generic variant is returned after the first error.
     errored: bool,
+
+    shard_downloaded: Option<ShardProgressCallback>,
 }
 
 impl AsyncRead for Download {
@@ -424,12 +444,13 @@ impl Download {
         if let Some(chunk_slab) = self.chunk_iter.next() {
             let hosts = self.hosts.clone();
             let account_key = self.account_key.clone();
+            let shard_progress_callback = self.shard_downloaded.clone();
             self.queue
                 .push_back(AbortOnDropHandle::new(maybe_spawn!(async move {
-                    let len = chunk_slab.length as usize;
+                    let len = chunk_slab.slab.length as usize;
                     let mut buf = Vec::with_capacity(len);
                     SlabRecovery::new(hosts, account_key, chunk_slab)?
-                        .recover_shards()
+                        .recover_shards(shard_progress_callback)
                         .await?
                         .decode()?
                         .write(&mut buf)
@@ -499,6 +520,7 @@ impl Download {
             queue: VecDeque::with_capacity(options.max_inflight),
             chunk_iter,
             errored: false,
+            shard_downloaded: options.shard_downloaded,
         };
         for _ in 0..options.max_inflight {
             download.spawn_next();
@@ -631,9 +653,9 @@ mod test {
                 slab.length = length as u32;
 
                 let mut recovered_data = Vec::with_capacity(length);
-                SlabRecovery::new(hosts.clone(), app_key.clone(), slab)
+                SlabRecovery::new(hosts.clone(), app_key.clone(), ChunkSlab { slab, index: 0 })
                     .unwrap()
-                    .recover_shards()
+                    .recover_shards(None)
                     .await
                     .unwrap()
                     .decode()

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -1251,7 +1251,7 @@ mod test {
             assert_eq!(download_progress.len(), expected_pairs,
                 "download: expected {} unique slab shards, got {}",
                 expected_pairs, download_progress.len());
-            
+
             let expected_count = 160;
             for ((slab_idx, shard_idx), count) in download_progress.iter() {
                 assert_eq!(*count, expected_count, "shard ({}, {}) was downloaded {} times, expected {}", slab_idx, shard_idx, count, expected_count);

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -1247,15 +1247,16 @@ mod test {
             assert_eq!(data, recovered_data);
 
             let download_progress = download_progress.lock().unwrap();
-            let expected_pairs = min_shards * num_slabs;
-            assert_eq!(download_progress.len(), expected_pairs,
-                "download: expected {} unique slab shards, got {}",
-                expected_pairs, download_progress.len());
+            let chunks_per_slab = SLAB_SIZE as usize / (1 << 18);
+            let expected_total = chunks_per_slab * min_shards * num_slabs;
+            let actual_total: usize = download_progress.values().sum();
+            assert_eq!(actual_total, expected_total,
+                "download: expected {} total callbacks, got {}",
+                expected_total, actual_total);
 
-            let expected_count = 160;
-            for ((slab_idx, shard_idx), count) in download_progress.iter() {
-                assert_eq!(*count, expected_count, "shard ({}, {}) was downloaded {} times, expected {}", slab_idx, shard_idx, count, expected_count);
+            for ((slab_idx, shard_idx), _) in download_progress.iter() {
                 assert!(*shard_idx < total_shards, "invalid shard index {} in callback", shard_idx);
+                assert!(*slab_idx < num_slabs, "invalid slab index {} in callback", slab_idx);
             }
         }).await }
         }

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -16,7 +16,7 @@
 //! user's encryption keys -- if it changes, previously stored data becomes
 //! inaccessible. Generate it once (e.g. with a random hash) and never change it.
 //!
-//! Use [Builder] to connect to an indexer and obtain an [SDK] instance. There are
+//! Use [Builder] to connect to an indexer and obtain an [Sdk] instance. There are
 //! two paths:
 //!
 //! - **First time**: Call [Builder::request_connection] to start the approval flow,
@@ -25,7 +25,7 @@
 //!   user's recovery phrase.
 //! - **Returning**: Call [Builder::connected] with a previously exported [AppKey].
 //!
-//! Once you have an [SDK], use it to upload, download, and manage objects:
+//! Once you have an [Sdk], use it to upload, download, and manage objects:
 //!
 //! ```ignore
 //! // Upload
@@ -40,7 +40,7 @@
 //! # Key management
 //!
 //! The [AppKey] grants full access to a user's data. After connecting, retrieve it
-//! with [SDK::app_key], then persist it using [AppKey::export] and restore it with
+//! with [Sdk::app_key], then persist it using [AppKey::export] and restore it with
 //! [AppKey::import] so users don't need to re-approve on every launch.
 
 #[macro_use]
@@ -194,7 +194,7 @@ impl AppKey {
     }
 }
 
-/// A cursor for paginating through object events returned by [SDK::object_events].
+/// A cursor for paginating through object events returned by [Sdk::object_events].
 pub struct ObjectsCursor {
     /// Only return events after this timestamp.
     pub after: DateTime<Utc>,
@@ -222,7 +222,7 @@ impl Serialize for GeoLocation {
     }
 }
 
-/// Parameters for filtering hosts returned by [SDK::hosts].
+/// Parameters for filtering hosts returned by [Sdk::hosts].
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
 pub struct HostQuery {
     /// Sort hosts by proximity to this location.

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -47,6 +47,7 @@
 mod compat;
 
 pub(crate) use compat::{task, time};
+use sia_core::rhp4::SECTOR_SIZE;
 use sia_core::signing::PrivateKey;
 
 mod app_client;
@@ -57,26 +58,23 @@ mod erasure_coding;
 mod hosts;
 mod object_encryption;
 mod rhp4;
+mod sdk;
 mod slabs;
 mod upload;
 
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
 
+pub use sdk::{Error, Sdk};
+
 use std::sync::Arc;
 
-use log::{debug, warn};
 use serde::Serialize;
-use thiserror::Error;
-use tokio::io::AsyncRead;
 
-use crate::app_client::SlabPinParams;
 pub use crate::hosts::Host;
 use crate::hosts::Hosts;
-use crate::rhp4::{Client, HostEndpoint};
-use crate::task::AbortOnDropHandle;
+
 use crate::time::Duration;
-use crate::upload::Uploader;
 pub use chrono::{DateTime, Utc};
 pub use reqwest::{IntoUrl, Url};
 #[doc(hidden)]
@@ -90,11 +88,11 @@ pub use app_client::Error as AppApiError;
 pub use builder::{
     ApprovedState, Builder, BuilderError, DisconnectedState, RequestingApprovalState,
 };
-pub use download::{Download, DownloadError, DownloadOptions};
+pub use download::{Download, DownloadError};
 pub use encryption::EncryptionKey;
 pub use hosts::{QueueError, RPCError};
 pub use slabs::{Object, ObjectEvent, PinnedSlab, SealedObject, SealedObjectError, Sector, Slab};
-pub use upload::{PackedUpload, UploadError, UploadOptions};
+pub use upload::{PackedUpload, UploadError};
 
 /// A unique identifier for an indexer application. It should be constant for an application.
 pub type AppID = Hash256;
@@ -285,350 +283,188 @@ pub struct Account {
     pub last_used: DateTime<Utc>,
 }
 
-/// Errors that can occur when using the SDK.
-#[derive(Error, Debug)]
-pub enum Error {
-    /// An error from the indexer API.
-    #[error("app error: {0}")]
-    App(String),
+#[cfg(not(target_arch = "wasm32"))]
+pub type ShardProgressCallback = Arc<dyn Fn(ShardProgress) + Send + Sync + 'static>;
 
-    /// An error during upload.
-    #[error("upload error: {0}")]
-    Upload(#[from] UploadError),
+#[cfg(target_arch = "wasm32")]
+pub type ShardProgressCallback = Arc<dyn Fn(ShardProgress) + 'static>;
 
-    /// An error during download.
-    #[error("download error: {0}")]
-    Download(#[from] DownloadError),
-
-    /// A TLS connection error.
-    #[error("TLS error: {0}")]
-    Tls(String),
-
-    /// An error opening or sealing an object.
-    #[error("sealed object: {0}")]
-    SealedObject(#[from] SealedObjectError),
+/// Information about a successfully uploaded or downloaded shard, used for progress reporting.
+pub struct ShardProgress {
+    pub host_key: PublicKey,
+    pub shard_size: usize,
+    pub shard_index: usize,
+    pub slab_index: usize,
+    pub elapsed: Duration,
 }
 
-/// The main interface with interacting with the Sia storage network. It provides methods for uploading and downloading objects, as well as managing hosts and account information.
-#[derive(Clone)]
-pub struct SDK {
-    app_key: Arc<AppKey>,
-    api_client: app_client::Client,
-    hosts: Hosts<Client>,
-    uploader: Uploader<Client>,
-    _refresh_task: Arc<AbortOnDropHandle<()>>,
+/// Options for configuring a download.
+pub struct DownloadOptions {
+    /// Maximum number of concurrent chunk downloads. Defaults to 80.
+    pub max_inflight: usize,
+    /// Byte offset to start downloading from.
+    pub offset: u64,
+    /// Number of bytes to download. If `None`, downloads the entire object.
+    pub length: Option<u64>,
+
+    pub shard_downloaded: Option<ShardProgressCallback>,
 }
 
-impl SDK {
-    async fn refresh_hosts(
-        app_key: &AppKey,
-        api_client: &app_client::Client,
-        hosts: &Hosts<Client>,
-    ) -> Result<(), app_client::Error> {
-        const PAGE_SIZE: usize = 100;
-        let mut all_hosts = Vec::new();
-        for i in (0..).step_by(PAGE_SIZE) {
-            let page = api_client
-                .hosts(
-                    &app_key.0,
-                    HostQuery {
-                        offset: Some(i),
-                        limit: Some(PAGE_SIZE as u64),
-                        ..Default::default()
-                    },
-                )
-                .await?;
-            let done = page.len() < PAGE_SIZE;
-            all_hosts.extend(page);
-            if done {
-                break;
-            }
+impl DownloadOptions {
+    /// Configures a callback to receive progress updates for each downloaded shard.
+    #[cfg(target_arch = "wasm32")]
+    pub fn on_shard_downloaded<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(ShardProgress) + 'static,
+    {
+        self.shard_downloaded = Some(Arc::new(callback));
+        self
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn on_shard_downloaded<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(ShardProgress) + Send + Sync + 'static,
+    {
+        self.shard_downloaded = Some(Arc::new(callback));
+        self
+    }
+}
+
+impl Default for DownloadOptions {
+    fn default() -> Self {
+        Self {
+            max_inflight: 80, // ~20 MiB in memory
+            offset: 0,
+            length: None,
+            shard_downloaded: None,
+        }
+    }
+}
+
+/// Options for configuring an upload.
+pub struct UploadOptions {
+    /// The number of data shards per slab. Defaults to 10.
+    pub data_shards: u8,
+    /// The number of parity shards per slab. Defaults to 20.
+    pub parity_shards: u8,
+    /// The maximum number of concurrent shard uploads. Defaults to 15.
+    pub max_inflight: usize,
+
+    /// Optional callback to receive progress updates for each uploaded shard.
+    pub shard_uploaded: Option<ShardProgressCallback>,
+}
+
+impl UploadOptions {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn on_shard_uploaded<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(ShardProgress) + Send + Sync + 'static,
+    {
+        self.shard_uploaded = Some(Arc::new(callback));
+        self
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn on_shard_uploaded<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(ShardProgress) + 'static,
+    {
+        self.shard_uploaded = Some(Arc::new(callback));
+        self
+    }
+}
+
+impl UploadOptions {
+    /// Returns the optimal data size per slab in bytes.
+    pub fn optimal_data_size(&self) -> u64 {
+        SECTOR_SIZE as u64 * self.data_shards as u64
+    }
+
+    /// Returns the total slab size including parity shards in bytes.
+    pub fn slab_size(&self) -> u64 {
+        SECTOR_SIZE as u64 * (self.data_shards as u64 + self.parity_shards as u64)
+    }
+
+    /// Validates the upload options and erasure coding parameters to ensure
+    /// sufficient durability.
+    ///
+    /// This checks that the redundancy ratio is between 1.5x and 4x and that
+    /// the probability of recovering the original data meets a minimum threshold
+    /// of 99.99%.
+    pub fn validate(&self) -> Result<(), UploadError> {
+        const MIN_REDUNDANCY: f64 = 1.5;
+        const MAX_REDUNDANCY: f64 = 4.0;
+        const RECOVERY_PROBABILITY: f64 = 0.75;
+        const MIN_RECOVERY_PROBABILITY: f64 = 99.99;
+        const MAX_TOTAL_SHARDS: u16 = 256;
+
+        if self.max_inflight == 0 {
+            return Err(UploadError::InvalidOptions(
+                "max_inflight must be greater than 0".into(),
+            ));
         }
 
-        let good_for_upload: Vec<_> = all_hosts
-            .iter()
-            .filter(|h| h.good_for_upload)
-            .map(|h| HostEndpoint {
-                public_key: h.public_key,
-                addresses: h.addresses.clone(),
-            })
-            .collect();
+        let data_shards = self.data_shards as u16;
+        let parity_shards = self.parity_shards as u16;
+        let total_shards = data_shards + parity_shards;
 
-        debug!(
-            "Refreshed hosts: total {}, good for upload {}",
-            all_hosts.len(),
-            good_for_upload.len()
-        );
-        hosts.update(all_hosts, true);
-        let hosts = hosts.clone();
-        maybe_spawn!(async move {
-            hosts.warm_connections(good_for_upload).await;
-        });
+        if data_shards == 0 {
+            return Err(UploadError::InvalidOptions(
+                "data shards cannot be zero".into(),
+            ));
+        } else if parity_shards == 0 {
+            return Err(UploadError::InvalidOptions(
+                "parity shards cannot be zero".into(),
+            ));
+        } else if total_shards > MAX_TOTAL_SHARDS {
+            return Err(UploadError::InvalidOptions(format!(
+                "total shards {total_shards} exceeds maximum of {MAX_TOTAL_SHARDS}"
+            )));
+        }
+
+        let redundancy = total_shards as f64 / data_shards as f64;
+        if redundancy < MIN_REDUNDANCY {
+            return Err(UploadError::InvalidOptions(format!(
+                "redundancy of {redundancy:.2} is too low"
+            )));
+        } else if redundancy > MAX_REDUNDANCY {
+            return Err(UploadError::InvalidOptions(format!(
+                "redundancy of {redundancy:.2} is too high"
+            )));
+        }
+
+        // Calculate recovery probability using the binomial CDF.
+        // P(X >= data_shards) where X ~ Binomial(total_shards, RECOVERY_PROBABILITY)
+        let q = 1.0 - RECOVERY_PROBABILITY;
+        let mut term = q.powi(total_shards as i32);
+        for i in 0..data_shards {
+            term *= (total_shards - i) as f64 / (i + 1) as f64 * (RECOVERY_PROBABILITY / q);
+        }
+        let mut sum = term;
+        for i in data_shards..total_shards {
+            term *= (total_shards - i) as f64 / (i + 1) as f64 * (RECOVERY_PROBABILITY / q);
+            sum += term;
+        }
+        let prob = sum * 100.0;
+        if prob < MIN_RECOVERY_PROBABILITY {
+            return Err(UploadError::InvalidOptions(format!(
+                "not enough redundancy {data_shards}-of-{total_shards}: recovery probability {:.2}% is below minimum threshold of {MIN_RECOVERY_PROBABILITY:.2}%",
+                (prob * 100.0).floor() / 100.0
+            )));
+        }
         Ok(())
     }
+}
 
-    /// Creates a new SDK instance.
-    async fn new(
-        api_client: app_client::Client,
-        app_key: Arc<AppKey>,
-    ) -> Result<Self, BuilderError> {
-        let hosts = Hosts::new(Client::new());
-        Self::refresh_hosts(&app_key, &api_client, &hosts).await?;
-        let uploader = Uploader::new(hosts.clone(), app_key.clone());
-        let refresh_task = Self::spawn_refresh_task(
-            app_key.clone(),
-            api_client.clone(),
-            hosts.clone(),
-            Duration::from_secs(10 * 60),
-        );
-        Ok(Self {
-            app_key,
-            api_client,
-            hosts,
-            uploader,
-            _refresh_task: Arc::new(refresh_task),
-        })
-    }
-
-    /// Spawns a background task that refreshes the host list at the given interval.
-    fn spawn_refresh_task(
-        app_key: Arc<AppKey>,
-        api_client: app_client::Client,
-        hosts: Hosts<Client>,
-        interval: Duration,
-    ) -> AbortOnDropHandle<()> {
-        AbortOnDropHandle::new(maybe_spawn!(async move {
-            loop {
-                crate::time::sleep(interval).await;
-                if let Err(err) = Self::refresh_hosts(&app_key, &api_client, &hosts).await {
-                    warn!("failed to refresh hosts: {err}");
-                }
-            }
-        }))
-    }
-
-    /// Returns the application key used by the SDK.
-    ///
-    /// This should be kept secret and secure. Applications
-    /// should store it safely.
-    pub fn app_key(&self) -> &AppKey {
-        &self.app_key
-    }
-
-    /// Reads until EOF and uploads all slabs. The data will be erasure coded,
-    /// encrypted, and uploaded.
-    ///
-    /// Pass [Object::default] for new uploads. To resume a previous upload,
-    /// pass the object returned from the earlier call. Appending data changes
-    /// an object's ID. It must be re-pinned afterward and any references to
-    /// the previous ID must be updated.
-    ///
-    /// # Arguments
-    /// * `object` - The object to upload into. Use `Object::default()` for new uploads.
-    /// * `r` - The reader to read the data from. It will be read until EOF.
-    /// * `options` - The [UploadOptions] to use for the upload.
-    ///
-    /// # Returns
-    /// The object containing the metadata needed to download. The caller must
-    /// pin the object to the indexer after uploading.
-    pub async fn upload<R: AsyncRead + Unpin + 'static>(
-        &self,
-        object: Object,
-        reader: R,
-        options: UploadOptions,
-    ) -> Result<Object, UploadError> {
-        self.uploader.upload(object, reader, options).await
-    }
-
-    /// Creates a new packed upload. This allows multiple objects to be packed together
-    /// for more efficient uploads. The returned `PackedUpload` can be used to add objects to the upload, and then finalized to get the resulting objects.
-    ///
-    /// # Arguments
-    /// * `options` - The [UploadOptions] to use for the upload.
-    ///
-    /// # Returns
-    /// A [PackedUpload] that can be used to add objects and finalize the upload.
-    pub fn upload_packed(&self, options: UploadOptions) -> PackedUpload {
-        self.uploader.upload_packed(options)
-    }
-
-    /// Returns a [Download] handle that streams the object's data. The handle
-    /// implements [tokio::io::AsyncRead] — pipe it into any writer with
-    /// [tokio::io::copy] or read chunks directly. In-flight chunk recovery is
-    /// cancelled when the handle is dropped.
-    pub fn download(
-        &self,
-        object: &Object,
-        options: DownloadOptions,
-    ) -> Result<Download, DownloadError> {
-        Download::new(object, self.hosts.clone(), self.app_key.clone(), options)
-    }
-
-    /// Retrieves a list of hosts from the indexer matching the provided query
-    /// that can be used for uploading and downloading data.
-    ///
-    /// # Arguments
-    /// * `query` - Filtering criteria to select hosts.
-    pub async fn hosts(&self, query: HostQuery) -> Result<Vec<Host>, Error> {
-        self.api_client
-            .hosts(&self.app_key.0, query)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))
-    }
-
-    /// Retrieves account information from the indexer.
-    pub async fn account(&self) -> Result<Account, Error> {
-        self.api_client
-            .account(&self.app_key.0)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))
-    }
-
-    /// Retrieves an object from the indexer by its key.
-    ///
-    /// # Arguments
-    /// * `key` - The key of the object to retrieve.
-    pub async fn object(&self, key: &Hash256) -> Result<Object, Error> {
-        let sealed = self
-            .api_client
-            .object(&self.app_key.0, key)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))?;
-
-        let obj = sealed.open(self.app_key.as_ref())?;
-        Ok(obj)
-    }
-
-    /// Retrieves a list of object events from the indexer. This
-    /// can be used to synchronize local state with the indexer.
-    ///
-    /// # Arguments
-    /// * `cursor` - An optional cursor to continue from a previous call.
-    /// * `limit` - An optional limit on the number of events to retrieve.
-    pub async fn object_events(
-        &self,
-        cursor: Option<ObjectsCursor>,
-        limit: Option<usize>,
-    ) -> Result<Vec<ObjectEvent>, Error> {
-        let events = self
-            .api_client
-            .objects(&self.app_key.0, cursor, limit)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))?;
-
-        let objs = events
-            .into_iter()
-            .map(|event| {
-                let object = match event.object {
-                    Some(sealed) => Some(sealed.open(self.app_key.as_ref())?),
-                    None => None,
-                };
-                Ok(ObjectEvent {
-                    id: event.id,
-                    deleted: event.deleted,
-                    updated_at: event.updated_at,
-                    object,
-                })
-            })
-            .collect::<Result<_, Error>>()?;
-
-        Ok(objs)
-    }
-
-    /// Prunes unused slabs from the indexer. This helps to free up
-    /// storage space by removing slabs that are no longer
-    /// referenced by objects.
-    pub async fn prune_slabs(&self) -> Result<(), Error> {
-        self.api_client
-            .prune_slabs(&self.app_key.0)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))?;
-        Ok(())
-    }
-
-    /// Updates the metadata of an object in the indexer. The object
-    /// must already be pinned to the indexer.
-    ///
-    /// # Arguments
-    /// * `object` - The object to update.
-    pub async fn update_object_metadata(&self, object: &Object) -> Result<(), Error> {
-        let sealed = object.seal(self.app_key.as_ref());
-        self.api_client
-            .pin_object(&self.app_key.0, &sealed)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))?;
-        Ok(())
-    }
-
-    /// Deletes the object with the given id.
-    ///
-    /// # Arguments
-    /// * `id` - The id of the object to delete.
-    pub async fn delete_object(&self, id: &Hash256) -> Result<(), Error> {
-        self.api_client
-            .delete_object(&self.app_key.0, id)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))
-    }
-
-    /// Generates a shared URL for the given object that is valid until the specified time.
-    ///
-    /// This object should be considered public even if the URL is kept secret,
-    /// as anyone with the URL can access the object until the expiration time.
-    ///
-    /// # Arguments
-    /// * `object` - The object to share.
-    /// * `valid_until` - The time until which the shared URL is valid.
-    pub fn share_object(&self, object: &Object, valid_until: DateTime<Utc>) -> Result<Url, Error> {
-        self.api_client
-            .shared_object_url(&self.app_key.0, object, valid_until)
-            .map_err(|e| Error::App(format!("{e:?}")))
-    }
-
-    /// Retrieves a shared object from the given share URL.
-    ///
-    /// # Arguments
-    /// * `share_url` - The URL of the shared object.
-    pub async fn shared_object<U: IntoUrl>(&self, share_url: U) -> Result<Object, Error> {
-        let share_url = share_url
-            .into_url()
-            .map_err(|e| Error::App(format!("{e:?}")))?;
-        self.api_client
-            .shared_object(share_url)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))
-    }
-
-    /// Pins an object to the indexer
-    pub async fn pin_object(&self, object: &Object) -> Result<(), Error> {
-        let slabs = object
-            .slabs()
-            .iter()
-            .map(|s| SlabPinParams {
-                encryption_key: s.encryption_key.clone(),
-                min_shards: s.min_shards,
-                sectors: s.sectors.clone(),
-            })
-            .collect();
-
-        self.api_client
-            .pin_slabs(&self.app_key.0, slabs)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))?;
-
-        self.api_client
-            .pin_object(&self.app_key.0, &object.seal(self.app_key.as_ref()))
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))?;
-        Ok(())
-    }
-
-    /// Retrieves a pinned slab from the indexer by its id.
-    pub async fn slab(&self, id: &Hash256) -> Result<PinnedSlab, Error> {
-        self.api_client
-            .slab(&self.app_key.0, id)
-            .await
-            .map_err(|e| Error::App(format!("{e:?}")))
+impl Default for UploadOptions {
+    fn default() -> Self {
+        Self {
+            data_shards: 10,
+            parity_shards: 20,
+            max_inflight: 15,
+            shard_uploaded: None,
+        }
     }
 }
 
@@ -657,6 +493,8 @@ mod test {
     use crate::compat::run_local;
     use crate::download::Download;
     use crate::hosts::QueueError;
+    use crate::rhp4::Client;
+    use crate::upload::Uploader;
     use bytes::{Bytes, BytesMut};
     use sia_core::rhp4::SECTOR_SIZE;
     use sia_core::signing::PrivateKey;
@@ -1335,106 +1173,4 @@ mod test {
             }
         }).await }
         }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[tokio::test]
-    async fn test_refresh_task_periodic_and_abort() {
-        use httptest::http::{Response, StatusCode};
-        use httptest::matchers::*;
-        use httptest::{Expectation, Server};
-
-        const INTERVAL: Duration = Duration::from_millis(200);
-        const WAIT: Duration = Duration::from_millis(500);
-
-        // API returns hosts with good_for_upload=false so warm_connections is a no-op
-        let hosts: Vec<Host> = (0..3)
-            .map(|_| Host {
-                public_key: PrivateKey::from_seed(&random_seed()).public_key(),
-                addresses: vec![NetAddress {
-                    protocol: sia_core::types::v2::Protocol::QUIC,
-                    address: "localhost:1234".to_string(),
-                }],
-                country_code: "US".to_string(),
-                latitude: 0.0,
-                longitude: 0.0,
-                good_for_upload: false,
-            })
-            .collect();
-        let server = Server::run();
-        server.expect(
-            Expectation::matching(request::method_path("GET", "/hosts"))
-                .times(..)
-                .respond_with(
-                    Response::builder()
-                        .status(StatusCode::OK)
-                        .body(serde_json::to_string(&hosts).unwrap())
-                        .unwrap(),
-                ),
-        );
-
-        let app_key = Arc::new(AppKey::import(random_seed()));
-        let client = crate::app_client::Client::new(server.url("/").to_string()).unwrap();
-        let hosts = Hosts::new(crate::rhp4::Client::new());
-
-        // helper: seed one good-for-upload host so available_for_upload() == 1
-        let add_upload_host = |hosts: &Hosts<crate::rhp4::Client>| {
-            hosts.update(
-                vec![Host {
-                    public_key: PrivateKey::from_seed(&random_seed()).public_key(),
-                    addresses: vec![],
-                    country_code: String::new(),
-                    latitude: 0.0,
-                    longitude: 0.0,
-                    good_for_upload: true,
-                }],
-                false,
-            );
-        };
-
-        // verify initial refresh replaces hosts
-        add_upload_host(&hosts);
-        assert_eq!(hosts.available_for_upload(), 1);
-        SDK::refresh_hosts(&app_key, &client, &hosts).await.unwrap();
-        assert_eq!(
-            hosts.available_for_upload(),
-            0,
-            "initial refresh should clear upload hosts"
-        );
-
-        // spawn the periodic refresh task with a short interval
-        add_upload_host(&hosts);
-        assert_eq!(hosts.available_for_upload(), 1);
-        let handle =
-            SDK::spawn_refresh_task(app_key.clone(), client.clone(), hosts.clone(), INTERVAL);
-
-        // wait for periodic refresh to run
-        tokio::time::sleep(WAIT).await;
-        assert_eq!(
-            hosts.available_for_upload(),
-            0,
-            "periodic refresh should have run"
-        );
-
-        // verify it refreshes again
-        add_upload_host(&hosts);
-        tokio::time::sleep(WAIT).await;
-        assert_eq!(
-            hosts.available_for_upload(),
-            0,
-            "second periodic refresh should have run"
-        );
-
-        // drop handle to abort the task
-        drop(handle);
-        add_upload_host(&hosts);
-        assert_eq!(hosts.available_for_upload(), 1);
-
-        // wait past the interval - should NOT refresh (task aborted)
-        tokio::time::sleep(WAIT).await;
-        assert_eq!(
-            hosts.available_for_upload(),
-            1,
-            "refresh task should be aborted"
-        );
-    }
 }

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -1172,5 +1172,113 @@ mod test {
                 _ => panic!(),
             }
         }).await }
+
+        async fn test_progress_callbacks() { run_local(async {
+            let min_shards: usize = 10;
+            let total_shards: usize = 30;
+            let num_slabs = 3;
+
+            let app_key = Arc::new(AppKey::import(random_seed()));
+            let hosts = Hosts::new(Client::new());
+            hosts.update(
+                (0..60)
+                    .map(|_| Host {
+                        public_key: PrivateKey::from_seed(&random_seed()).public_key(),
+                        addresses: vec![NetAddress {
+                            protocol: sia_core::types::v2::Protocol::QUIC,
+                            address: "localhost:1234".to_string(),
+                        }],
+                        country_code: "US".to_string(),
+                        latitude: 0.0,
+                        longitude: 0.0,
+                        good_for_upload: true,
+                    })
+                    .collect(),
+                true,
+            );
+            let data_size = SLAB_SIZE as usize * num_slabs;
+            let mut data = BytesMut::zeroed(data_size);
+            random_bytes(&mut data);
+            let data = data.freeze();
+
+            // upload with progress callback
+            let upload_progress: Arc<std::sync::Mutex<Vec<ShardProgress>>> =
+                Arc::new(std::sync::Mutex::new(Vec::new()));
+            let upload_progress_clone = upload_progress.clone();
+            let upload_opts = UploadOptions::default()
+                .on_shard_uploaded(move |p: ShardProgress| {
+                    upload_progress_clone.lock().unwrap().push(p);
+                });
+
+            let uploader = Uploader::new(hosts.clone(), app_key.clone());
+            let obj = uploader
+                .upload(Object::default(), Cursor::new(data.clone()), upload_opts)
+                .await
+                .unwrap();
+            assert_eq!(obj.slabs().len(), num_slabs);
+
+            // verify upload callbacks: exactly one per (slab_index, shard_index)
+            {
+                let events = upload_progress.lock().unwrap();
+                let expected = total_shards * num_slabs;
+                assert_eq!(events.len(), expected,
+                    "upload: expected {expected} callbacks, got {}", events.len());
+
+                let mut counts: std::collections::HashMap<(usize, usize), usize> =
+                    std::collections::HashMap::new();
+                for event in events.iter() {
+                    assert_eq!(event.shard_size, SECTOR_SIZE);
+                    *counts.entry((event.slab_index, event.shard_index)).or_default() += 1;
+                }
+                for slab_idx in 0..num_slabs {
+                    for shard_idx in 0..total_shards {
+                        assert_eq!(*counts.get(&(slab_idx, shard_idx)).unwrap_or(&0), 1,
+                            "upload slab {slab_idx} shard {shard_idx}: expected 1 callback");
+                    }
+                }
+                // verify no phantom (slab, shard) pairs beyond expected ranges
+                assert_eq!(counts.len(), num_slabs * total_shards,
+                    "upload: unexpected (slab, shard) pairs");
+            }
+
+            // download with progress callback
+            let download_progress: Arc<std::sync::Mutex<Vec<ShardProgress>>> =
+                Arc::new(std::sync::Mutex::new(Vec::new()));
+            let download_progress_clone = download_progress.clone();
+            let download_opts = DownloadOptions::default()
+                .on_shard_downloaded(move |p: ShardProgress| {
+                    download_progress_clone.lock().unwrap().push(p);
+                });
+
+            let mut recovered_data = Vec::with_capacity(data_size);
+            let mut download = Download::new(&obj, hosts.clone(), app_key.clone(), download_opts).unwrap();
+            copy(&mut download, &mut recovered_data).await.unwrap();
+            assert_eq!(data, recovered_data);
+
+            // verify download callbacks: min_shards per chunk per slab
+            {
+                let events = download_progress.lock().unwrap();
+                let chunks_per_slab = (SLAB_SIZE as usize).div_ceil(1 << 18);
+                let expected = chunks_per_slab * min_shards * num_slabs;
+                assert_eq!(events.len(), expected,
+                    "download: expected {expected} callbacks, got {}", events.len());
+
+                let mut per_slab: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+                for event in events.iter() {
+                    assert!(event.shard_size > 0 && event.shard_size <= SECTOR_SIZE);
+                    assert!(event.shard_index < total_shards);
+                    *per_slab.entry(event.slab_index).or_default() += 1;
+                }
+                for slab_idx in 0..num_slabs {
+                    assert_eq!(*per_slab.get(&slab_idx).unwrap_or(&0),
+                        chunks_per_slab * min_shards,
+                        "download slab {slab_idx}: expected {} callbacks",
+                        chunks_per_slab * min_shards);
+                }
+                // no phantom slab indices
+                assert_eq!(per_slab.len(), num_slabs,
+                    "download: unexpected slab indices: {:?}", per_slab.keys().collect::<Vec<_>>());
+            }
+        }).await }
         }
 }

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -499,7 +499,9 @@ mod test {
     use sia_core::rhp4::SECTOR_SIZE;
     use sia_core::signing::PrivateKey;
     use sia_core::types::v2::NetAddress;
+    use std::collections::HashMap;
     use std::io::Cursor;
+    use std::sync::Mutex;
     use tokio::io::copy;
 
     use crate::time::Duration;
@@ -1201,13 +1203,15 @@ mod test {
             random_bytes(&mut data);
             let data = data.freeze();
 
-            // upload with progress callback
-            let upload_progress: Arc<std::sync::Mutex<Vec<ShardProgress>>> =
-                Arc::new(std::sync::Mutex::new(Vec::new()));
+            let upload_progress: Arc<Mutex<HashMap<(usize, usize), ShardProgress>>> = Arc::new(Mutex::new(HashMap::new()));
             let upload_progress_clone = upload_progress.clone();
             let upload_opts = UploadOptions::default()
                 .on_shard_uploaded(move |p: ShardProgress| {
-                    upload_progress_clone.lock().unwrap().push(p);
+                    if upload_progress_clone.lock().unwrap().contains_key(&(p.slab_index, p.shard_index)) {
+                        panic!("duplicate upload callback for slab {}, shard {}", p.slab_index, p.shard_index);
+                    }
+                    assert_eq!(p.shard_size, SECTOR_SIZE);
+                    upload_progress_clone.lock().unwrap().insert((p.slab_index, p.shard_index), p);
                 });
 
             let uploader = Uploader::new(hosts.clone(), app_key.clone());
@@ -1217,37 +1221,24 @@ mod test {
                 .unwrap();
             assert_eq!(obj.slabs().len(), num_slabs);
 
+            let upload_progress = upload_progress.lock().unwrap();
             // verify upload callbacks: exactly one per (slab_index, shard_index)
-            {
-                let events = upload_progress.lock().unwrap();
-                let expected = total_shards * num_slabs;
-                assert_eq!(events.len(), expected,
-                    "upload: expected {expected} callbacks, got {}", events.len());
-
-                let mut counts: std::collections::HashMap<(usize, usize), usize> =
-                    std::collections::HashMap::new();
-                for event in events.iter() {
-                    assert_eq!(event.shard_size, SECTOR_SIZE);
-                    *counts.entry((event.slab_index, event.shard_index)).or_default() += 1;
+            assert_eq!(upload_progress.len(), total_shards * num_slabs,
+                "upload: expected {} callbacks, got {}",
+                total_shards * num_slabs, upload_progress.len());
+            for i in 0..num_slabs {
+                for j in 0..total_shards {
+                    assert!(upload_progress.contains_key(&(i, j)),
+                        "missing upload callback for slab {}, shard {}", i, j);
                 }
-                for slab_idx in 0..num_slabs {
-                    for shard_idx in 0..total_shards {
-                        assert_eq!(*counts.get(&(slab_idx, shard_idx)).unwrap_or(&0), 1,
-                            "upload slab {slab_idx} shard {shard_idx}: expected 1 callback");
-                    }
-                }
-                // verify no phantom (slab, shard) pairs beyond expected ranges
-                assert_eq!(counts.len(), num_slabs * total_shards,
-                    "upload: unexpected (slab, shard) pairs");
             }
 
-            // download with progress callback
-            let download_progress: Arc<std::sync::Mutex<Vec<ShardProgress>>> =
-                Arc::new(std::sync::Mutex::new(Vec::new()));
+            let download_progress: Arc<Mutex<HashMap<(usize, usize), usize>>> =
+                Arc::new(Mutex::new(HashMap::new()));
             let download_progress_clone = download_progress.clone();
             let download_opts = DownloadOptions::default()
                 .on_shard_downloaded(move |p: ShardProgress| {
-                    download_progress_clone.lock().unwrap().push(p);
+                    *download_progress_clone.lock().unwrap().entry((p.slab_index, p.shard_index)).or_default() += 1;
                 });
 
             let mut recovered_data = Vec::with_capacity(data_size);
@@ -1255,29 +1246,16 @@ mod test {
             copy(&mut download, &mut recovered_data).await.unwrap();
             assert_eq!(data, recovered_data);
 
-            // verify download callbacks: min_shards per chunk per slab
-            {
-                let events = download_progress.lock().unwrap();
-                let chunks_per_slab = (SLAB_SIZE as usize).div_ceil(1 << 18);
-                let expected = chunks_per_slab * min_shards * num_slabs;
-                assert_eq!(events.len(), expected,
-                    "download: expected {expected} callbacks, got {}", events.len());
-
-                let mut per_slab: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
-                for event in events.iter() {
-                    assert!(event.shard_size > 0 && event.shard_size <= SECTOR_SIZE);
-                    assert!(event.shard_index < total_shards);
-                    *per_slab.entry(event.slab_index).or_default() += 1;
-                }
-                for slab_idx in 0..num_slabs {
-                    assert_eq!(*per_slab.get(&slab_idx).unwrap_or(&0),
-                        chunks_per_slab * min_shards,
-                        "download slab {slab_idx}: expected {} callbacks",
-                        chunks_per_slab * min_shards);
-                }
-                // no phantom slab indices
-                assert_eq!(per_slab.len(), num_slabs,
-                    "download: unexpected slab indices: {:?}", per_slab.keys().collect::<Vec<_>>());
+            let download_progress = download_progress.lock().unwrap();
+            let expected_pairs = min_shards * num_slabs;
+            assert_eq!(download_progress.len(), expected_pairs,
+                "download: expected {} unique slab shards, got {}",
+                expected_pairs, download_progress.len());
+            
+            let expected_count = 160;
+            for ((slab_idx, shard_idx), count) in download_progress.iter() {
+                assert_eq!(*count, expected_count, "shard ({}, {}) was downloaded {} times, expected {}", slab_idx, shard_idx, count, expected_count);
+                assert!(*shard_idx < total_shards, "invalid shard index {} in callback", shard_idx);
             }
         }).await }
         }

--- a/sia_storage/src/rhp4/mock.rs
+++ b/sia_storage/src/rhp4/mock.rs
@@ -41,6 +41,7 @@ impl Client {
     /// Sets an initial per-sector read delay. After each read, the per-sector
     /// delay is halved. Used to simulate out-of-order chunk completion.
     /// Sectors written after this is set will start with `delay`.
+    #[allow(dead_code)] // used in tests
     pub fn set_initial_read_delay(&self, delay: Duration) {
         *self.initial_read_delay.write().unwrap() = Some(delay);
     }

--- a/sia_storage/src/sdk.rs
+++ b/sia_storage/src/sdk.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use log::{debug, warn};
@@ -9,6 +8,7 @@ use thiserror::Error;
 use tokio::io::AsyncRead;
 use url::Url;
 
+use crate::time::Duration;
 use crate::app_client::{self, SlabPinParams};
 use crate::hosts::Hosts;
 use crate::rhp4::{Client, HostEndpoint};
@@ -387,7 +387,7 @@ mod test {
         use httptest::{Expectation, Server};
         use sia_core::signing::PrivateKey;
         use sia_core::types::v2::NetAddress;
-        use std::time::Duration;
+        use crate::time::Duration;
 
         use crate::hosts::Hosts;
         use crate::{AppKey, Host};

--- a/sia_storage/src/sdk.rs
+++ b/sia_storage/src/sdk.rs
@@ -377,16 +377,6 @@ mod test {
         seed
     }
 
-    fn random_bytes(buf: &mut [u8]) {
-        getrandom::fill(buf).unwrap();
-    }
-
-    fn random_u64() -> u64 {
-        let mut bytes = [0u8; 8];
-        getrandom::fill(&mut bytes).unwrap();
-        u64::from_le_bytes(bytes)
-    }
-
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn test_refresh_task_periodic_and_abort() {

--- a/sia_storage/src/sdk.rs
+++ b/sia_storage/src/sdk.rs
@@ -8,11 +8,11 @@ use thiserror::Error;
 use tokio::io::AsyncRead;
 use url::Url;
 
-use crate::time::Duration;
 use crate::app_client::{self, SlabPinParams};
 use crate::hosts::Hosts;
 use crate::rhp4::{Client, HostEndpoint};
 use crate::task::AbortOnDropHandle;
+use crate::time::Duration;
 use crate::upload::Uploader;
 use crate::{
     Account, AppKey, BuilderError, Download, DownloadError, DownloadOptions, Host, HostQuery,
@@ -382,12 +382,12 @@ mod test {
     async fn test_refresh_task_periodic_and_abort() {
         use std::sync::Arc;
 
+        use crate::time::Duration;
         use httptest::http::{Response, StatusCode};
         use httptest::matchers::*;
         use httptest::{Expectation, Server};
         use sia_core::signing::PrivateKey;
         use sia_core::types::v2::NetAddress;
-        use crate::time::Duration;
 
         use crate::hosts::Hosts;
         use crate::{AppKey, Host};

--- a/sia_storage/src/sdk.rs
+++ b/sia_storage/src/sdk.rs
@@ -1,0 +1,499 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use log::{debug, warn};
+use reqwest::IntoUrl;
+use sia_core::types::Hash256;
+use thiserror::Error;
+use tokio::io::AsyncRead;
+use url::Url;
+
+use crate::app_client::{self, SlabPinParams};
+use crate::hosts::Hosts;
+use crate::rhp4::{Client, HostEndpoint};
+use crate::task::AbortOnDropHandle;
+use crate::upload::Uploader;
+use crate::{
+    Account, AppKey, BuilderError, Download, DownloadError, DownloadOptions, Host, HostQuery,
+    Object, ObjectEvent, ObjectsCursor, PackedUpload, PinnedSlab, SealedObjectError, UploadError,
+    UploadOptions,
+};
+
+/// Errors that can occur when using the SDK.
+#[derive(Error, Debug)]
+pub enum Error {
+    /// An error from the indexer API.
+    #[error("app error: {0}")]
+    App(String),
+
+    /// An error during upload.
+    #[error("upload error: {0}")]
+    Upload(#[from] UploadError),
+
+    /// An error during download.
+    #[error("download error: {0}")]
+    Download(#[from] DownloadError),
+
+    /// A TLS connection error.
+    #[error("TLS error: {0}")]
+    Tls(String),
+
+    /// An error opening or sealing an object.
+    #[error("sealed object: {0}")]
+    SealedObject(#[from] SealedObjectError),
+}
+
+/// The main interface with interacting with the Sia storage network. It provides methods for uploading and downloading objects, as well as managing hosts and account information.
+#[derive(Clone)]
+pub struct Sdk {
+    app_key: Arc<AppKey>,
+    api_client: app_client::Client,
+    hosts: Hosts<Client>,
+    uploader: Uploader<Client>,
+    _refresh_task: Arc<AbortOnDropHandle<()>>,
+}
+
+impl Sdk {
+    async fn refresh_hosts(
+        app_key: &AppKey,
+        api_client: &app_client::Client,
+        hosts: &Hosts<Client>,
+    ) -> Result<(), app_client::Error> {
+        const PAGE_SIZE: usize = 100;
+        let mut all_hosts = Vec::new();
+        for i in (0..).step_by(PAGE_SIZE) {
+            let page = api_client
+                .hosts(
+                    &app_key.0,
+                    HostQuery {
+                        offset: Some(i),
+                        limit: Some(PAGE_SIZE as u64),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            let done = page.len() < PAGE_SIZE;
+            all_hosts.extend(page);
+            if done {
+                break;
+            }
+        }
+
+        let good_for_upload: Vec<_> = all_hosts
+            .iter()
+            .filter(|h| h.good_for_upload)
+            .map(|h| HostEndpoint {
+                public_key: h.public_key,
+                addresses: h.addresses.clone(),
+            })
+            .collect();
+
+        debug!(
+            "Refreshed hosts: total {}, good for upload {}",
+            all_hosts.len(),
+            good_for_upload.len()
+        );
+        hosts.update(all_hosts, true);
+        let hosts = hosts.clone();
+        maybe_spawn!(async move {
+            hosts.warm_connections(good_for_upload).await;
+        });
+        Ok(())
+    }
+
+    /// Creates a new SDK instance.
+    pub(crate) async fn new(
+        api_client: app_client::Client,
+        app_key: Arc<AppKey>,
+    ) -> Result<Self, BuilderError> {
+        let hosts = Hosts::new(Client::new());
+        Self::refresh_hosts(&app_key, &api_client, &hosts).await?;
+        let uploader = Uploader::new(hosts.clone(), app_key.clone());
+        let refresh_task = Self::spawn_refresh_task(
+            app_key.clone(),
+            api_client.clone(),
+            hosts.clone(),
+            Duration::from_secs(10 * 60),
+        );
+        Ok(Self {
+            app_key,
+            api_client,
+            hosts,
+            uploader,
+            _refresh_task: Arc::new(refresh_task),
+        })
+    }
+
+    /// Spawns a background task that refreshes the host list at the given interval.
+    fn spawn_refresh_task(
+        app_key: Arc<AppKey>,
+        api_client: app_client::Client,
+        hosts: Hosts<Client>,
+        interval: Duration,
+    ) -> AbortOnDropHandle<()> {
+        AbortOnDropHandle::new(maybe_spawn!(async move {
+            loop {
+                crate::time::sleep(interval).await;
+                if let Err(err) = Self::refresh_hosts(&app_key, &api_client, &hosts).await {
+                    warn!("failed to refresh hosts: {err}");
+                }
+            }
+        }))
+    }
+
+    /// Returns the application key used by the SDK.
+    ///
+    /// This should be kept secret and secure. Applications
+    /// should store it safely.
+    pub fn app_key(&self) -> &AppKey {
+        &self.app_key
+    }
+
+    /// Reads until EOF and uploads all slabs. The data will be erasure coded,
+    /// encrypted, and uploaded.
+    ///
+    /// Pass [Object::default] for new uploads. To resume a previous upload,
+    /// pass the object returned from the earlier call. Appending data changes
+    /// an object's ID. It must be re-pinned afterward and any references to
+    /// the previous ID must be updated.
+    ///
+    /// # Arguments
+    /// * `object` - The object to upload into. Use `Object::default()` for new uploads.
+    /// * `r` - The reader to read the data from. It will be read until EOF.
+    /// * `options` - The [UploadOptions] to use for the upload.
+    ///
+    /// # Returns
+    /// The object containing the metadata needed to download. The caller must
+    /// pin the object to the indexer after uploading.
+    pub async fn upload<R: AsyncRead + Unpin + 'static>(
+        &self,
+        object: Object,
+        reader: R,
+        options: UploadOptions,
+    ) -> Result<Object, UploadError> {
+        self.uploader.upload(object, reader, options).await
+    }
+
+    /// Creates a new packed upload. This allows multiple objects to be packed together
+    /// for more efficient uploads. The returned `PackedUpload` can be used to add objects to the upload, and then finalized to get the resulting objects.
+    ///
+    /// # Arguments
+    /// * `options` - The [UploadOptions] to use for the upload.
+    ///
+    /// # Returns
+    /// A [PackedUpload] that can be used to add objects and finalize the upload.
+    pub fn upload_packed(&self, options: UploadOptions) -> PackedUpload {
+        self.uploader.upload_packed(options)
+    }
+
+    /// Returns a [Download] handle that streams the object's data. The handle
+    /// implements [tokio::io::AsyncRead] — pipe it into any writer with
+    /// [tokio::io::copy] or read chunks directly. In-flight chunk recovery is
+    /// cancelled when the handle is dropped.
+    pub fn download(
+        &self,
+        object: &Object,
+        options: DownloadOptions,
+    ) -> Result<Download, DownloadError> {
+        Download::new(object, self.hosts.clone(), self.app_key.clone(), options)
+    }
+
+    /// Retrieves a list of hosts from the indexer matching the provided query
+    /// that can be used for uploading and downloading data.
+    ///
+    /// # Arguments
+    /// * `query` - Filtering criteria to select hosts.
+    pub async fn hosts(&self, query: HostQuery) -> Result<Vec<Host>, Error> {
+        self.api_client
+            .hosts(&self.app_key.0, query)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))
+    }
+
+    /// Retrieves account information from the indexer.
+    pub async fn account(&self) -> Result<Account, Error> {
+        self.api_client
+            .account(&self.app_key.0)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))
+    }
+
+    /// Retrieves an object from the indexer by its key.
+    ///
+    /// # Arguments
+    /// * `key` - The key of the object to retrieve.
+    pub async fn object(&self, key: &Hash256) -> Result<Object, Error> {
+        let sealed = self
+            .api_client
+            .object(&self.app_key.0, key)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+
+        let obj = sealed.open(self.app_key.as_ref())?;
+        Ok(obj)
+    }
+
+    /// Retrieves a list of object events from the indexer. This
+    /// can be used to synchronize local state with the indexer.
+    ///
+    /// # Arguments
+    /// * `cursor` - An optional cursor to continue from a previous call.
+    /// * `limit` - An optional limit on the number of events to retrieve.
+    pub async fn object_events(
+        &self,
+        cursor: Option<ObjectsCursor>,
+        limit: Option<usize>,
+    ) -> Result<Vec<ObjectEvent>, Error> {
+        let events = self
+            .api_client
+            .objects(&self.app_key.0, cursor, limit)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+
+        let objs = events
+            .into_iter()
+            .map(|event| {
+                let object = match event.object {
+                    Some(sealed) => Some(sealed.open(self.app_key.as_ref())?),
+                    None => None,
+                };
+                Ok(ObjectEvent {
+                    id: event.id,
+                    deleted: event.deleted,
+                    updated_at: event.updated_at,
+                    object,
+                })
+            })
+            .collect::<Result<_, Error>>()?;
+
+        Ok(objs)
+    }
+
+    /// Prunes unused slabs from the indexer. This helps to free up
+    /// storage space by removing slabs that are no longer
+    /// referenced by objects.
+    pub async fn prune_slabs(&self) -> Result<(), Error> {
+        self.api_client
+            .prune_slabs(&self.app_key.0)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+        Ok(())
+    }
+
+    /// Updates the metadata of an object in the indexer. The object
+    /// must already be pinned to the indexer.
+    ///
+    /// # Arguments
+    /// * `object` - The object to update.
+    pub async fn update_object_metadata(&self, object: &Object) -> Result<(), Error> {
+        let sealed = object.seal(self.app_key.as_ref());
+        self.api_client
+            .pin_object(&self.app_key.0, &sealed)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+        Ok(())
+    }
+
+    /// Deletes the object with the given id.
+    ///
+    /// # Arguments
+    /// * `id` - The id of the object to delete.
+    pub async fn delete_object(&self, id: &Hash256) -> Result<(), Error> {
+        self.api_client
+            .delete_object(&self.app_key.0, id)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))
+    }
+
+    /// Generates a shared URL for the given object that is valid until the specified time.
+    ///
+    /// This object should be considered public even if the URL is kept secret,
+    /// as anyone with the URL can access the object until the expiration time.
+    ///
+    /// # Arguments
+    /// * `object` - The object to share.
+    /// * `valid_until` - The time until which the shared URL is valid.
+    pub fn share_object(&self, object: &Object, valid_until: DateTime<Utc>) -> Result<Url, Error> {
+        self.api_client
+            .shared_object_url(&self.app_key.0, object, valid_until)
+            .map_err(|e| Error::App(format!("{e:?}")))
+    }
+
+    /// Retrieves a shared object from the given share URL.
+    ///
+    /// # Arguments
+    /// * `share_url` - The URL of the shared object.
+    pub async fn shared_object<U: IntoUrl>(&self, share_url: U) -> Result<Object, Error> {
+        let share_url = share_url
+            .into_url()
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+        self.api_client
+            .shared_object(share_url)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))
+    }
+
+    /// Pins an object to the indexer
+    pub async fn pin_object(&self, object: &Object) -> Result<(), Error> {
+        let slabs = object
+            .slabs()
+            .iter()
+            .map(|s| SlabPinParams {
+                encryption_key: s.encryption_key.clone(),
+                min_shards: s.min_shards,
+                sectors: s.sectors.clone(),
+            })
+            .collect();
+
+        self.api_client
+            .pin_slabs(&self.app_key.0, slabs)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+
+        self.api_client
+            .pin_object(&self.app_key.0, &object.seal(self.app_key.as_ref()))
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))?;
+        Ok(())
+    }
+
+    /// Retrieves a pinned slab from the indexer by its id.
+    pub async fn slab(&self, id: &Hash256) -> Result<PinnedSlab, Error> {
+        self.api_client
+            .slab(&self.app_key.0, id)
+            .await
+            .map_err(|e| Error::App(format!("{e:?}")))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn random_seed() -> [u8; 32] {
+        let mut seed = [0u8; 32];
+        getrandom::fill(&mut seed).unwrap();
+        seed
+    }
+
+    fn random_bytes(buf: &mut [u8]) {
+        getrandom::fill(buf).unwrap();
+    }
+
+    fn random_u64() -> u64 {
+        let mut bytes = [0u8; 8];
+        getrandom::fill(&mut bytes).unwrap();
+        u64::from_le_bytes(bytes)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn test_refresh_task_periodic_and_abort() {
+        use std::sync::Arc;
+
+        use httptest::http::{Response, StatusCode};
+        use httptest::matchers::*;
+        use httptest::{Expectation, Server};
+        use sia_core::signing::PrivateKey;
+        use sia_core::types::v2::NetAddress;
+        use std::time::Duration;
+
+        use crate::hosts::Hosts;
+        use crate::{AppKey, Host};
+
+        const INTERVAL: Duration = Duration::from_millis(200);
+        const WAIT: Duration = Duration::from_millis(500);
+
+        // API returns hosts with good_for_upload=false so warm_connections is a no-op
+        let hosts: Vec<Host> = (0..3)
+            .map(|_| Host {
+                public_key: PrivateKey::from_seed(&random_seed()).public_key(),
+                addresses: vec![NetAddress {
+                    protocol: sia_core::types::v2::Protocol::QUIC,
+                    address: "localhost:1234".to_string(),
+                }],
+                country_code: "US".to_string(),
+                latitude: 0.0,
+                longitude: 0.0,
+                good_for_upload: false,
+            })
+            .collect();
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/hosts"))
+                .times(..)
+                .respond_with(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .body(serde_json::to_string(&hosts).unwrap())
+                        .unwrap(),
+                ),
+        );
+
+        let app_key = Arc::new(AppKey::import(random_seed()));
+        let client = crate::app_client::Client::new(server.url("/").to_string()).unwrap();
+        let hosts = Hosts::new(crate::rhp4::Client::new());
+
+        // helper: seed one good-for-upload host so available_for_upload() == 1
+        let add_upload_host = |hosts: &Hosts<crate::rhp4::Client>| {
+            hosts.update(
+                vec![Host {
+                    public_key: PrivateKey::from_seed(&random_seed()).public_key(),
+                    addresses: vec![],
+                    country_code: String::new(),
+                    latitude: 0.0,
+                    longitude: 0.0,
+                    good_for_upload: true,
+                }],
+                false,
+            );
+        };
+
+        // verify initial refresh replaces hosts
+        add_upload_host(&hosts);
+        assert_eq!(hosts.available_for_upload(), 1);
+        Sdk::refresh_hosts(&app_key, &client, &hosts).await.unwrap();
+        assert_eq!(
+            hosts.available_for_upload(),
+            0,
+            "initial refresh should clear upload hosts"
+        );
+
+        // spawn the periodic refresh task with a short interval
+        add_upload_host(&hosts);
+        assert_eq!(hosts.available_for_upload(), 1);
+        let handle =
+            Sdk::spawn_refresh_task(app_key.clone(), client.clone(), hosts.clone(), INTERVAL);
+
+        // wait for periodic refresh to run
+        tokio::time::sleep(WAIT).await;
+        assert_eq!(
+            hosts.available_for_upload(),
+            0,
+            "periodic refresh should have run"
+        );
+
+        // verify it refreshes again
+        add_upload_host(&hosts);
+        tokio::time::sleep(WAIT).await;
+        assert_eq!(
+            hosts.available_for_upload(),
+            0,
+            "second periodic refresh should have run"
+        );
+
+        // drop handle to abort the task
+        drop(handle);
+        add_upload_host(&hosts);
+        assert_eq!(hosts.available_for_upload(), 1);
+
+        // wait past the interval - should NOT refresh (task aborted)
+        tokio::time::sleep(WAIT).await;
+        assert_eq!(
+            hosts.available_for_upload(),
+            1,
+            "refresh task should be aborted"
+        );
+    }
+}

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -1,14 +1,14 @@
 use std::io;
 use std::sync::Arc;
 
-use crate::AppKey;
+use crate::{AppKey, ShardProgress, ShardProgressCallback, UploadOptions};
 use bytes::{Bytes, BytesMut};
 use log::debug;
 use sia_core::rhp4::{self as rhp, SECTOR_SIZE};
 use sia_core::signing::PublicKey;
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWriteExt, BufReader, SimplexStream, WriteHalf, copy, simplex};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinSet;
 
 use crate::encryption::{EncryptionKey, encrypt_shard};
@@ -31,7 +31,7 @@ struct ShardUpload<T: Transport> {
 impl<T: Transport> ShardUpload<T> {
     fn spawn_write(
         &self,
-        tasks: &mut JoinSet<Result<Sector, UploadError>>,
+        tasks: &mut JoinSet<Result<(Sector, Duration), UploadError>>,
         host_key: PublicKey,
         write_timeout: Duration,
         permit: OwnedSemaphorePermit,
@@ -53,11 +53,12 @@ impl<T: Transport> ShardUpload<T> {
                 );
                 let _ = hosts.retry(host_key);
             })?;
+            let elapsed = now.elapsed();
             debug!(
                 "slab {slab_index} shard {shard_index} uploaded to {host_key} in {:?}",
-                now.elapsed()
+                elapsed
             );
-            Ok(Sector { root, host_key })
+            Ok((Sector { root, host_key }, elapsed))
         });
     }
 }
@@ -116,113 +117,6 @@ pub enum UploadError {
     /// The upload was cancelled.
     #[error("upload cancelled")]
     Cancelled,
-}
-
-/// Options for configuring an upload.
-pub struct UploadOptions {
-    /// The number of data shards per slab. Defaults to 10.
-    pub data_shards: u8,
-    /// The number of parity shards per slab. Defaults to 20.
-    pub parity_shards: u8,
-    /// The maximum number of concurrent shard uploads. Defaults to 15.
-    pub max_inflight: usize,
-
-    /// Optional channel to notify when each shard is uploaded.
-    /// This can be used to implement progress reporting.
-    pub shard_uploaded: Option<mpsc::UnboundedSender<()>>,
-}
-
-impl UploadOptions {
-    /// Returns the optimal data size per slab in bytes.
-    pub fn optimal_data_size(&self) -> u64 {
-        SECTOR_SIZE as u64 * self.data_shards as u64
-    }
-
-    /// Returns the total slab size including parity shards in bytes.
-    pub fn slab_size(&self) -> u64 {
-        SECTOR_SIZE as u64 * (self.data_shards as u64 + self.parity_shards as u64)
-    }
-
-    /// Validates the upload options and erasure coding parameters to ensure
-    /// sufficient durability.
-    ///
-    /// This checks that the redundancy ratio is between 1.5x and 4x and that
-    /// the probability of recovering the original data meets a minimum threshold
-    /// of 99.99%.
-    pub fn validate(&self) -> Result<(), UploadError> {
-        const MIN_REDUNDANCY: f64 = 1.5;
-        const MAX_REDUNDANCY: f64 = 4.0;
-        const RECOVERY_PROBABILITY: f64 = 0.75;
-        const MIN_RECOVERY_PROBABILITY: f64 = 99.99;
-        const MAX_TOTAL_SHARDS: u16 = 256;
-
-        if self.max_inflight == 0 {
-            return Err(UploadError::InvalidOptions(
-                "max_inflight must be greater than 0".into(),
-            ));
-        }
-
-        let data_shards = self.data_shards as u16;
-        let parity_shards = self.parity_shards as u16;
-        let total_shards = data_shards + parity_shards;
-
-        if data_shards == 0 {
-            return Err(UploadError::InvalidOptions(
-                "data shards cannot be zero".into(),
-            ));
-        } else if parity_shards == 0 {
-            return Err(UploadError::InvalidOptions(
-                "parity shards cannot be zero".into(),
-            ));
-        } else if total_shards > MAX_TOTAL_SHARDS {
-            return Err(UploadError::InvalidOptions(format!(
-                "total shards {total_shards} exceeds maximum of {MAX_TOTAL_SHARDS}"
-            )));
-        }
-
-        let redundancy = total_shards as f64 / data_shards as f64;
-        if redundancy < MIN_REDUNDANCY {
-            return Err(UploadError::InvalidOptions(format!(
-                "redundancy of {redundancy:.2} is too low"
-            )));
-        } else if redundancy > MAX_REDUNDANCY {
-            return Err(UploadError::InvalidOptions(format!(
-                "redundancy of {redundancy:.2} is too high"
-            )));
-        }
-
-        // Calculate recovery probability using the binomial CDF.
-        // P(X >= data_shards) where X ~ Binomial(total_shards, RECOVERY_PROBABILITY)
-        let q = 1.0 - RECOVERY_PROBABILITY;
-        let mut term = q.powi(total_shards as i32);
-        for i in 0..data_shards {
-            term *= (total_shards - i) as f64 / (i + 1) as f64 * (RECOVERY_PROBABILITY / q);
-        }
-        let mut sum = term;
-        for i in data_shards..total_shards {
-            term *= (total_shards - i) as f64 / (i + 1) as f64 * (RECOVERY_PROBABILITY / q);
-            sum += term;
-        }
-        let prob = sum * 100.0;
-        if prob < MIN_RECOVERY_PROBABILITY {
-            return Err(UploadError::InvalidOptions(format!(
-                "not enough redundancy {data_shards}-of-{total_shards}: recovery probability {:.2}% is below minimum threshold of {MIN_RECOVERY_PROBABILITY:.2}%",
-                (prob * 100.0).floor() / 100.0
-            )));
-        }
-        Ok(())
-    }
-}
-
-impl Default for UploadOptions {
-    fn default() -> Self {
-        Self {
-            data_shards: 10,
-            parity_shards: 20,
-            max_inflight: 15,
-            shard_uploaded: None,
-        }
-    }
 }
 
 struct ObjectUpload {
@@ -345,7 +239,7 @@ impl<T: Transport> Uploader<T> {
     async fn upload_slab_shard(
         shard: ShardUpload<T>,
         permit: OwnedSemaphorePermit,
-        progress_tx: Option<mpsc::UnboundedSender<()>>,
+        progress_callback: Option<ShardProgressCallback>,
         initial_host: (PublicKey, usize),
     ) -> Result<(usize, Sector), UploadError> {
         let (host_key, attempts) = initial_host;
@@ -359,13 +253,19 @@ impl<T: Transport> Uploader<T> {
                 biased;
                 Some(res) = tasks.join_next() => {
                     match res.unwrap() {
-                        Ok(sector) => {
+                        Ok((sector, elapsed)) => {
                             if sector.host_key != host_key {
                                 debug!("slab {} shard {} penalizing original host {}", shard.slab_index, shard.shard_index, host_key);
                                 shard.client.add_failure(host_key)
                             }
-                            if let Some(progress_tx) = progress_tx {
-                                let _ = progress_tx.send(());
+                            if let Some(progress_callback) = progress_callback {
+                                progress_callback(ShardProgress {
+                                    host_key: sector.host_key,
+                                    shard_index: shard.shard_index,
+                                    slab_index: shard.slab_index,
+                                    shard_size: SECTOR_SIZE,
+                                    elapsed,
+                                });
                             }
                             return Ok((shard.shard_index, sector));
                         }

--- a/sia_storage_ffi/src/builder.rs
+++ b/sia_storage_ffi/src/builder.rs
@@ -223,7 +223,7 @@ impl Builder {
     }
 
     /// Attempts to connect using the provided app key.
-    /// If the app key is valid, returns Some([SDK]), otherwise returns None.
+    /// If the app key is valid, returns Some([Sdk]), otherwise returns None.
     ///
     /// If you receive None, call [Builder::request_connection] to request a new connection.
     ///
@@ -296,7 +296,7 @@ impl Builder {
     }
 
     /// Registers the application with the indexer using the provided mnemonic.
-    /// Once registered, returns an [SDK] instance that can be used to interact
+    /// Once registered, returns an [Sdk] instance that can be used to interact
     /// with the indexer.
     ///
     /// # Arguments

--- a/sia_storage_ffi/src/builder.rs
+++ b/sia_storage_ffi/src/builder.rs
@@ -5,7 +5,7 @@ use sia_core::signing::Signature;
 use sia_storage::{self, Hash256};
 use thiserror::Error;
 
-use crate::{AppMeta, SDK, spawn};
+use crate::{AppMeta, Sdk, spawn};
 
 #[derive(Debug, Error, uniffi::Error)]
 #[uniffi(flat_error)]
@@ -229,11 +229,11 @@ impl Builder {
     ///
     /// # Arguments
     /// * `app_key` - The application key used for authentication.
-    pub async fn connected(&self, app_key: Arc<AppKey>) -> Result<Option<Arc<SDK>>, BuilderError> {
+    pub async fn connected(&self, app_key: Arc<AppKey>) -> Result<Option<Arc<Sdk>>, BuilderError> {
         self.with_state_transition(|state| async move {
             match state {
                 BuilderState::Disconnected(builder) => match builder.connected(&app_key.0).await? {
-                    Some(sdk) => Ok((BuilderState::Finalized, Some(Arc::new(SDK { inner: sdk })))),
+                    Some(sdk) => Ok((BuilderState::Finalized, Some(Arc::new(Sdk { inner: sdk })))),
                     None => Ok((BuilderState::Disconnected(builder), None)),
                 },
                 _ => Err(BuilderError::InvalidState),
@@ -301,12 +301,12 @@ impl Builder {
     ///
     /// # Arguments
     /// * `mnemonic` - The user's mnemonic phrase used to derive the application key.
-    pub async fn register(&self, mnemonic: String) -> Result<Arc<SDK>, BuilderError> {
+    pub async fn register(&self, mnemonic: String) -> Result<Arc<Sdk>, BuilderError> {
         self.with_state_transition(|state| async move {
             match state {
                 BuilderState::Approved(builder) => {
                     let sdk = builder.register(&mnemonic).await?;
-                    Ok((BuilderState::Finalized, Arc::new(SDK { inner: sdk })))
+                    Ok((BuilderState::Finalized, Arc::new(Sdk { inner: sdk })))
                 }
                 _ => Err(BuilderError::InvalidState),
             }

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -45,7 +45,7 @@ pub trait ProgressCallback: Send + Sync {
     fn progress(&self, progress: ShardProgress);
 }
 
-/// Information about a successfully uploaded shard.
+/// Information about a successfully uploaded or downloaded shard.
 #[derive(uniffi::Record)]
 pub struct ShardProgress {
     pub host_key: String,
@@ -773,6 +773,7 @@ pub struct DownloadOptions {
     pub length: Option<u64>,
 
     /// Optional callback to report download progress.
+    #[uniffi(default = None)]
     pub shard_downloaded: Option<Arc<dyn ProgressCallback>>,
 }
 

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -41,8 +41,18 @@ where
 }
 
 #[uniffi::export(with_foreign)]
-pub trait UploadProgressCallback: Send + Sync {
-    fn progress(&self, uploaded: u64, encoded_size: u64);
+pub trait ProgressCallback: Send + Sync {
+    fn progress(&self, progress: ShardProgress);
+}
+
+/// Information about a successfully uploaded shard.
+#[derive(uniffi::Record)]
+pub struct ShardProgress {
+    pub host_key: String,
+    pub shard_size: u64,
+    pub shard_index: u32,
+    pub slab_index: u32,
+    pub elapsed_ms: u64,
 }
 
 #[derive(Debug, Error, uniffi::Error)]
@@ -712,38 +722,93 @@ impl Download {
 /// Provides options for an upload operation.
 #[derive(uniffi::Record)]
 pub struct UploadOptions {
-    #[uniffi(default = 10)]
-    pub max_inflight: u8,
-    #[uniffi(default = 10)]
-    pub data_shards: u8,
-    #[uniffi(default = 20)]
-    pub parity_shards: u8,
+    #[uniffi(default = None)]
+    pub max_inflight: Option<u32>,
+
+    #[uniffi(default = None)]
+    pub data_shards: Option<u8>,
+
+    #[uniffi(default = None)]
+    pub parity_shards: Option<u8>,
 
     /// Optional callback to report upload progress.
-    /// The callback will be called with the number of bytes uploaded
-    /// and the total encoded size of the upload.
     #[uniffi(default = None)]
-    pub progress_callback: Option<Arc<dyn UploadProgressCallback>>,
+    pub shard_uploaded: Option<Arc<dyn ProgressCallback>>,
+}
+
+impl From<UploadOptions> for sia_storage::UploadOptions {
+    fn from(val: UploadOptions) -> Self {
+        let mut options = sia_storage::UploadOptions::default();
+        options.max_inflight = val
+            .max_inflight
+            .map(|v| v as usize)
+            .unwrap_or(options.max_inflight);
+        options.data_shards = val.data_shards.unwrap_or(options.data_shards);
+        options.parity_shards = val.parity_shards.unwrap_or(options.parity_shards);
+        options.shard_uploaded =
+            val.shard_uploaded
+                .map(|callback| -> sia_storage::ShardProgressCallback {
+                    Arc::new(move |p: sia_storage::ShardProgress| {
+                        callback.progress(ShardProgress {
+                            host_key: p.host_key.to_string(),
+                            shard_size: p.shard_size as u64,
+                            shard_index: p.shard_index as u32,
+                            slab_index: p.slab_index as u32,
+                            elapsed_ms: p.elapsed.as_millis() as u64,
+                        });
+                    })
+                });
+        options
+    }
 }
 
 /// Provides options for a download operation.
 #[derive(uniffi::Record)]
 pub struct DownloadOptions {
-    #[uniffi(default = 10)]
-    pub max_inflight: u8,
-    #[uniffi(default = 0)]
-    pub offset: u64,
+    #[uniffi(default = None)]
+    pub max_inflight: Option<u8>,
+    #[uniffi(default = None)]
+    pub offset: Option<u64>,
     #[uniffi(default = None)]
     pub length: Option<u64>,
+
+    /// Optional callback to report download progress.
+    pub shard_downloaded: Option<Arc<dyn ProgressCallback>>,
+}
+
+impl From<DownloadOptions> for sia_storage::DownloadOptions {
+    fn from(val: DownloadOptions) -> Self {
+        let mut options = sia_storage::DownloadOptions::default();
+        options.max_inflight = val
+            .max_inflight
+            .map(|v| v as usize)
+            .unwrap_or(options.max_inflight);
+        options.offset = val.offset.unwrap_or(options.offset);
+        options.length = val.length;
+        options.shard_downloaded =
+            val.shard_downloaded
+                .map(|callback| -> sia_storage::ShardProgressCallback {
+                    Arc::new(move |p: sia_storage::ShardProgress| {
+                        callback.progress(ShardProgress {
+                            host_key: p.host_key.to_string(),
+                            shard_size: p.shard_size as u64,
+                            shard_index: p.shard_index as u32,
+                            slab_index: p.slab_index as u32,
+                            elapsed_ms: p.elapsed.as_millis() as u64,
+                        });
+                    })
+                });
+        options
+    }
 }
 
 #[derive(uniffi::Object)]
-pub struct SDK {
-    inner: sia_storage::SDK,
+pub struct Sdk {
+    inner: sia_storage::Sdk,
 }
 
 #[uniffi::export]
-impl SDK {
+impl Sdk {
     /// Returns the application key used by the SDK.
     ///
     /// This should be kept secret and secure. Applications
@@ -764,36 +829,14 @@ impl SDK {
     pub async fn upload_packed(&self, options: UploadOptions) -> PackedUpload {
         let sdk = self.inner.clone();
         let (action_tx, mut action_rx) = mpsc::channel(10);
-        let slab_size = options.data_shards as usize * SECTOR_SIZE;
+        let options: sia_storage::UploadOptions = options.into();
+        let slab_size = options.data_shards as u64 * SECTOR_SIZE as u64;
         let length = Arc::new(AtomicU64::new(0));
         let closed = Arc::new(AtomicBool::new(false));
 
         let task_length = length.clone();
         let upload_task = spawn(async move {
-            let progress_tx = if let Some(callback) = options.progress_callback {
-                let total_shards = options.data_shards as u64 + options.parity_shards as u64;
-                let slab_size = total_shards * SECTOR_SIZE as u64;
-                let (tx, mut rx) = mpsc::unbounded_channel();
-                tokio::spawn(async move {
-                    let mut sectors: u64 = 0;
-                    while rx.recv().await.is_some() {
-                        sectors += 1;
-                        let size = sectors * SECTOR_SIZE as u64;
-                        let slabs_size = sectors.div_ceil(total_shards) * slab_size;
-                        callback.progress(size, slabs_size);
-                    }
-                });
-                Some(tx)
-            } else {
-                None
-            };
-            let mut packed_upload = sdk.upload_packed(sia_storage::UploadOptions {
-                max_inflight: options.max_inflight as usize,
-                data_shards: options.data_shards,
-                parity_shards: options.parity_shards,
-                shard_uploaded: progress_tx,
-            });
-
+            let mut packed_upload = sdk.upload_packed(options);
             while let Some(action) = action_rx.recv().await {
                 match action {
                     PackedUploadAction::Add(reader, add_tx) => {
@@ -818,7 +861,7 @@ impl SDK {
         PackedUpload {
             upload_task,
             tx: action_tx,
-            slab_size: slab_size as u64,
+            slab_size,
             length,
             closed,
         }
@@ -849,35 +892,7 @@ impl SDK {
         let obj = object.object();
         spawn(async move {
             let r = FFIReader::new(r);
-            let progress_tx = if let Some(callback) = options.progress_callback {
-                let total_shards = options.data_shards as u64 + options.parity_shards as u64;
-                let slab_size = total_shards * SECTOR_SIZE as u64;
-                let (tx, mut rx) = mpsc::unbounded_channel();
-                tokio::spawn(async move {
-                    let mut sectors: u64 = 0;
-                    while rx.recv().await.is_some() {
-                        sectors += 1;
-                        let size = sectors * SECTOR_SIZE as u64;
-                        let slabs_size = sectors.div_ceil(total_shards) * slab_size;
-                        callback.progress(size, slabs_size);
-                    }
-                });
-                Some(tx)
-            } else {
-                None
-            };
-            let obj = sdk
-                .upload(
-                    obj,
-                    r,
-                    sia_storage::UploadOptions {
-                        max_inflight: options.max_inflight as usize,
-                        data_shards: options.data_shards,
-                        parity_shards: options.parity_shards,
-                        shard_uploaded: progress_tx,
-                    },
-                )
-                .await?;
+            let obj = sdk.upload(obj, r, options.into()).await?;
             Ok(Arc::new(PinnedObject {
                 inner: Arc::new(Mutex::new(obj)),
             }))
@@ -895,14 +910,7 @@ impl SDK {
         // Enter the runtime so Download::new's spawned recovery tasks have a
         // reactor in scope.
         let _guard = RUNTIME.handle().enter();
-        let reader = self.inner.download(
-            &object.object(),
-            sia_storage::DownloadOptions {
-                offset: options.offset,
-                length: options.length,
-                max_inflight: options.max_inflight as usize,
-            },
-        )?;
+        let reader = self.inner.download(&object.object(), options.into())?;
         Ok(Download {
             inner: Arc::new(tokio::sync::Mutex::new(Some(reader))),
             cancel: tokio_util::sync::CancellationToken::new(),

--- a/sia_storage_napi/examples/benchmark.mjs
+++ b/sia_storage_napi/examples/benchmark.mjs
@@ -84,7 +84,11 @@ async function main() {
   // Upload the data.
   console.log(`Uploading ${formatBytes(size)} of random data...`);
   const uploadStart = performance.now();
-  const obj = await sdk.upload(new PinnedObject(), new Blob([data]).stream(), {});
+  const obj = await sdk.upload(new PinnedObject(), new Blob([data]).stream(), {
+    onShardUploaded: (progress) => {
+      console.log(progress);
+    },
+  });
   const uploadMs = performance.now() - uploadStart;
 
   // Pin the object.
@@ -99,7 +103,11 @@ async function main() {
   let lastChunkTime = null;
 
   const downloadStart = performance.now();
-  const dlStream = sdk.download(obj, {});
+  const dlStream = sdk.download(obj, {
+    onShardDownloaded: (progress) => {
+      console.log(progress);
+    },
+  });
   for await (const chunk of dlStream) {
     const now = performance.now();
     if (ttfb === null) {

--- a/sia_storage_napi/src/builder.rs
+++ b/sia_storage_napi/src/builder.rs
@@ -5,7 +5,7 @@ use napi_derive::napi;
 use sia_core::signing::Signature;
 use sia_storage::Hash256;
 
-use crate::{AppMeta, Sdk};
+use crate::{AppMetadata, Sdk};
 
 /// An AppKey is used to sign requests to the indexer.
 ///
@@ -119,7 +119,7 @@ impl Builder {
 impl Builder {
     /// Creates a new SDK builder with the provided indexer URL.
     #[napi(constructor)]
-    pub fn new(indexer_url: String, app_meta: AppMeta) -> Result<Self> {
+    pub fn new(indexer_url: String, app_meta: AppMetadata) -> Result<Self> {
         if app_meta.id.len() != 32 {
             return Err(Error::from_reason("app ID must be 32 bytes"));
         }

--- a/sia_storage_napi/src/lib.rs
+++ b/sia_storage_napi/src/lib.rs
@@ -21,7 +21,7 @@ pub use logging::*;
 
 /// Metadata about an application connecting to the indexer.
 #[napi(object)]
-pub struct AppMeta {
+pub struct AppMetadata {
     pub id: Buffer,
     pub name: String,
     pub description: String,
@@ -317,7 +317,7 @@ pub struct ShardProgress {
     pub shard_size: u32,
     pub shard_index: u32,
     pub slab_index: u32,
-    pub elapsed: f64,
+    pub elapsed_ms: f64,
 }
 
 /// A Send-safe wrapper around a JS callback that converts it into a
@@ -350,7 +350,7 @@ impl SendableCallback<ShardProgress> {
                     shard_size: p.shard_size as u32,
                     shard_index: p.shard_index as u32,
                     slab_index: p.slab_index as u32,
-                    elapsed: p.elapsed.as_millis() as f64,
+                    elapsed_ms: p.elapsed.as_millis() as f64,
                 },
                 ThreadsafeFunctionCallMode::NonBlocking,
             );

--- a/sia_storage_napi/src/lib.rs
+++ b/sia_storage_napi/src/lib.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
+use sia_core::rhp4::SECTOR_SIZE;
 use sia_core::signing::{PublicKey, Signature};
 use sia_core::types::{self, Hash256, HexParseError};
 use std::str::FromStr;
@@ -665,7 +666,7 @@ impl Sdk {
         let length = Arc::new(AtomicU64::new(0));
         let closed = Arc::new(AtomicBool::new(false));
         let (action_tx, mut action_rx) = mpsc::channel(10);
-        let slab_size = sia_storage::encoded_size(1, options.data_shards, options.parity_shards);
+        let slab_size = SECTOR_SIZE as u64 * options.data_shards as u64;
         let task_length = length.clone();
         let upload_task = spawn(async move {
             let mut packed_upload = sdk.upload_packed(options);

--- a/sia_storage_napi/src/lib.rs
+++ b/sia_storage_napi/src/lib.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, Utc};
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
-use sia_core::rhp4::SECTOR_SIZE;
 use sia_core::signing::{PublicKey, Signature};
 use sia_core::types::{self, Hash256, HexParseError};
 use std::str::FromStr;
@@ -310,20 +309,132 @@ impl From<sia_storage::Account> for Account {
     }
 }
 
-/// Upload options.
+/// Progress information about a successfully uploaded or downloaded shard.
 #[napi(object)]
+pub struct ShardProgress {
+    pub host_key: String,
+    pub shard_size: u32,
+    pub shard_index: u32,
+    pub slab_index: u32,
+    pub elapsed: f64,
+}
+
+/// A Send-safe wrapper around a JS callback that converts it into a
+/// `ThreadsafeFunction` during napi parameter extraction.
+pub struct SendableCallback<T: ToNapiValue + 'static> {
+    pub(crate) inner: ThreadsafeFunction<T, (), T, napi::Status, false, true>,
+}
+
+impl<T: ToNapiValue + 'static> FromNapiValue for SendableCallback<T> {
+    unsafe fn from_napi_value(
+        env: napi::sys::napi_env,
+        value: napi::sys::napi_value,
+    ) -> Result<Self> {
+        let func = unsafe { Function::<'static, T, ()>::from_napi_value(env, value)? };
+        let callback = func
+            .build_threadsafe_function()
+            .weak::<true>()
+            .build()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(Self { inner: callback })
+    }
+}
+
+impl SendableCallback<ShardProgress> {
+    fn into_shard_callback(self) -> sia_storage::ShardProgressCallback {
+        Arc::new(move |p: sia_storage::ShardProgress| {
+            self.inner.call(
+                ShardProgress {
+                    host_key: p.host_key.to_string(),
+                    shard_size: p.shard_size as u32,
+                    shard_index: p.shard_index as u32,
+                    slab_index: p.slab_index as u32,
+                    elapsed: p.elapsed.as_millis() as f64,
+                },
+                ThreadsafeFunctionCallMode::NonBlocking,
+            );
+        })
+    }
+}
+
+/// Upload options.
+#[napi(object, object_to_js = false)]
+#[derive(Default)]
 pub struct UploadOptions {
-    pub max_inflight: Option<u8>,
+    pub max_inflight: Option<u32>,
     pub data_shards: Option<u8>,
     pub parity_shards: Option<u8>,
+    #[napi(ts_type = "(progress: ShardProgress) => void")]
+    pub on_shard_uploaded: Option<SendableCallback<ShardProgress>>,
+}
+
+impl From<UploadOptions> for sia_storage::UploadOptions {
+    fn from(val: UploadOptions) -> Self {
+        let mut options = sia_storage::UploadOptions::default();
+        options.data_shards = val.data_shards.unwrap_or(options.data_shards);
+        options.parity_shards = val.parity_shards.unwrap_or(options.parity_shards);
+        options.max_inflight = val
+            .max_inflight
+            .map(|v| v as usize)
+            .unwrap_or(options.max_inflight);
+        options.shard_uploaded = val.on_shard_uploaded.map(|cb| cb.into_shard_callback());
+        options
+    }
+}
+
+/// A Send-safe wrapper around `UploadOptions` that converts the JS callback
+/// into a `ThreadsafeFunction` during napi parameter extraction.
+pub struct SendableUploadOptions(pub(crate) sia_storage::UploadOptions);
+
+impl FromNapiValue for SendableUploadOptions {
+    unsafe fn from_napi_value(
+        env: napi::sys::napi_env,
+        value: napi::sys::napi_value,
+    ) -> Result<Self> {
+        let opts = unsafe { UploadOptions::from_napi_value(env, value)? };
+        Ok(Self(opts.into()))
+    }
 }
 
 /// Download options.
-#[napi(object)]
+#[napi(object, object_to_js = false)]
 pub struct DownloadOptions {
     pub max_inflight: Option<u8>,
     pub offset: Option<BigInt>,
     pub length: Option<BigInt>,
+    #[napi(ts_type = "(progress: ShardProgress) => void")]
+    pub on_shard_downloaded: Option<SendableCallback<ShardProgress>>,
+}
+
+impl TryFrom<DownloadOptions> for sia_storage::DownloadOptions {
+    type Error = napi::Error;
+
+    fn try_from(val: DownloadOptions) -> Result<Self> {
+        let mut options = sia_storage::DownloadOptions::default();
+        if let Some(max_inflight) = val.max_inflight {
+            options.max_inflight = max_inflight as usize;
+        }
+        if let Some(offset) = val.offset {
+            let (signed, offset, lossless) = offset.get_u64();
+            if signed {
+                return Err(Error::from_reason("offset must be non-negative"));
+            } else if !lossless {
+                return Err(Error::from_reason("offset too large"));
+            }
+            options.offset = offset;
+        }
+        if let Some(length) = val.length {
+            let (signed, length, lossless) = length.get_u64();
+            if signed {
+                return Err(Error::from_reason("length must be non-negative"));
+            } else if !lossless {
+                return Err(Error::from_reason("length too large"));
+            }
+            options.length = Some(length);
+        }
+        options.shard_downloaded = val.on_shard_downloaded.map(|cb| cb.into_shard_callback());
+        Ok(options)
+    }
 }
 
 /// An object pinned to an indexer.
@@ -427,33 +538,6 @@ impl PinnedObject {
     pub fn updated_at(&self) -> DateTime<Utc> {
         *self.inner.lock().unwrap().updated_at()
     }
-}
-
-/// Wires an optional JS progress callback into a `shard_uploaded` channel.
-/// Reports `(uploaded_bytes, encoded_size)` matching the FFI crate's
-/// `UploadProgressCallback::progress` signature.
-fn setup_progress_channel(
-    callback: Option<ThreadsafeFunction<(u64, u64)>>,
-    data_shards: u8,
-    parity_shards: u8,
-) -> Option<mpsc::UnboundedSender<()>> {
-    let callback = callback?;
-    let total_shards = data_shards as u64 + parity_shards as u64;
-    let slab_size = total_shards * SECTOR_SIZE as u64;
-    let (tx, mut rx) = mpsc::unbounded_channel();
-    tokio::spawn(async move {
-        let mut sectors: u64 = 0;
-        while rx.recv().await.is_some() {
-            sectors += 1;
-            let size = sectors * SECTOR_SIZE as u64;
-            let slabs_size = sectors.div_ceil(total_shards) * slab_size;
-            callback.call(
-                Ok((size, slabs_size)),
-                ThreadsafeFunctionCallMode::NonBlocking,
-            );
-        }
-    });
-    Some(tx)
 }
 
 enum PackedUploadAction {
@@ -561,7 +645,7 @@ impl PackedUpload {
 
 #[napi]
 pub struct Sdk {
-    pub(crate) inner: sia_storage::SDK,
+    pub(crate) inner: sia_storage::Sdk,
 }
 
 #[napi]
@@ -574,32 +658,17 @@ impl Sdk {
 
     /// Creates a new packed upload for efficiently uploading multiple small
     /// objects together. Returns a `PackedUpload` handle.
-    #[napi(
-        ts_args_type = "options: UploadOptions, progressFn?: (uploaded: number, encodedSize: number) => void"
-    )]
-    pub async fn upload_packed(
-        &self,
-        options: UploadOptions,
-        progress_fn: Option<ThreadsafeFunction<(u64, u64)>>,
-    ) -> PackedUpload {
+    #[napi(ts_args_type = "options?: UploadOptions")]
+    pub fn upload_packed(&self, options: Option<SendableUploadOptions>) -> PackedUpload {
+        let options: sia_storage::UploadOptions = options.map(|o| o.0).unwrap_or_default();
         let sdk = self.inner.clone();
-        let data_shards = options.data_shards.unwrap_or(10);
-        let parity_shards = options.parity_shards.unwrap_or(20);
-        let max_inflight = options.max_inflight.unwrap_or(10);
-        let slab_size = data_shards as u64 * SECTOR_SIZE as u64;
         let length = Arc::new(AtomicU64::new(0));
         let closed = Arc::new(AtomicBool::new(false));
         let (action_tx, mut action_rx) = mpsc::channel(10);
-
+        let slab_size = sia_storage::encoded_size(1, options.data_shards, options.parity_shards);
         let task_length = length.clone();
-        let upload_task = tokio::spawn(async move {
-            let progress_tx = setup_progress_channel(progress_fn, data_shards, parity_shards);
-            let mut packed_upload = sdk.upload_packed(sia_storage::UploadOptions {
-                max_inflight: max_inflight as usize,
-                data_shards,
-                parity_shards,
-                shard_uploaded: progress_tx,
-            });
+        let upload_task = spawn(async move {
+            let mut packed_upload = sdk.upload_packed(options);
 
             while let Some(action) = action_rx.recv().await {
                 match action {
@@ -637,33 +706,19 @@ impl Sdk {
     /// pass the object returned from the earlier call. Appending data changes
     /// an object's ID. It must be re-pinned afterward and any references to
     /// the previous ID must be updated.
-    #[napi(
-        ts_args_type = "object: PinnedObject, stream: ReadableStream, options: UploadOptions, progressFn?: (uploaded: number, encodedSize: number) => void"
-    )]
+    #[napi(ts_args_type = "object: PinnedObject, stream: ReadableStream, options?: UploadOptions")]
     pub async fn upload(
         &self,
         object: &PinnedObject,
         stream: SendableReader,
-        options: UploadOptions,
-        progress_fn: Option<ThreadsafeFunction<(u64, u64)>>,
+        options: Option<SendableUploadOptions>,
     ) -> Result<PinnedObject> {
+        let options = options.map(|o| o.0).unwrap_or_default();
         let inner = object.inner.lock().unwrap().clone();
-        let data_shards = options.data_shards.unwrap_or(10);
-        let parity_shards = options.parity_shards.unwrap_or(20);
-        let max_inflight = options.max_inflight.unwrap_or(10);
-        let progress_tx = setup_progress_channel(progress_fn, data_shards, parity_shards);
         let obj = self
             .inner
-            .upload(
-                inner,
-                stream.0,
-                sia_storage::UploadOptions {
-                    max_inflight: max_inflight as usize,
-                    data_shards,
-                    parity_shards,
-                    shard_uploaded: progress_tx,
-                },
-            )
+            .clone()
+            .upload(inner, stream.0, options)
             .await
             .map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(PinnedObject {
@@ -678,32 +733,13 @@ impl Sdk {
         &self,
         env: Env,
         object: &PinnedObject,
-        options: DownloadOptions,
+        options: Option<DownloadOptions>,
     ) -> Result<ReadableStream<'_, Buffer>> {
         let object = object.object();
-
-        let mut download_opts = sia_storage::DownloadOptions::default();
-        if let Some(max_inflight) = options.max_inflight {
-            download_opts.max_inflight = max_inflight as usize;
-        }
-        if let Some(offset) = options.offset {
-            let (signed, offset, lossless) = offset.get_u64();
-            if signed {
-                return Err(Error::from_reason("offset must be non-negative"));
-            } else if !lossless {
-                return Err(Error::from_reason("offset too large"));
-            }
-            download_opts.offset = offset;
-        }
-        if let Some(length) = options.length {
-            let (signed, length, lossless) = length.get_u64();
-            if signed {
-                return Err(Error::from_reason("length must be non-negative"));
-            } else if !lossless {
-                return Err(Error::from_reason("length too large"));
-            }
-            download_opts.length = Some(length);
-        }
+        let download_opts: sia_storage::DownloadOptions = options
+            .map(|o| o.try_into())
+            .transpose()?
+            .unwrap_or_default();
 
         let stream = within_runtime_if_available(|| {
             let reader = self

--- a/sia_storage_wasm/examples/main.js
+++ b/sia_storage_wasm/examples/main.js
@@ -1,9 +1,7 @@
 import init, {
   Builder,
-  set_log_level,
-  generate_recovery_phrase,
-  validate_recovery_phrase,
-  calculate_encoded_size,
+  setLogLevel,
+  generateRecoveryPhrase,
   PinnedObject,
 } from './pkg/sia_storage_wasm.js';
 
@@ -47,16 +45,7 @@ function askUser(label) {
 
 async function main() {
   await init();
-  set_log_level('debug');
-
-  // -- offline utilities --
-  const phrase = generate_recovery_phrase();
-  log('Recovery phrase:', phrase);
-  validate_recovery_phrase(phrase);
-  log('Phrase is valid');
-
-  const encoded = calculate_encoded_size(1024, 10, 20);
-  log('Encoded size of 1024 bytes (10/20):', encoded);
+  setLogLevel('info');
 
   // -- builder flow --
   const builder = new Builder(INDEXER_URL, {
@@ -71,7 +60,7 @@ async function main() {
   await builder.waitForApproval();
 
   const mnemonic = await askUser('Enter mnemonic (or leave empty to generate new):');
-  const phrase2 = mnemonic || generate_recovery_phrase();
+  const phrase2 = mnemonic || generateRecoveryPhrase();
   if (!mnemonic) log('Generated mnemonic:', phrase2);
 
   const sdk = await builder.register(phrase2);
@@ -83,9 +72,9 @@ async function main() {
   log(`\nUploading ${(uploadSize / 1024 / 1024).toFixed(1)} MiB of random data...`);
 
   const uploadStart = performance.now();
-  const obj = await sdk.upload(new Blob([uploadData]).stream(), new PinnedObject(), {
-    onProgress: (uploaded, encodedSize) => {
-      log(`  progress: ${(uploaded / 1024 / 1024).toFixed(1)} MiB uploaded, ${(encodedSize / 1024 / 1024).toFixed(1)} MiB encoded`);
+  const obj = await sdk.upload(new PinnedObject(), new Blob([uploadData]).stream(),  {
+    onShardUploaded: (progress) => {
+      log(progress);
     },
   });
   const uploadElapsed = (performance.now() - uploadStart) / 1000;

--- a/sia_storage_wasm/src/lib.rs
+++ b/sia_storage_wasm/src/lib.rs
@@ -74,7 +74,7 @@ pub fn init() {
 /// set_log_level("debug"); // verbose — shows RPC calls, slab progress, etc.
 /// set_log_level("error"); // quiet — only fatal errors
 /// ```
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = "setLogLevel")]
 pub fn set_log_level(level: &str) {
     let filter = match level {
         "trace" => log::LevelFilter::Trace,
@@ -87,19 +87,19 @@ pub fn set_log_level(level: &str) {
 }
 
 /// Generates a new BIP-39 12-word recovery phrase.
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = "generateRecoveryPhrase")]
 pub fn generate_recovery_phrase() -> String {
     sia_storage::generate_recovery_phrase()
 }
 
 /// Validates a BIP-39 recovery phrase.
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = "validateRecoveryPhrase")]
 pub fn validate_recovery_phrase(phrase: &str) -> Result<(), JsError> {
     sia_storage::validate_recovery_phrase(phrase).map_err(to_js_err)
 }
 
 /// Calculates the encoded size of data after erasure coding.
-#[wasm_bindgen]
-pub fn calculate_encoded_size(data_size: f64, data_shards: u8, parity_shards: u8) -> f64 {
+#[wasm_bindgen(js_name = "encodedSize")]
+pub fn encoded_size(data_size: f64, data_shards: u8, parity_shards: u8) -> f64 {
     sia_storage::encoded_size(data_size as u64, data_shards, parity_shards) as f64
 }

--- a/sia_storage_wasm/src/sdk.rs
+++ b/sia_storage_wasm/src/sdk.rs
@@ -174,7 +174,7 @@ impl Sdk {
     /// re-pin and update any references to the old ID.
     ///
     /// ```js
-    /// const obj = await sdk.upload(file.stream(), new PinnedObject());
+    /// const obj = await sdk.upload(new PinnedObject(), file.stream());
     /// await sdk.pinObject(obj);
     /// ```
     pub async fn upload(
@@ -206,8 +206,7 @@ impl Sdk {
     }
 
     /// Generates a signed share URL for an object. Anyone with the URL can
-    /// download and decrypt the object until `valid_until_ms` (milliseconds
-    /// since epoch, i.e. `Date.getTime()`).
+    /// download and decrypt the object until `validUntil`.
     #[wasm_bindgen(js_name = "shareObject")]
     pub fn share_object(
         &self,

--- a/sia_storage_wasm/src/sdk.rs
+++ b/sia_storage_wasm/src/sdk.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use sia_core::types::Hash256;
 use sia_core::types::v2::Protocol;
-use sia_storage::{self, HostQuery as StorageHostQuery, SDK as StorageSdk};
+use sia_storage::{self, HostQuery as StorageHostQuery, Sdk as StorageSdk};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use wasm_bindgen::prelude::*;
 
@@ -12,7 +12,8 @@ use crate::object::PinnedObject;
 use crate::packed::PackedUpload;
 use crate::run_local;
 use crate::types::{
-    self, DownloadOptions, HostQuery, ObjectEvent, ObjectsCursor, UploadOptions, ms_to_chrono,
+    self, HostQuery, ObjectEvent, ObjectsCursor, download_options_from_js, ms_to_chrono,
+    upload_options_from_js,
 };
 
 /// The main Sia storage SDK. Provides methods for uploading, downloading,
@@ -153,14 +154,15 @@ impl Sdk {
     ///   console.log('got', chunk.length, 'bytes');
     /// }
     /// ```
+    #[wasm_bindgen(unchecked_return_type = "ReadableStream")]
     pub fn download(
         &self,
         object: &PinnedObject,
-        options: Option<DownloadOptions>,
+        options: Option<JsValue>,
     ) -> Result<web_sys::ReadableStream, JsError> {
         const CHUNK_SIZE: usize = 1 << 18; // matches sia_storage chunk size for optimal performance
         let obj = object.0.clone();
-        let opts: sia_storage::DownloadOptions = options.map(|o| o.into()).unwrap_or_default();
+        let opts = options.map(download_options_from_js).unwrap_or_default();
         let download = self.inner.download(&obj, opts).map_err(to_js_err)?;
         Ok(wasm_streams::ReadableStream::from_async_read(download.compat(), CHUNK_SIZE).into_raw())
     }
@@ -177,16 +179,12 @@ impl Sdk {
     /// ```
     pub async fn upload(
         &self,
-        source: web_sys::ReadableStream,
         object: PinnedObject,
-        #[wasm_bindgen(unchecked_optional_param_type = "UploadOptions")] options: JsValue,
+        source: web_sys::ReadableStream,
+        options: Option<JsValue>,
     ) -> Result<PinnedObject, JsError> {
         let sdk = self.inner.clone();
-        let opts: sia_storage::UploadOptions = if options.is_undefined() || options.is_null() {
-            Default::default()
-        } else {
-            UploadOptions::from_js(options)?.into()
-        };
+        let opts = options.map(upload_options_from_js).unwrap_or_default();
         let obj = object.0;
         let reader = wasm_streams::ReadableStream::from_raw(source)
             .into_async_read()
@@ -202,15 +200,8 @@ impl Sdk {
     /// to avoid wasting storage. Call `add(data)` for each object, then
     /// `finalize()` to get the resulting `PinnedObject` handles.
     #[wasm_bindgen(js_name = "uploadPacked")]
-    pub fn upload_packed(
-        &self,
-        #[wasm_bindgen(unchecked_optional_param_type = "UploadOptions")] options: JsValue,
-    ) -> Result<PackedUpload, JsError> {
-        let opts: sia_storage::UploadOptions = if options.is_undefined() || options.is_null() {
-            Default::default()
-        } else {
-            UploadOptions::from_js(options)?.into()
-        };
+    pub fn upload_packed(&self, options: Option<JsValue>) -> Result<PackedUpload, JsError> {
+        let opts = options.map(upload_options_from_js).unwrap_or_default();
         Ok(PackedUpload::new(self.inner.upload_packed(opts)))
     }
 
@@ -253,3 +244,12 @@ impl Sdk {
             .map_err(to_js_err)
     }
 }
+
+#[wasm_bindgen(typescript_custom_section)]
+const _: &str = r#"
+interface Sdk {
+    download(object: PinnedObject, options?: DownloadOptions): ReadableStream;
+    upload(object: PinnedObject, source: ReadableStream, options?: UploadOptions): Promise<PinnedObject>;
+    uploadPacked(options?: UploadOptions): PackedUpload;
+}
+"#;

--- a/sia_storage_wasm/src/sdk.rs
+++ b/sia_storage_wasm/src/sdk.rs
@@ -44,7 +44,8 @@ impl Sdk {
         let a = run_local(async move { sdk.account().await })
             .await
             .map_err(to_js_err)?;
-        types::to_js(&a)
+        let wrapped: types::Account = a.into();
+        types::to_js(&wrapped)
     }
 
     /// Returns a list of usable hosts, optionally filtered by a HostQuery.

--- a/sia_storage_wasm/src/types.rs
+++ b/sia_storage_wasm/src/types.rs
@@ -4,6 +4,31 @@ use wasm_bindgen::prelude::*;
 use crate::helpers::to_js_err;
 use crate::object::PinnedObject;
 
+/// Progress information about a successfully uploaded or downloaded shard.
+#[derive(serde::Serialize, tsify::Tsify)]
+#[tsify(into_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct ShardProgress {
+    pub host_key: String,
+    pub shard_size: usize,
+    pub shard_index: usize,
+    pub slab_index: usize,
+    /// Elapsed time in milliseconds since the start of the upload or download.
+    pub elapsed: f64,
+}
+
+impl From<sia_storage::ShardProgress> for ShardProgress {
+    fn from(p: sia_storage::ShardProgress) -> Self {
+        Self {
+            host_key: p.host_key.to_string(),
+            shard_size: p.shard_size,
+            shard_index: p.shard_index,
+            slab_index: p.slab_index,
+            elapsed: p.elapsed.as_millis() as f64,
+        }
+    }
+}
+
 /// Application metadata deserialized from a plain JS object.
 #[derive(serde::Deserialize, tsify::Tsify)]
 #[tsify(from_wasm_abi)]
@@ -17,116 +42,80 @@ pub struct AppMetadata {
     pub callback_url: Option<String>,
 }
 
-/// Options for uploading data. Deserialized from a plain JS object.
-/// The `onProgress` callback is extracted separately since JS functions
-/// can't pass through serde.
-pub struct UploadOptions {
-    pub data_shards: Option<u8>,
-    pub parity_shards: Option<u8>,
-    pub max_inflight: Option<usize>,
-    pub on_progress: Option<js_sys::Function>,
-}
-
-// Manually generate the TS interface since tsify can't handle the mixed
-// serde + JS function field.
 #[wasm_bindgen(typescript_custom_section)]
 const _: &str = r#"
 export interface UploadOptions {
     dataShards?: number;
     parityShards?: number;
     maxInflight?: number;
-    onProgress?: (uploaded: number, encodedSize: number) => void;
+    onShardUploaded?: (progress: ShardProgress) => void;
 }
 "#;
 
-impl UploadOptions {
-    /// Deserializes from a JsValue, extracting the onProgress callback separately.
-    pub fn from_js(val: JsValue) -> Result<Self, JsError> {
-        use wasm_bindgen::JsCast;
-
-        // Extract the callback before deserializing the rest
-        let on_progress = js_sys::Reflect::get(&val, &"onProgress".into())
-            .ok()
-            .filter(|v| v.is_function())
-            .map(|v| v.unchecked_into::<js_sys::Function>());
-
-        #[derive(serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct Opts {
-            data_shards: Option<u8>,
-            parity_shards: Option<u8>,
-            max_inflight: Option<usize>,
-        }
-
-        let opts: Opts = serde_wasm_bindgen::from_value(val).map_err(to_js_err)?;
-        Ok(Self {
-            data_shards: opts.data_shards,
-            parity_shards: opts.parity_shards,
-            max_inflight: opts.max_inflight,
-            on_progress,
-        })
-    }
+fn shard_progress_callback(cb: js_sys::Function) -> sia_storage::ShardProgressCallback {
+    std::sync::Arc::new(move |p: sia_storage::ShardProgress| {
+        let progress: ShardProgress = p.into();
+        let js_val = serde_wasm_bindgen::to_value(&progress).unwrap_or(JsValue::UNDEFINED);
+        let _ = cb.call1(&JsValue::NULL, &js_val);
+    })
 }
 
-impl From<UploadOptions> for sia_storage::UploadOptions {
-    fn from(opts: UploadOptions) -> Self {
-        let mut merged = sia_storage::UploadOptions::default();
-        if let Some(v) = opts.data_shards {
-            merged.data_shards = v;
-        }
-        if let Some(v) = opts.parity_shards {
-            merged.parity_shards = v;
-        }
-        if let Some(v) = opts.max_inflight {
-            merged.max_inflight = v;
-        }
-        merged.shard_uploaded = opts.on_progress.map(|cb| {
-            let total_shards = merged.data_shards as u64 + merged.parity_shards as u64;
-            let slab_size = total_shards * sia_core::rhp4::SECTOR_SIZE as u64;
-            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-            tokio::task::spawn_local(async move {
-                let mut sectors: u64 = 0;
-                while rx.recv().await.is_some() {
-                    sectors += 1;
-                    let uploaded = sectors * sia_core::rhp4::SECTOR_SIZE as u64;
-                    let encoded = sectors.div_ceil(total_shards) * slab_size;
-                    let _ = cb.call2(
-                        &wasm_bindgen::JsValue::NULL,
-                        &wasm_bindgen::JsValue::from(uploaded as f64),
-                        &wasm_bindgen::JsValue::from(encoded as f64),
-                    );
-                }
-            });
-            tx
-        });
-        merged
-    }
+fn get_f64(obj: &js_sys::Object, key: &str) -> Option<f64> {
+    js_sys::Reflect::get(obj, &key.into())
+        .ok()
+        .and_then(|v| v.as_f64())
 }
 
-/// Options for downloading data.
-#[derive(serde::Deserialize, tsify::Tsify)]
-#[tsify(from_wasm_abi)]
-#[serde(rename_all = "camelCase")]
-pub struct DownloadOptions {
-    pub max_inflight: Option<usize>,
-    pub offset: Option<f64>,
-    pub length: Option<f64>,
+fn get_function(obj: &js_sys::Object, key: &str) -> Option<js_sys::Function> {
+    js_sys::Reflect::get(obj, &key.into())
+        .ok()
+        .and_then(|v| v.dyn_into::<js_sys::Function>().ok())
 }
 
-impl From<DownloadOptions> for sia_storage::DownloadOptions {
-    fn from(opts: DownloadOptions) -> Self {
-        let mut merged = sia_storage::DownloadOptions::default();
-        if let Some(v) = opts.max_inflight {
-            merged.max_inflight = v;
-        }
-        if let Some(v) = opts.offset {
-            merged.offset = v as u64;
-        }
-        if let Some(v) = opts.length {
-            merged.length = Some(v as u64);
-        }
-        merged
+pub(crate) fn upload_options_from_js(val: JsValue) -> sia_storage::UploadOptions {
+    let obj = js_sys::Object::from(val);
+    let mut options = sia_storage::UploadOptions::default();
+    if let Some(v) = get_f64(&obj, "dataShards") {
+        options.data_shards = v as u8;
     }
+    if let Some(v) = get_f64(&obj, "parityShards") {
+        options.parity_shards = v as u8;
+    }
+    if let Some(v) = get_f64(&obj, "maxInflight") {
+        options.max_inflight = v as usize;
+    }
+    if let Some(cb) = get_function(&obj, "onShardUploaded") {
+        options.shard_uploaded = Some(shard_progress_callback(cb));
+    }
+    options
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const _: &str = r#"
+export interface DownloadOptions {
+    maxInflight?: number;
+    offset?: number;
+    length?: number;
+    onShardDownloaded?: (progress: ShardProgress) => void;
+}
+"#;
+
+pub(crate) fn download_options_from_js(val: JsValue) -> sia_storage::DownloadOptions {
+    let obj = js_sys::Object::from(val);
+    let mut options = sia_storage::DownloadOptions::default();
+    if let Some(v) = get_f64(&obj, "maxInflight") {
+        options.max_inflight = v as usize;
+    }
+    if let Some(v) = get_f64(&obj, "offset") {
+        options.offset = v as u64;
+    }
+    if let Some(v) = get_f64(&obj, "length") {
+        options.length = Some(v as u64);
+    }
+    if let Some(cb) = get_function(&obj, "onShardDownloaded") {
+        options.shard_downloaded = Some(shard_progress_callback(cb));
+    }
+    options
 }
 
 /// Query parameters for filtering hosts.

--- a/sia_storage_wasm/src/types.rs
+++ b/sia_storage_wasm/src/types.rs
@@ -13,7 +13,7 @@ pub struct ShardProgress {
     pub shard_size: usize,
     pub shard_index: usize,
     pub slab_index: usize,
-    /// Elapsed time in milliseconds since the start of the upload or download.
+    /// Elapsed time in milliseconds since the start of the shard upload or download.
     pub elapsed: f64,
 }
 

--- a/sia_storage_wasm/src/types.rs
+++ b/sia_storage_wasm/src/types.rs
@@ -14,7 +14,7 @@ pub struct ShardProgress {
     pub shard_index: usize,
     pub slab_index: usize,
     /// Elapsed time in milliseconds since the start of the shard upload or download.
-    pub elapsed: f64,
+    pub elapsed_ms: f64,
 }
 
 impl From<sia_storage::ShardProgress> for ShardProgress {
@@ -24,7 +24,63 @@ impl From<sia_storage::ShardProgress> for ShardProgress {
             shard_size: p.shard_size,
             shard_index: p.shard_index,
             slab_index: p.slab_index,
-            elapsed: p.elapsed.as_millis() as f64,
+            elapsed_ms: p.elapsed.as_millis() as f64,
+        }
+    }
+}
+
+/// Application info registered with the indexer.
+#[derive(serde::Serialize, tsify::Tsify)]
+#[tsify(into_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct App {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub logo_url: Option<String>,
+    pub service_url: Option<String>,
+}
+
+impl From<sia_storage::App> for App {
+    fn from(a: sia_storage::App) -> Self {
+        Self {
+            id: a.id.to_string(),
+            name: a.name,
+            description: a.description,
+            logo_url: a.logo_url,
+            service_url: a.service_url,
+        }
+    }
+}
+
+/// Information about the user's account on the indexer.
+#[derive(serde::Serialize, tsify::Tsify)]
+#[tsify(into_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct Account {
+    pub account_key: String,
+    pub max_pinned_data: u64,
+    pub remaining_storage: u64,
+    pub pinned_data: u64,
+    pub pinned_size: u64,
+    pub ready: bool,
+    pub app: App,
+    #[tsify(type = "Date")]
+    #[serde(with = "serde_wasm_bindgen::preserve")]
+    pub last_used: js_sys::Date,
+}
+
+impl From<sia_storage::Account> for Account {
+    fn from(a: sia_storage::Account) -> Self {
+        Self {
+            account_key: a.account_key.to_string(),
+            max_pinned_data: a.max_pinned_data,
+            remaining_storage: a.remaining_storage,
+            pinned_data: a.pinned_data,
+            pinned_size: a.pinned_size,
+            ready: a.ready,
+            app: a.app.into(),
+            last_used: js_sys::Date::new(&JsValue::from(a.last_used.timestamp_millis() as f64)),
         }
     }
 }
@@ -225,25 +281,6 @@ export interface PinnedSlab {
     encryptionKey: string;
     minShards: number;
     sectors: Sector[];
-}
-
-export interface App {
-    id: string
-    name: string
-    description: string
-    serviceUrl?: string
-    logoUrl?: string
-}
-
-export interface Account {
-    accountKey: string;
-    maxPinnedData: number;
-    remainingStorage: number;
-    pinnedData: number;
-    pinnedSize: number;
-    ready: boolean;
-    app: App;
-    lastUsed: Date;
 }
 
 export interface Host {

--- a/sia_storage_wasm/src/types.rs
+++ b/sia_storage_wasm/src/types.rs
@@ -227,6 +227,14 @@ export interface PinnedSlab {
     sectors: Sector[];
 }
 
+export interface App {
+    id: string
+    name: string
+    description: string
+    serviceUrl?: string
+    logoUrl?: string
+}
+
 export interface Account {
     accountKey: string;
     maxPinnedData: number;
@@ -234,14 +242,8 @@ export interface Account {
     pinnedData: number;
     pinnedSize: number;
     ready: boolean;
-    app: {
-        id: string;
-        name: string;
-        description: string;
-        serviceUrl?: string;
-        logoUrl?: string;
-    };
-    lastUsed: string;
+    app: App;
+    lastUsed: Date;
 }
 
 export interface Host {


### PR DESCRIPTION
Replaces the upload progress channel with a callback on native. Adds a download progress callback.  Ensures all the bindings have the same callback shape.