### PR TITLE
Concurrent dials

### DIFF
--- a/.changeset/deduplicate_concurrent_dials_for_rhp4_clients.md
+++ b/.changeset/deduplicate_concurrent_dials_for_rhp4_clients.md
@@ -1,0 +1,5 @@
+---
+sia_storage: patch
+---
+
+# Deduplicate concurrent dials for RHP4 clients.

--- a/.changeset/enforce_chromes_64_concurrent_pending_connections_limit_in_webtransport_client.md
+++ b/.changeset/enforce_chromes_64_concurrent_pending_connections_limit_in_webtransport_client.md
@@ -1,0 +1,5 @@
+---
+sia_storage: patch
+---
+
+# Enforce Chrome's 64 concurrent pending connections limit in WebTransport client.

--- a/sia_storage/src/encryption.rs
+++ b/sia_storage/src/encryption.rs
@@ -222,12 +222,7 @@ mod test {
         EncryptionKey::from(key)
     }
 
-    fn encrypt_shards(
-        key: &EncryptionKey,
-        shard_start: u8,
-        offset: usize,
-        shards: &mut Vec<Vec<u8>>,
-    ) {
+    fn encrypt_shards(key: &EncryptionKey, shard_start: u8, offset: usize, shards: &mut [Vec<u8>]) {
         shards.iter_mut().enumerate().for_each(|(i, shard)| {
             encrypt_shard(key, shard_start + i as u8, offset, shard);
         });

--- a/sia_storage/src/rhp4/siamux.rs
+++ b/sia_storage/src/rhp4/siamux.rs
@@ -111,13 +111,16 @@ impl Client {
     }
 
     async fn host_stream(&self, host: &HostEndpoint) -> Result<Stream, ConnectError> {
-        let cell = self
-            .open_conns
-            .write()
-            .unwrap()
-            .entry(host.public_key)
-            .or_insert_with(|| Arc::new(OnceCell::new()))
-            .clone();
+        let cell = if let Some(cell) = self.open_conns.read().unwrap().get(&host.public_key) {
+            cell.clone()
+        } else {
+            self.open_conns
+                .write()
+                .unwrap()
+                .entry(host.public_key)
+                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .clone()
+        };
         let conn = cell
             .get_or_try_init(|| async {
                 let mux = timeout(Duration::from_secs(5), self.new_conn(host))

--- a/sia_storage/src/rhp4/siamux.rs
+++ b/sia_storage/src/rhp4/siamux.rs
@@ -9,6 +9,7 @@ use std::num::ParseIntError;
 use std::sync::{Arc, RwLock};
 use thiserror::{self, Error};
 use tokio::net::{TcpStream, lookup_host};
+use tokio::sync::OnceCell;
 
 use crate::rhp4::HostEndpoint;
 use crate::time::Duration;
@@ -48,9 +49,11 @@ pub enum ConnectError {
     NoEndpoint,
 }
 
+type ConnCell = Arc<OnceCell<Arc<Mux>>>;
+
 #[derive(Clone)]
 pub struct Client {
-    open_conns: Arc<RwLock<HashMap<PublicKey, Arc<Mux>>>>,
+    open_conns: Arc<RwLock<HashMap<PublicKey, ConnCell>>>,
 }
 
 impl Default for Client {
@@ -64,11 +67,6 @@ impl Client {
         Self {
             open_conns: Arc::new(RwLock::new(HashMap::new())),
         }
-    }
-
-    fn existing_conn(&self, host: &PublicKey) -> Option<Arc<Mux>> {
-        let cache = self.open_conns.read().unwrap();
-        cache.get(host).cloned()
     }
 
     async fn new_conn(&self, host: &HostEndpoint) -> Result<Mux, ConnectError> {
@@ -113,26 +111,25 @@ impl Client {
     }
 
     async fn host_stream(&self, host: &HostEndpoint) -> Result<Stream, ConnectError> {
-        let conn = match self.existing_conn(&host.public_key) {
-            Some(conn) => {
-                debug!("reusing existing siamux connection to {}", host.public_key);
-                conn
-            }
-            None => {
-                let new_conn = timeout(Duration::from_secs(5), self.new_conn(host))
+        let cell = self
+            .open_conns
+            .write()
+            .unwrap()
+            .entry(host.public_key)
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone();
+        let conn = cell
+            .get_or_try_init(|| async {
+                let mux = timeout(Duration::from_secs(5), self.new_conn(host))
                     .await
                     .inspect_err(|e| {
                         debug!("siamux connection to {} timed out: {e}", host.public_key);
                     })??;
-                let new_conn = Arc::new(new_conn);
-                self.open_conns
-                    .write()
-                    .unwrap()
-                    .insert(host.public_key, new_conn.clone());
                 debug!("created new siamux connection to {}", host.public_key);
-                new_conn
-            }
-        };
+                Ok::<_, ConnectError>(Arc::new(mux))
+            })
+            .await?
+            .clone();
 
         let stream = conn.dial_stream().inspect_err(|_| {
             self.open_conns.write().unwrap().remove(&host.public_key);

--- a/sia_storage/src/rhp4/web_transport.rs
+++ b/sia_storage/src/rhp4/web_transport.rs
@@ -211,12 +211,15 @@ impl Client {
     /// turns out to be stale, the RPC method will call [`evict`] and the
     /// next call will establish a fresh connection.
     async fn connection(&self, host: &HostEndpoint) -> Result<Rc<Connection>, Error> {
-        let cell = self
-            .pool
-            .borrow_mut()
-            .entry(host.public_key)
-            .or_insert_with(|| Rc::new(OnceCell::new()))
-            .clone();
+        let cell = if let Some(cell) = self.pool.borrow().get(&host.public_key) {
+            cell.clone()
+        } else {
+            self.pool
+                .borrow_mut()
+                .entry(host.public_key)
+                .or_insert_with(|| Rc::new(OnceCell::new()))
+                .clone()
+        };
         let conn = cell
             .get_or_try_init(|| async {
                 // Gate concurrent dials to stay under Chrome's pending-connection cap.

--- a/sia_storage/src/rhp4/web_transport.rs
+++ b/sia_storage/src/rhp4/web_transport.rs
@@ -24,6 +24,7 @@ use sia_core::signing::{PrivateKey, PublicKey};
 use sia_core::types::Hash256;
 use sia_core::types::v2::Protocol;
 use tokio::io::{AsyncRead, ReadBuf};
+use tokio::sync::{OnceCell, Semaphore};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
@@ -42,6 +43,11 @@ extern "C" {
 
 /// The WebTransport URL path for the RHP4 protocol.
 const RHP4_PATH: &str = "/sia/rhp/v4";
+
+/// Maximum concurrent in-flight dials. Chrome caps pending HTTP/3
+/// connections; gating dials here prevents the browser from rejecting or
+/// stalling when many hosts are contacted at once.
+const MAX_PENDING_CONNS: usize = 64;
 
 // --- Connection ---
 
@@ -179,9 +185,12 @@ impl AsyncRead for Stream {
 
 // --- Client with connection pooling ---
 
+type ConnCell = Rc<OnceCell<Rc<Connection>>>;
+
 #[derive(Clone)]
 pub struct Client {
-    pool: Rc<RefCell<HashMap<PublicKey, Rc<Connection>>>>,
+    pool: Rc<RefCell<HashMap<PublicKey, ConnCell>>>,
+    dial_sema: Rc<Semaphore>,
 }
 
 impl Default for Client {
@@ -194,6 +203,7 @@ impl Client {
     pub fn new() -> Self {
         Client {
             pool: Rc::new(RefCell::new(HashMap::new())),
+            dial_sema: Rc::new(Semaphore::new(MAX_PENDING_CONNS)),
         }
     }
 
@@ -201,35 +211,46 @@ impl Client {
     /// turns out to be stale, the RPC method will call [`evict`] and the
     /// next call will establish a fresh connection.
     async fn connection(&self, host: &HostEndpoint) -> Result<Rc<Connection>, Error> {
-        if let Some(conn) = self.pool.borrow().get(&host.public_key).cloned() {
-            return Ok(conn);
-        }
+        let cell = self
+            .pool
+            .borrow_mut()
+            .entry(host.public_key)
+            .or_insert_with(|| Rc::new(OnceCell::new()))
+            .clone();
+        let conn = cell
+            .get_or_try_init(|| async {
+                // Gate concurrent dials to stay under Chrome's pending-connection cap.
+                let _permit = self
+                    .dial_sema
+                    .acquire()
+                    .await
+                    .map_err(|e| Error::Transport(format!("dial semaphore closed: {e}")))?;
 
-        // Connect to first available QUIC address
-        let mut last_err = None;
-        for addr in &host.addresses {
-            if addr.protocol != Protocol::QUIC {
-                continue;
-            }
-            match connect(&addr.address).await {
-                Ok(conn) => {
-                    let conn = Rc::new(conn);
-                    self.pool.borrow_mut().insert(host.public_key, conn.clone());
-                    return Ok(conn);
+                // Connect to first available QUIC address
+                let mut last_err = None;
+                for addr in &host.addresses {
+                    if addr.protocol != Protocol::QUIC {
+                        continue;
+                    }
+                    match connect(&addr.address).await {
+                        Ok(conn) => return Ok(Rc::new(conn)),
+                        Err(e) => {
+                            debug!("[WT] connect to {} failed: {e}", addr.address);
+                            last_err = Some(e);
+                        }
+                    }
                 }
-                Err(e) => {
-                    debug!("[WT] connect to {} failed: {e}", addr.address);
-                    last_err = Some(e);
-                }
-            }
-        }
 
-        Err(last_err.unwrap_or_else(|| {
-            Error::Transport(format!(
-                "no QUIC/WebTransport address for host {}",
-                host.public_key
-            ))
-        }))
+                Err(last_err.unwrap_or_else(|| {
+                    Error::Transport(format!(
+                        "no QUIC/WebTransport address for host {}",
+                        host.public_key
+                    ))
+                }))
+            })
+            .await?
+            .clone();
+        Ok(conn)
     }
 
     fn evict(&self, host_key: &PublicKey) {

--- a/sia_storage/src/slabs.rs
+++ b/sia_storage/src/slabs.rs
@@ -549,10 +549,11 @@ mod test {
             },
         ];
         let meta = b"hello, world!".to_vec();
-
-        let mut obj = Object::default();
-        obj.slabs = slabs.clone();
-        obj.metadata = meta.clone();
+        let obj = Object{
+            slabs: slabs.clone(),
+            metadata: meta.clone(),
+            ..Default::default()
+        };
 
         let seed: [u8; 32] = random_bytes_32();
         let private_key = AppKey::import(seed);


### PR DESCRIPTION
Deduplicates concurrent dials to the same host using `OnceCell` and adds a semaphore for concurrent dials to the WebTransport client to prevent going over Chrome's limit for pending connections.