### PR TITLE
Remove hardcoded rpc settings timeout when fetching prices

### DIFF
--- a/.changeset/removed_hardcoded_1s_timeout_for_rpc_settings_when_writing_and_reading_sectors.md
+++ b/.changeset/removed_hardcoded_1s_timeout_for_rpc_settings_when_writing_and_reading_sectors.md
@@ -1,0 +1,8 @@
+---
+sia_storage_ffi: patch
+sia_storage_wasm: patch
+sia_storage: patch
+sia_storage_napi: patch
+---
+
+# Removed hardcoded 1s timeout for RPC settings when writing and reading sectors

--- a/sia_storage/src/app_client.rs
+++ b/sia_storage/src/app_client.rs
@@ -1287,7 +1287,7 @@ mod tests {
                 &ephemeral_key,
                 &AppMetadata {
                     id: app_id,
-                    name: "name".into(),
+                    name: "name",
                     description: "description",
                     service_url: "https://service.com",
                     logo_url: Some("https://logo.com"),
@@ -1693,7 +1693,7 @@ mod tests {
                 .objects(
                     &app_key,
                     Some(ObjectsCursor {
-                        after: object.updated_at.into(),
+                        after: object.updated_at,
                         id: object.id(),
                     }),
                     Some(1)
@@ -1765,7 +1765,7 @@ mod tests {
                     length: 512,
                 },
             ],
-            encrypted_metadata: b"hello world!".to_vec().into(),
+            encrypted_metadata: b"hello world!".to_vec(),
             created_at: DateTime::<FixedOffset>::parse_from_rfc3339(
                 "2025-09-09T16:10:46.898399-07:00",
             )

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -527,28 +527,28 @@ impl<T: Transport> Hosts<T> {
         write_timeout: Duration,
     ) -> Result<Hash256, RPCError> {
         let host = self.host_endpoint(host_key)?;
-        let (prices, _) = Self::fetch_prices(
-            self.transport.clone(),
-            &self.price_cache,
-            &self.hosts,
-            &host,
-            Duration::from_secs(1),
-            false,
-        )
-        .await?;
         let start = Instant::now();
-        timeout(
-            write_timeout,
+        timeout(write_timeout, async {
+            let (prices, _) = Self::fetch_prices(
+                self.transport.clone(),
+                &self.price_cache,
+                &self.hosts,
+                &host,
+                write_timeout,
+                false,
+            )
+            .await?;
             self.transport
-                .write_sector(&host, prices, account_key, sector),
-        )
+                .write_sector(&host, prices, account_key, sector)
+                .await
+                .map_err(RPCError::Rhp)
+        })
         .await
         .inspect_err(|_| self.hosts.add_failure(host_key))?
         .inspect_err(|_| self.hosts.add_failure(host_key))
         .inspect(|_| {
             self.hosts.add_write_sample(host_key, start.elapsed());
         })
-        .map_err(RPCError::Rhp)
     }
 
     pub async fn read_sector(
@@ -561,28 +561,28 @@ impl<T: Transport> Hosts<T> {
         read_timeout: Duration,
     ) -> Result<bytes::Bytes, RPCError> {
         let host = self.host_endpoint(host_key)?;
-        let (prices, _) = Self::fetch_prices(
-            self.transport.clone(),
-            &self.price_cache,
-            &self.hosts,
-            &host,
-            Duration::from_secs(1),
-            false,
-        )
-        .await?;
         let start = Instant::now();
-        timeout(
-            read_timeout,
+        timeout(read_timeout, async {
+            let (prices, _) = Self::fetch_prices(
+                self.transport.clone(),
+                &self.price_cache,
+                &self.hosts,
+                &host,
+                read_timeout,
+                false,
+            )
+            .await?;
             self.transport
-                .read_sector(&host, prices, account_key, root, offset, length),
-        )
+                .read_sector(&host, prices, account_key, root, offset, length)
+                .await
+                .map_err(RPCError::Rhp)
+        })
         .await
         .inspect_err(|_| self.hosts.add_failure(host_key))?
         .inspect_err(|_| self.hosts.add_failure(host_key))
         .inspect(|_| {
             self.hosts.add_read_sample(host_key, start.elapsed());
         })
-        .map_err(RPCError::Rhp)
     }
 }
 

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -527,7 +527,6 @@ impl<T: Transport> Hosts<T> {
         write_timeout: Duration,
     ) -> Result<Hash256, RPCError> {
         let host = self.host_endpoint(host_key)?;
-        let start = Instant::now();
         timeout(write_timeout, async {
             let (prices, _) = Self::fetch_prices(
                 self.transport.clone(),
@@ -538,17 +537,18 @@ impl<T: Transport> Hosts<T> {
                 false,
             )
             .await?;
-            self.transport
+            let start = Instant::now();
+            let root = self
+                .transport
                 .write_sector(&host, prices, account_key, sector)
                 .await
-                .map_err(RPCError::Rhp)
+                .map_err(RPCError::Rhp)?;
+            self.hosts.add_write_sample(host_key, start.elapsed());
+            Ok(root)
         })
         .await
         .inspect_err(|_| self.hosts.add_failure(host_key))?
         .inspect_err(|_| self.hosts.add_failure(host_key))
-        .inspect(|_| {
-            self.hosts.add_write_sample(host_key, start.elapsed());
-        })
     }
 
     pub async fn read_sector(
@@ -561,7 +561,6 @@ impl<T: Transport> Hosts<T> {
         read_timeout: Duration,
     ) -> Result<bytes::Bytes, RPCError> {
         let host = self.host_endpoint(host_key)?;
-        let start = Instant::now();
         timeout(read_timeout, async {
             let (prices, _) = Self::fetch_prices(
                 self.transport.clone(),
@@ -572,17 +571,18 @@ impl<T: Transport> Hosts<T> {
                 false,
             )
             .await?;
-            self.transport
+            let start = Instant::now();
+            let data = self
+                .transport
                 .read_sector(&host, prices, account_key, root, offset, length)
                 .await
-                .map_err(RPCError::Rhp)
+                .map_err(RPCError::Rhp)?;
+            self.hosts.add_read_sample(host_key, start.elapsed());
+            Ok(data)
         })
         .await
         .inspect_err(|_| self.hosts.add_failure(host_key))?
         .inspect_err(|_| self.hosts.add_failure(host_key))
-        .inspect(|_| {
-            self.hosts.add_read_sample(host_key, start.elapsed());
-        })
     }
 }
 

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -542,13 +542,12 @@ impl<T: Transport> Hosts<T> {
                 .transport
                 .write_sector(&host, prices, account_key, sector)
                 .await
+                .inspect_err(|_| self.hosts.add_failure(host_key))
                 .map_err(RPCError::Rhp)?;
             self.hosts.add_write_sample(host_key, start.elapsed());
             Ok(root)
         })
-        .await
-        .inspect_err(|_| self.hosts.add_failure(host_key))?
-        .inspect_err(|_| self.hosts.add_failure(host_key))
+        .await?
     }
 
     pub async fn read_sector(
@@ -576,13 +575,12 @@ impl<T: Transport> Hosts<T> {
                 .transport
                 .read_sector(&host, prices, account_key, root, offset, length)
                 .await
+                .inspect_err(|_| self.hosts.add_failure(host_key))
                 .map_err(RPCError::Rhp)?;
             self.hosts.add_read_sample(host_key, start.elapsed());
             Ok(data)
         })
-        .await
-        .inspect_err(|_| self.hosts.add_failure(host_key))?
-        .inspect_err(|_| self.hosts.add_failure(host_key))
+        .await?
     }
 }
 

--- a/sia_storage/src/rhp4/mock.rs
+++ b/sia_storage/src/rhp4/mock.rs
@@ -142,9 +142,8 @@ impl Transport for Client {
         // per-sector decreasing delay (used to simulate out-of-order chunk completion)
         let read_delay = {
             let mut delays = self.read_delays.write().unwrap();
-            delays.get(&root).copied().map(|delay| {
+            delays.get(&root).copied().inspect(|&delay| {
                 delays.insert(root, delay / 2);
-                delay
             })
         };
         if let Some(delay) = read_delay {


### PR DESCRIPTION
Found this causes issues when dealing with slow hosts or bad connections.