### PR TITLE
feat(napi): emit type definitions

### DIFF
--- a/.changeset/napi_emit_type_definitions.md
+++ b/.changeset/napi_emit_type_definitions.md
@@ -1,0 +1,7 @@
+---
+sia_storage_napi: patch
+---
+
+# Emit NAPI type definitions
+
+Enable the `type-def` feature on `napi-derive` and add `ts_args_type` on `set_logger` so `napi build --dts` produces a usable `index.d.ts`.

--- a/.changeset/setlogger_now_matches_the_napi_callback.md
+++ b/.changeset/setlogger_now_matches_the_napi_callback.md
@@ -1,0 +1,5 @@
+---
+sia_storage_wasm: major
+---
+
+# setLogger now matches the NAPI callback.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,17 +545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_log"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
-dependencies = [
- "log",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,7 +2817,6 @@ version = "0.2.0"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
- "console_log",
  "hex",
  "js-sys",
  "log",

--- a/sia_storage_napi/Cargo.toml
+++ b/sia_storage_napi/Cargo.toml
@@ -16,7 +16,7 @@ futures-core = "0.3.32"
 log = "0.4.29"
 chrono = { version = "0.4", features = ["serde"] }
 napi = { version = "3.8.5", features = ["async", "napi8", "chrono_date", "web_stream"] }
-napi-derive = "3.5.4"
+napi-derive = { version = "3.5.4", features = ["type-def"] }
 rand = "0.10.0"
 sia_core = { version = "0.3.0", path = "../sia_core" }
 sia_storage = { version = "0.7.0", path = "../sia_storage" }

--- a/sia_storage_napi/src/logging.rs
+++ b/sia_storage_napi/src/logging.rs
@@ -33,8 +33,8 @@ impl log::Log for ForwardLogger {
 /// Sets a logging callback to receive log messages from the SDK.
 ///
 /// The callback receives formatted log messages as strings.
-/// `level` should be one of: "error", "warn", "info", "debug", "trace".
-#[napi]
+/// `level` should be one of: "off", "error", "warn", "info", "debug", "trace".
+#[napi(ts_args_type = "callback: (message: string) => void, level: \"off\" | \"error\" | \"warn\" | \"info\" | \"debug\" | \"trace\"")]
 pub fn set_logger(callback: LogFn, level: String) {
     LOGGER_SET.call_once(|| {
         log::set_logger(&FORWARDER).unwrap();

--- a/sia_storage_napi/src/logging.rs
+++ b/sia_storage_napi/src/logging.rs
@@ -34,7 +34,9 @@ impl log::Log for ForwardLogger {
 ///
 /// The callback receives formatted log messages as strings.
 /// `level` should be one of: "off", "error", "warn", "info", "debug", "trace".
-#[napi(ts_args_type = "callback: (message: string) => void, level: \"off\" | \"error\" | \"warn\" | \"info\" | \"debug\" | \"trace\"")]
+#[napi(
+    ts_args_type = "callback: (message: string) => void, level: \"off\" | \"error\" | \"warn\" | \"info\" | \"debug\" | \"trace\""
+)]
 pub fn set_logger(callback: LogFn, level: String) {
     LOGGER_SET.call_once(|| {
         log::set_logger(&FORWARDER).unwrap();

--- a/sia_storage_wasm/Cargo.toml
+++ b/sia_storage_wasm/Cargo.toml
@@ -27,6 +27,5 @@ tokio = { version = "1", features = ["rt", "io-util", "sync"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 console_error_panic_hook = "0.1"
 log = "0.4"
-console_log = { version = "1", features = ["color"] }
 serde = "1.0.228"
 tsify = { version = "0.4", features = ["js"] }

--- a/sia_storage_wasm/examples/main.js
+++ b/sia_storage_wasm/examples/main.js
@@ -1,6 +1,6 @@
 import init, {
   Builder,
-  setLogLevel,
+  setLogger,
   generateRecoveryPhrase,
   PinnedObject,
 } from './pkg/sia_storage_wasm.js';
@@ -45,7 +45,7 @@ function askUser(label) {
 
 async function main() {
   await init();
-  setLogLevel('info');
+  setLogger((msg) => console.log(msg), 'info');
 
   // -- builder flow --
   const builder = new Builder(INDEXER_URL, {

--- a/sia_storage_wasm/src/lib.rs
+++ b/sia_storage_wasm/src/lib.rs
@@ -1,6 +1,7 @@
 mod app_key;
 mod builder;
 mod helpers;
+mod logging;
 mod object;
 mod packed;
 mod sdk;
@@ -35,13 +36,12 @@ where
     rx.await.expect("run_local task was dropped")
 }
 
-/// Set up panic hook, logger, and tokio runtime for browser use.
-/// Defaults to Info level. Call `set_log_level("debug")` for verbose output.
+/// Set up panic hook and tokio runtime for browser use.
+///
+/// Call [`setLogger`](crate::logging::set_logger) to receive log messages.
 #[wasm_bindgen(start)]
 pub fn init() {
     console_error_panic_hook::set_once();
-    console_log::init_with_level(log::Level::Trace).ok();
-    log::set_max_level(log::LevelFilter::Info);
 
     // Create a single-threaded tokio runtime + LocalSet. The runtime
     // context is entered so tokio primitives work. The LocalSet runs
@@ -62,28 +62,6 @@ pub fn init() {
     // Run the LocalSet forever on the browser event loop so spawned
     // tasks are actually polled.
     wasm_bindgen_futures::spawn_local(local_set.run_until(std::future::pending::<()>()));
-}
-
-/// Sets the global log level filter at runtime.
-///
-/// Accepts `"debug"`, `"info"`, `"warn"`, or `"error"`. Unrecognized
-/// values default to `"info"`. The change takes effect immediately for
-/// all subsequent `log::debug!()` / `log::info!()` / etc. calls.
-///
-/// ```js
-/// set_log_level("debug"); // verbose — shows RPC calls, slab progress, etc.
-/// set_log_level("error"); // quiet — only fatal errors
-/// ```
-#[wasm_bindgen(js_name = "setLogLevel")]
-pub fn set_log_level(level: &str) {
-    let filter = match level {
-        "trace" => log::LevelFilter::Trace,
-        "debug" => log::LevelFilter::Debug,
-        "warn" => log::LevelFilter::Warn,
-        "error" => log::LevelFilter::Error,
-        _ => log::LevelFilter::Info,
-    };
-    log::set_max_level(filter);
 }
 
 /// Generates a new BIP-39 12-word recovery phrase.

--- a/sia_storage_wasm/src/lib.rs
+++ b/sia_storage_wasm/src/lib.rs
@@ -38,7 +38,7 @@ where
 
 /// Set up panic hook and tokio runtime for browser use.
 ///
-/// Call [`setLogger`](crate::logging::set_logger) to receive log messages.
+/// Call `setLogger` to receive log messages.
 #[wasm_bindgen(start)]
 pub fn init() {
     console_error_panic_hook::set_once();

--- a/sia_storage_wasm/src/logging.rs
+++ b/sia_storage_wasm/src/logging.rs
@@ -39,7 +39,9 @@ extern "C" {
     #[wasm_bindgen(typescript_type = "(message: string) => void")]
     pub type LogCallback;
 
-    #[wasm_bindgen(typescript_type = "\"off\" | \"error\" | \"warn\" | \"info\" | \"debug\" | \"trace\"")]
+    #[wasm_bindgen(
+        typescript_type = "\"off\" | \"error\" | \"warn\" | \"info\" | \"debug\" | \"trace\""
+    )]
     pub type LogLevel;
 }
 

--- a/sia_storage_wasm/src/logging.rs
+++ b/sia_storage_wasm/src/logging.rs
@@ -1,0 +1,62 @@
+use std::cell::RefCell;
+use std::sync::Once;
+
+use js_sys::Function;
+use wasm_bindgen::prelude::*;
+
+thread_local! {
+    static LOGGER: RefCell<Option<Function>> = const { RefCell::new(None) };
+}
+
+static LOGGER_SET: Once = Once::new();
+
+static FORWARDER: ForwardLogger = ForwardLogger;
+
+struct ForwardLogger;
+
+impl log::Log for ForwardLogger {
+    fn enabled(&self, _meta: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        LOGGER.with(|l| {
+            if let Some(logger) = l.borrow().as_ref() {
+                let msg = format!("[{}] {}", record.level(), record.args());
+                let _ = logger.call1(&JsValue::NULL, &JsValue::from_str(&msg));
+            }
+        });
+    }
+
+    fn flush(&self) {}
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "(message: string) => void")]
+    pub type LogCallback;
+
+    #[wasm_bindgen(typescript_type = "\"off\" | \"error\" | \"warn\" | \"info\" | \"debug\" | \"trace\"")]
+    pub type LogLevel;
+}
+
+/// Sets a logging callback to receive log messages from the SDK.
+///
+/// The callback receives formatted log messages as strings.
+/// `level` should be one of: "off", "error", "warn", "info", "debug", "trace".
+#[wasm_bindgen(js_name = "setLogger")]
+pub fn set_logger(callback: LogCallback, level: LogLevel) {
+    LOGGER_SET.call_once(|| {
+        log::set_logger(&FORWARDER).unwrap();
+    });
+    let callback: Function = callback.unchecked_into();
+    LOGGER.with(|l| l.borrow_mut().replace(callback));
+    if let Some(level) = JsValue::from(level).as_string()
+        && let Ok(filter) = level.parse::<log::LevelFilter>()
+    {
+        log::set_max_level(filter);
+    }
+}


### PR DESCRIPTION
- Enable napi-derive's type-def feature so napi build --dts emits a complete .d.ts.
- Annotate set_logger so the LogFn alias resolves to a real TypeScript function type.
  - LogFn is a type alias over napi-rs's ThreadsafeFunction<...> wrapper, a generic that encodes the JS-side callable signature in its type parameters. napi-rs's type-def codegen walks Rust types to emit TS, but it doesn't introspect those generics to reconstruct a callable signature.