### PR TITLE
refactor upload into pipeline

### DIFF
--- a/.changeset/validate_upload_packed.md
+++ b/.changeset/validate_upload_packed.md
@@ -1,0 +1,8 @@
+---
+sia_storage: minor
+sia_storage_ffi: minor
+sia_storage_napi: minor
+sia_storage_wasm: minor
+---
+
+# `upload_packed` now returns a `Result` and will error if invalid options are passed to it.

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -543,7 +543,7 @@ mod test {
 
     use crate::compat::run_local;
     use crate::hosts::Hosts;
-    use crate::upload::Uploader;
+    use crate::upload::{upload_object, upload_slabs};
     use crate::{Host, ShardProgress, UploadOptions};
 
     cross_target_tests! {
@@ -578,11 +578,15 @@ mod test {
             // chunk completion during download
             transport.set_initial_read_delay(Duration::from_millis(500));
 
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-            let obj = uploader
-                .upload(Object::default(), Cursor::new(data.clone()), UploadOptions::default())
-                .await
-                .unwrap();
+            let obj = upload_object(
+                hosts.clone(),
+                app_key.clone(),
+                Object::default(),
+                Cursor::new(data.clone()),
+                UploadOptions::default(),
+            )
+            .await
+            .unwrap();
 
             let mut recovered_data = Vec::with_capacity(slab_size);
             let mut download = Download::new(
@@ -626,7 +630,7 @@ mod test {
             let data = data.freeze();
             let app_key = Arc::new(AppKey::import(rand::random()));
 
-            let slabs = Uploader::upload_slabs(
+            let slabs = upload_slabs(
                 hosts.clone(),
                 app_key.clone(),
                 Cursor::new(data.clone()),
@@ -703,11 +707,15 @@ mod test {
             let data = data.freeze();
             let app_key = Arc::new(AppKey::import(rand::random()));
 
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-            let obj = uploader
-                .upload(Object::default(), Cursor::new(data.clone()), upload_options)
-                .await
-                .unwrap();
+            let obj = upload_object(
+                hosts.clone(),
+                app_key.clone(),
+                Object::default(),
+                Cursor::new(data.clone()),
+                upload_options,
+            )
+            .await
+            .unwrap();
             assert_eq!(obj.slabs().len(), num_slabs);
 
             // download with progress callback

--- a/sia_storage/src/erasure_coding.rs
+++ b/sia_storage/src/erasure_coding.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use bytes::{Bytes, BytesMut};
 use reed_solomon_erasure::galois_8::ReedSolomon;
 use sia_core::rhp4::{SECTOR_SIZE, SEGMENT_SIZE};
@@ -24,6 +26,10 @@ impl ErasureCoder {
         Ok(ErasureCoder {
             encoder: ReedSolomon::new(data_shards, parity_shards)?,
         })
+    }
+
+    pub fn data_shards(&self) -> usize {
+        self.encoder.data_shard_count()
     }
 
     /// encodes the shards using reed solomon erasure coding,
@@ -71,37 +77,99 @@ impl ErasureCoder {
         }
         Ok(())
     }
+}
 
-    pub async fn read_slab_shards<R: AsyncRead + Unpin>(
-        r: &mut R,
-        data_shards: usize,
-        shards: &mut [BytesMut],
-    ) -> Result<usize> {
-        // limit total read size to the size of the slab's data shards
-        let mut r = r.take(data_shards as u64 * SECTOR_SIZE as u64);
-        let mut data_size = 0;
-        for off in (0..SECTOR_SIZE).step_by(SEGMENT_SIZE) {
-            let start = off;
-            let end = off + SEGMENT_SIZE;
-            for shard in &mut shards[..data_shards].iter_mut() {
-                let segment = &mut shard[start..end];
-                let mut bytes_read = 0;
-                while bytes_read < SEGMENT_SIZE {
-                    // note: read_exact + UnexpectedEoF is not used due to the documentation
-                    // saying "the contents of buf are unspecified." when UnexpectedEoF is
-                    // returned. It's *most likely* fine to rely on the contents being
-                    // a partial read, but better to not make the assumption for every
-                    // possible implementation of the Read trait.
-                    let n = r.read(&mut segment[bytes_read..]).await?;
-                    if n == 0 {
-                        return Ok(data_size);
-                    }
-                    bytes_read += n;
-                    data_size += n;
-                }
-            }
+/// A streaming reader that interleaves incoming bytes across a slab's data
+/// shards as they become available. Yields a [ReadSlab] whenever a full slab
+/// has been accumulated; call [SlabReader::finish] to recover any trailing
+/// partial slab.
+pub(crate) struct SlabReader {
+    data_shards: usize,
+    shards: Vec<BytesMut>,
+    length: usize,
+}
+
+pub(crate) struct ReadSlab {
+    pub length: usize,
+    pub shards: Vec<BytesMut>,
+}
+
+impl SlabReader {
+    pub(crate) fn new(data_shards: usize, parity_shards: usize) -> Self {
+        let total_shards = data_shards + parity_shards;
+        Self {
+            data_shards,
+            shards: vec![BytesMut::zeroed(SECTOR_SIZE); total_shards],
+            length: 0,
         }
-        Ok(data_size)
+    }
+
+    pub fn length(&self) -> usize {
+        self.length
+    }
+
+    pub fn slab_size(&self) -> usize {
+        self.data_shards * SECTOR_SIZE
+    }
+
+    /// Finalizes the slab reader, returning any remaining data as a slab.
+    pub(crate) fn finish(mut self) -> Option<ReadSlab> {
+        if self.length == 0 {
+            return None;
+        }
+        let length = self.length;
+        let shards = mem::take(&mut self.shards);
+        Some(ReadSlab { length, shards })
+    }
+
+    /// Reads data from the reader until reaching the optimal slab size or EOF,
+    /// whichever comes first. This should be called in a loop until EOF is
+    /// reached.
+    ///
+    /// If the optimal slab size is reached, the completed slab is returned.
+    /// Any remaining data should be retrieved using [finish](Self::finish).
+    pub(crate) async fn read_slab<R: AsyncRead + Unpin>(
+        &mut self,
+        r: &mut R,
+    ) -> io::Result<(usize, Option<ReadSlab>)> {
+        let remaining = self.slab_size() - self.length;
+        if remaining == 0 {
+            return Ok((0, None));
+        }
+        let mut r = r.take(remaining as u64);
+        let mut total_read = 0;
+        loop {
+            if self.length == self.slab_size() {
+                break;
+            }
+
+            // calculate current position in the interleaved layout
+            let stripe_size = SEGMENT_SIZE * self.data_shards;
+            let shard_index = (self.length % stripe_size) / SEGMENT_SIZE;
+            let byte_in_seg = self.length % SEGMENT_SIZE;
+            let seg_start = (self.length / stripe_size) * SEGMENT_SIZE;
+
+            let segment =
+                &mut self.shards[shard_index][seg_start + byte_in_seg..seg_start + SEGMENT_SIZE];
+            let n = r.read(segment).await?;
+            if n == 0 {
+                break;
+            }
+            self.length += n;
+            total_read += n;
+        }
+        let slab = if self.length == self.slab_size() {
+            let length = mem::take(&mut self.length);
+            let total_shards = self.shards.len();
+            let shards = mem::replace(
+                &mut self.shards,
+                vec![BytesMut::zeroed(SECTOR_SIZE); total_shards],
+            );
+            Some(ReadSlab { length, shards })
+        } else {
+            None
+        };
+        Ok((total_read, slab))
     }
 }
 
@@ -156,38 +224,43 @@ mod tests {
     async fn test_striped_read() {
         const DATA_SHARDS: usize = 3;
         const PARITY_SHARDS: usize = 2;
+        const SLAB_SIZE: usize = SECTOR_SIZE * DATA_SHARDS;
 
         let test_cases = vec![
             // (data size, expected size)
-            (100, 100),                                                 // under
-            (SECTOR_SIZE * DATA_SHARDS, SECTOR_SIZE * DATA_SHARDS),     // exact
-            (2 * SECTOR_SIZE * DATA_SHARDS, SECTOR_SIZE * DATA_SHARDS), // over
+            (100, 100),               // under
+            (SLAB_SIZE, SLAB_SIZE),   // exact
+            (2 * SLAB_SIZE, SLAB_SIZE), // over
         ];
 
         for (data_size, expected_size) in test_cases {
             let mut data = vec![0u8; data_size];
             getrandom::fill(&mut data).unwrap();
 
-            let mut shards = vec![BytesMut::zeroed(SECTOR_SIZE); DATA_SHARDS + PARITY_SHARDS];
-            let size = ErasureCoder::read_slab_shards(
-                &mut Cursor::new(data.clone()),
-                DATA_SHARDS,
-                &mut shards,
-            )
-            .await
-            .unwrap();
+            let mut reader = SlabReader::new(DATA_SHARDS, PARITY_SHARDS);
+            let (n, slab) = reader
+                .read_slab(&mut Cursor::new(data.clone()))
+                .await
+                .unwrap();
+            assert_eq!(n, expected_size, "data size {data_size} read mismatch");
 
-            assert_eq!(
-                size as usize, expected_size,
-                "data size {data_size} mismatch"
-            );
+            let (size, shards) = if data_size >= SLAB_SIZE {
+                let slab = slab.expect("expected full slab");
+                (slab.length, slab.shards)
+            } else {
+                assert!(slab.is_none(), "data size {data_size} should not fill a slab");
+                let slab = reader.finish().unwrap();
+                (slab.length, slab.shards)
+            };
+
+            assert_eq!(size, expected_size, "data size {data_size} mismatch");
             assert_eq!(
                 shards.len(),
                 DATA_SHARDS + PARITY_SHARDS,
                 "data size {data_size} shard count mismatch"
             );
 
-            for (i, data) in data[..size as usize].chunks(64).enumerate() {
+            for (i, data) in data[..size].chunks(64).enumerate() {
                 let mut chunk = [0u8; SEGMENT_SIZE];
                 chunk[..data.len()].copy_from_slice(data); // pad it out with zeros
                 let index = i % DATA_SHARDS;
@@ -214,15 +287,17 @@ mod tests {
         data[3 * SECTOR_SIZE..].fill(4);
         let data = data.freeze();
 
-        let mut shards = vec![BytesMut::zeroed(SECTOR_SIZE); DATA_SHARDS + PARITY_SHARDS];
-        let size = ErasureCoder::read_slab_shards(
-            &mut Cursor::new(data.clone()),
-            DATA_SHARDS,
-            &mut shards,
-        )
-        .await
-        .unwrap();
-        assert_eq!(size as usize, data.len());
+        let mut reader = SlabReader::new(DATA_SHARDS, PARITY_SHARDS);
+        let (n, slab) = reader
+            .read_slab(&mut Cursor::new(data.clone()))
+            .await
+            .unwrap();
+        assert_eq!(n, data.len());
+        assert!(slab.is_none()); // 3.5 shards doesn't fill a 4-shard slab
+        let slab = reader.finish().unwrap();
+        let size = slab.length;
+        let mut shards = slab.shards;
+        assert_eq!(size, data.len());
 
         // we expect 5 shards and the last one is an empty parity shard
         assert_eq!(shards.len(), 5);

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -494,7 +494,7 @@ mod test {
     use crate::download::Download;
     use crate::hosts::QueueError;
     use crate::rhp4::Client;
-    use crate::upload::Uploader;
+    use crate::upload::{PackedUpload, upload_object};
     use bytes::{Bytes, BytesMut};
     use sia_core::rhp4::SECTOR_SIZE;
     use sia_core::signing::PrivateKey;
@@ -546,13 +546,9 @@ mod test {
                     .collect(),
                 true,
             );
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
-
             let input: Bytes = Bytes::from("Hello, world!");
 
-            let mut packed_upload = uploader.upload_packed(UploadOptions::default());
+            let mut packed_upload = PackedUpload::new(hosts.clone(), app_key.clone(), UploadOptions::default()).unwrap();
             assert_eq!(packed_upload.remaining(), SLAB_SIZE);
 
             packed_upload
@@ -633,17 +629,13 @@ mod test {
                     .collect(),
                 true,
             );
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
-
             let small_input = Bytes::from("Hello, world!");
 
             let mut large_input = BytesMut::zeroed(SLAB_SIZE as usize + 18); // 1 full slab + 18 bytes
             random_bytes(&mut large_input);
             let large_input = large_input.freeze();
 
-            let mut packed_upload = uploader.upload_packed(UploadOptions::default());
+            let mut packed_upload = PackedUpload::new(hosts.clone(), app_key.clone(), UploadOptions::default()).unwrap();
             packed_upload
                 .add(Cursor::new(small_input.clone()))
                 .await
@@ -721,15 +713,11 @@ mod test {
                     .collect(),
                 true,
             );
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
-
             let mut exact_input = BytesMut::zeroed(SLAB_SIZE as usize); // 1 full slab
             random_bytes(&mut exact_input);
             let exact_input = exact_input.freeze();
 
-            let mut packed_upload = uploader.upload_packed(UploadOptions::default());
+            let mut packed_upload = PackedUpload::new(hosts.clone(), app_key.clone(), UploadOptions::default()).unwrap();
             packed_upload
                 .add(Cursor::new(exact_input.clone()))
                 .await
@@ -760,6 +748,70 @@ mod test {
             assert_eq!(output.freeze(), exact_input);
         }).await }
 
+    async fn test_upload_download_packed_empty() { run_local(async {
+            let app_key = Arc::new(AppKey::import(random_seed()));
+            let hosts = Hosts::new(Client::new());
+            hosts.update(
+                (0..60)
+                    .map(|_| Host {
+                        public_key: PrivateKey::from_seed(&random_seed()).public_key(),
+                        addresses: vec![NetAddress {
+                            protocol: sia_core::types::v2::Protocol::QUIC,
+                            address: "localhost:1234".to_string(),
+                        }],
+                        country_code: "US".to_string(),
+                        latitude: 0.0,
+                        longitude: 0.0,
+                        good_for_upload: true,
+                    })
+                    .collect(),
+                true,
+            );
+            let non_empty: Bytes = Bytes::from("hello");
+
+            let mut packed_upload =
+                PackedUpload::new(hosts.clone(), app_key.clone(), UploadOptions::default())
+                    .unwrap();
+            // empty at head, between, and tail; interleaved with a non-empty.
+            packed_upload
+                .add(Cursor::new(Bytes::new()))
+                .await
+                .expect("add empty 1 to complete");
+            packed_upload
+                .add(Cursor::new(non_empty.clone()))
+                .await
+                .expect("add non-empty to complete");
+            packed_upload
+                .add(Cursor::new(Bytes::new()))
+                .await
+                .expect("add empty 2 to complete");
+
+            let objects = packed_upload.finalize().await.expect("upload to finish");
+            assert_eq!(objects.len(), 3);
+
+            // empty objects have zero slabs and zero size
+            assert_eq!(objects[0].slabs().len(), 0);
+            assert_eq!(objects[0].size(), 0);
+            assert_eq!(objects[2].slabs().len(), 0);
+            assert_eq!(objects[2].size(), 0);
+
+            // the non-empty object should round-trip normally
+            assert_eq!(objects[1].slabs().len(), 1);
+            assert_eq!(objects[1].size(), non_empty.len() as u64);
+            let mut output = BytesMut::zeroed(non_empty.len());
+            let mut download = Download::new(
+                &objects[1],
+                hosts.clone(),
+                app_key.clone(),
+                DownloadOptions::default(),
+            )
+            .unwrap();
+            copy(&mut download, &mut Cursor::new(&mut output[..]))
+                .await
+                .expect("download to complete");
+            assert_eq!(output.freeze(), non_empty);
+        }).await }
+
     async fn test_upload_download() { run_local(async {
         let app_key = Arc::new(AppKey::import(random_seed()));
         let hosts = Hosts::new(Client::new());
@@ -779,12 +831,9 @@ mod test {
                 .collect(),
             true,
         );
-
-        let uploader = Uploader::new(hosts.clone(), app_key.clone());
         let input: Bytes = Bytes::from("Hello, world!");
 
-        let object = uploader
-            .upload(Object::default(), Cursor::new(input.clone()), UploadOptions::default())
+        let object = upload_object(hosts.clone(), app_key.clone(), Object::default(), Cursor::new(input.clone()), UploadOptions::default())
             .await
             .expect("upload to complete");
 
@@ -833,23 +882,18 @@ mod test {
                     .collect(),
                 true,
             );
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
             let part1 = Bytes::from("Hello, ");
             let part2 = Bytes::from("world!");
             let expected = Bytes::from("Hello, world!");
 
             // first upload
-            let object = uploader
-                .upload(Object::default(), Cursor::new(part1.clone()), UploadOptions::default())
+            let object = upload_object(hosts.clone(), app_key.clone(), Object::default(), Cursor::new(part1.clone()), UploadOptions::default())
                 .await
                 .expect("first upload to complete");
             assert_eq!(object.size(), part1.len() as u64);
 
             // resume with second part
-            let object = uploader
-                .upload(object, Cursor::new(part2.clone()), UploadOptions::default())
+            let object = upload_object(hosts.clone(), app_key.clone(), object, Cursor::new(part2.clone()), UploadOptions::default())
                 .await
                 .expect("second upload to complete");
             assert_eq!(object.size(), expected.len() as u64);
@@ -893,10 +937,6 @@ mod test {
                     .collect(),
                 true,
             );
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
-
             // Use default 10 data shards, so slab_size = 10 * SECTOR_SIZE
             let slab_size = 10 * SECTOR_SIZE as u64;
             let data_size = slab_size * 3; // 3 slabs
@@ -905,8 +945,7 @@ mod test {
             random_bytes(&mut data);
             let data = data.freeze();
 
-            let object = uploader
-                .upload(Object::default(), Cursor::new(data.clone()), UploadOptions::default())
+            let object = upload_object(hosts.clone(), app_key.clone(), Object::default(), Cursor::new(data.clone()), UploadOptions::default())
                 .await
                 .expect("upload to complete");
 
@@ -992,14 +1031,9 @@ mod test {
                     .collect(),
                 true,
             );
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
-
             let input: Bytes = Bytes::from("Hello, world!");
 
-            let object = uploader
-                .upload(Object::default(), Cursor::new(input.clone()), UploadOptions::default())
+            let object = upload_object(hosts.clone(), app_key.clone(), Object::default(), Cursor::new(input.clone()), UploadOptions::default())
                 .await
                 .expect("upload to complete");
 
@@ -1027,12 +1061,9 @@ mod test {
     async fn test_upload_no_hosts() { run_local(async {
             let app_key = Arc::new(AppKey::import(random_seed()));
             let hosts = Hosts::new(Client::new());
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
             let input: Bytes = Bytes::from("Hello, world!");
 
-            let err = uploader
-                .upload(Object::default(), Cursor::new(input.clone()), UploadOptions::default())
+            let err = upload_object(hosts.clone(), app_key.clone(), Object::default(), Cursor::new(input.clone()), UploadOptions::default())
                 .await
                 .expect_err("upload to fail");
 
@@ -1078,13 +1109,9 @@ mod test {
                 host_keys.iter().take(1).copied(),
                 Duration::from_secs(2),
             );
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
             let input: Bytes = Bytes::from("Hello, world!");
 
-            let object = uploader
-                .upload(Object::default(), Cursor::new(input.clone()), UploadOptions::default())
+            let object = upload_object(hosts.clone(), app_key.clone(), Object::default(), Cursor::new(input.clone()), UploadOptions::default())
                 .await
                 .expect("upload should succeed with 1 slow host");
 
@@ -1122,13 +1149,9 @@ mod test {
 
             // Make all hosts slow
             mock_transport.set_slow_hosts(host_keys.iter().take(30).copied(), Duration::from_secs(2));
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
             let input: Bytes = Bytes::from("Hello, world!");
 
-            let _ = uploader
-                .upload(Object::default(), Cursor::new(input.clone()), UploadOptions::default())
+            let _ = upload_object(hosts.clone(), app_key.clone(), Object::default(), Cursor::new(input.clone()), UploadOptions::default())
                 .await
                 .expect("upload to succeed");
         }).await }
@@ -1159,13 +1182,9 @@ mod test {
                     .collect(),
                 true,
             );
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-
             let input: Bytes = Bytes::from("Hello, world!");
 
-            let err = uploader
-                .upload(Object::default(), Cursor::new(input.clone()), UploadOptions::default())
+            let err = upload_object(hosts.clone(), app_key.clone(), Object::default(), Cursor::new(input.clone()), UploadOptions::default())
                 .await
                 .expect_err("upload to fail");
 
@@ -1213,10 +1232,7 @@ mod test {
                     assert_eq!(p.shard_size, SECTOR_SIZE);
                     upload_progress_clone.lock().unwrap().insert((p.slab_index, p.shard_index), p);
                 });
-
-            let uploader = Uploader::new(hosts.clone(), app_key.clone());
-            let obj = uploader
-                .upload(Object::default(), Cursor::new(data.clone()), upload_opts)
+            let obj = upload_object(hosts.clone(), app_key.clone(), Object::default(), Cursor::new(data.clone()), upload_opts)
                 .await
                 .unwrap();
             assert_eq!(obj.slabs().len(), num_slabs);

--- a/sia_storage/src/mock.rs
+++ b/sia_storage/src/mock.rs
@@ -7,19 +7,19 @@ use crate::download::Download;
 use crate::hosts::Hosts;
 use crate::rhp4::Client;
 use crate::time::Duration;
-use crate::upload::Uploader;
-use crate::{
-    AppKey, DownloadError, DownloadOptions, Object, PackedUpload, UploadError, UploadOptions,
-};
+use crate::upload::{PackedUpload, upload_object};
+use crate::{AppKey, DownloadError, DownloadOptions, Object, UploadError, UploadOptions};
 
 pub struct MockUploader {
-    uploader: Uploader<Client>,
+    hosts: Hosts<Client>,
+    app_key: Arc<AppKey>,
 }
 
 impl MockUploader {
     pub fn new(hosts: MockHosts, app_key: Arc<AppKey>) -> Self {
         Self {
-            uploader: Uploader::new(hosts.inner, app_key),
+            hosts: hosts.inner,
+            app_key,
         }
     }
 
@@ -29,11 +29,11 @@ impl MockUploader {
         r: R,
         options: UploadOptions,
     ) -> Result<Object, UploadError> {
-        self.uploader.upload(object, r, options).await
+        upload_object(self.hosts.clone(), self.app_key.clone(), object, r, options).await
     }
 
-    pub fn upload_packed(&self, options: UploadOptions) -> PackedUpload {
-        self.uploader.upload_packed(options)
+    pub fn upload_packed(&self, options: UploadOptions) -> Result<PackedUpload, UploadError> {
+        PackedUpload::new(self.hosts.clone(), self.app_key.clone(), options)
     }
 }
 

--- a/sia_storage/src/sdk.rs
+++ b/sia_storage/src/sdk.rs
@@ -13,11 +13,10 @@ use crate::hosts::Hosts;
 use crate::rhp4::{Client, HostEndpoint};
 use crate::task::AbortOnDropHandle;
 use crate::time::Duration;
-use crate::upload::Uploader;
+use crate::upload::{PackedUpload, upload_object};
 use crate::{
     Account, AppKey, BuilderError, Download, DownloadError, DownloadOptions, Host, HostQuery,
-    Object, ObjectEvent, ObjectsCursor, PackedUpload, PinnedSlab, SealedObjectError, UploadError,
-    UploadOptions,
+    Object, ObjectEvent, ObjectsCursor, PinnedSlab, SealedObjectError, UploadError, UploadOptions,
 };
 
 /// Errors that can occur when using the SDK.
@@ -50,7 +49,6 @@ pub struct Sdk {
     app_key: Arc<AppKey>,
     api_client: app_client::Client,
     hosts: Hosts<Client>,
-    uploader: Uploader<Client>,
     _refresh_task: Arc<AbortOnDropHandle<()>>,
 }
 
@@ -109,7 +107,6 @@ impl Sdk {
     ) -> Result<Self, BuilderError> {
         let hosts = Hosts::new(Client::new());
         Self::refresh_hosts(&app_key, &api_client, &hosts).await?;
-        let uploader = Uploader::new(hosts.clone(), app_key.clone());
         let refresh_task = Self::spawn_refresh_task(
             app_key.clone(),
             api_client.clone(),
@@ -120,7 +117,6 @@ impl Sdk {
             app_key,
             api_client,
             hosts,
-            uploader,
             _refresh_task: Arc::new(refresh_task),
         })
     }
@@ -172,7 +168,14 @@ impl Sdk {
         reader: R,
         options: UploadOptions,
     ) -> Result<Object, UploadError> {
-        self.uploader.upload(object, reader, options).await
+        upload_object(
+            self.hosts.clone(),
+            self.app_key.clone(),
+            object,
+            reader,
+            options,
+        )
+        .await
     }
 
     /// Creates a new packed upload. This allows multiple objects to be packed together
@@ -183,8 +186,8 @@ impl Sdk {
     ///
     /// # Returns
     /// A [PackedUpload] that can be used to add objects and finalize the upload.
-    pub fn upload_packed(&self, options: UploadOptions) -> PackedUpload {
-        self.uploader.upload_packed(options)
+    pub fn upload_packed(&self, options: UploadOptions) -> Result<PackedUpload, UploadError> {
+        PackedUpload::new(self.hosts.clone(), self.app_key.clone(), options)
     }
 
     /// Returns a [Download] handle that streams the object's data. The handle

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -1,26 +1,28 @@
+use std::collections::VecDeque;
 use std::io;
 use std::sync::Arc;
 
-use crate::{AppKey, ShardProgress, ShardProgressCallback, UploadOptions};
-use bytes::{Bytes, BytesMut};
+use crate::encryption::{EncryptionKey, encrypt_shard};
+use crate::erasure_coding::{self, ErasureCoder, ReadSlab, SlabReader};
+use crate::hosts::{HostQueue, QueueError, RPCError};
+use crate::rhp4::Client;
+use crate::task::AbortOnDropHandle;
+use crate::time::{Duration, Elapsed, Instant, sleep};
+use crate::{
+    AppKey, Hosts, Object, Sector, ShardProgress, ShardProgressCallback, Slab, UploadOptions,
+};
+use bytes::Bytes;
 use log::debug;
-use sia_core::rhp4::{self as rhp, SECTOR_SIZE};
+use sia_core::rhp4::SECTOR_SIZE;
 use sia_core::signing::PublicKey;
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncWriteExt, BufReader, SimplexStream, WriteHalf, copy, simplex};
+use tokio::io::{AsyncRead, BufReader};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinSet;
 
-use crate::encryption::{EncryptionKey, encrypt_shard};
-use crate::erasure_coding::{self, ErasureCoder};
-use crate::hosts::{HostQueue, QueueError, RPCError};
-use crate::rhp4::Transport;
-use crate::task::AbortOnDropHandle;
-use crate::time::{Duration, Elapsed, Instant, sleep};
-use crate::{Hosts, Object, Sector, Slab};
-
-struct ShardUpload<T: Transport> {
-    client: Hosts<T>,
+struct ShardUpload {
+    semaphore: Arc<Semaphore>,
+    client: Hosts<Client>,
     hosts: HostQueue,
     account_key: Arc<AppKey>,
     data: Bytes,
@@ -28,10 +30,20 @@ struct ShardUpload<T: Transport> {
     shard_index: usize,
 }
 
-impl<T: Transport> ShardUpload<T> {
+struct SectorUploadResult {
+    sector: Sector,
+    shard_index: usize,
+    elapsed: Duration,
+}
+
+impl ShardUpload {
+    fn upload_timeout(attempts: usize) -> Duration {
+        Duration::from_secs((10 + (5 * attempts as u64)).min(120))
+    }
+
     fn spawn_write(
         &self,
-        tasks: &mut JoinSet<Result<(Sector, Duration), UploadError>>,
+        tasks: &mut JoinSet<Result<SectorUploadResult, UploadError>>,
         host_key: PublicKey,
         write_timeout: Duration,
         permit: OwnedSemaphorePermit,
@@ -46,20 +58,74 @@ impl<T: Transport> ShardUpload<T> {
             let _permit = permit;
             let now = Instant::now();
             let root = client.write_sector(host_key, &account_key.0, data, write_timeout).await
-            .inspect_err(|e| {
-                debug!(
-                    "slab {slab_index} shard {shard_index} upload to host {host_key} failed after {:?} {e}",
-                    now.elapsed()
-                );
-                let _ = hosts.retry(host_key);
-            })?;
+                .inspect_err(|e| {
+                    debug!(
+                        "slab {slab_index} shard {shard_index} upload to host {host_key} failed after {:?} {e}",
+                        now.elapsed()
+                    );
+                    let _ = hosts.retry(host_key);
+                })?;
             let elapsed = now.elapsed();
             debug!(
                 "slab {slab_index} shard {shard_index} uploaded to {host_key} in {:?}",
                 elapsed
             );
-            Ok((Sector { root, host_key }, elapsed))
+            Ok(SectorUploadResult {
+                sector: Sector { root, host_key },
+                shard_index,
+                elapsed,
+            })
         });
+    }
+
+    async fn upload_shard(
+        self,
+        initial_host: (PublicKey, usize),
+    ) -> Result<SectorUploadResult, UploadError> {
+        let (host_key, attempts) = initial_host;
+        let write_timeout = Self::upload_timeout(attempts);
+        let permit = self.semaphore.clone().acquire_owned().await?;
+        let mut tasks = JoinSet::new();
+        self.spawn_write(&mut tasks, host_key, write_timeout, permit);
+        loop {
+            let active = tasks.len();
+            tokio::select! {
+                biased;
+                Some(res) = tasks.join_next() => {
+                    match res? {
+                        Ok(result) => {
+                            if result.sector.host_key != host_key {
+                                debug!(
+                                    "slab {} shard {} penalizing original host {}",
+                                    self.slab_index, self.shard_index, host_key
+                                );
+                                self.client.add_failure(host_key)
+                            }
+                            return Ok(result);
+                        }
+                        Err(_) => {
+                            if tasks.is_empty() {
+                                let (host_key, attempts) = self.hosts.pop_front()?;
+                                let write_timeout = Self::upload_timeout(attempts);
+                                let permit = self.semaphore.clone().acquire_owned().await?;
+                                self.spawn_write(&mut tasks, host_key, write_timeout, permit);
+                            }
+                        }
+                    }
+                },
+                _ = sleep(Duration::from_secs(active.max(1) as u64)) => {
+                    if let Ok(racer) = self.semaphore.clone().try_acquire_owned()
+                        && let Ok((host_key, attempts)) = self.hosts.pop_front() {
+                            debug!(
+                                "slab {} shard {} racing slow host",
+                                self.slab_index, self.shard_index
+                            );
+                            let write_timeout = Self::upload_timeout(attempts);
+                            self.spawn_write(&mut tasks, host_key, write_timeout, racer);
+                        }
+                }
+            }
+        }
     }
 }
 
@@ -119,6 +185,223 @@ pub enum UploadError {
     Cancelled,
 }
 
+struct UploadedSlab {
+    encryption_key: EncryptionKey,
+    length: u32,
+    shards: Vec<Option<Sector>>,
+}
+
+/// A single-use streaming upload pipeline. Feed data into it by calling
+/// [read](Upload::read) repeatedly, then complete the upload with
+/// [finish](Upload::finish) to recover the uploaded slabs.
+pub(crate) struct Upload {
+    client: Hosts<Client>,
+    app_key: Arc<AppKey>,
+    erasure_coder: Arc<ErasureCoder>,
+    slab_buffer: Option<SlabReader>,
+    /// Semaphore to limit the maximum number of slabs in memory at once.
+    slab_sema: Arc<Semaphore>,
+    /// Semaphore to limit the maximum number of shards in flight at once.
+    /// Separate from `slab_sema` since slabs can be buffered while waiting
+    /// for shard uploads to complete, and we want to allow some buffering to
+    /// improve performance.
+    shard_sema: Arc<Semaphore>,
+    slab_tasks: VecDeque<AbortOnDropHandle<Result<UploadedSlab, UploadError>>>,
+    shard_uploaded: Option<ShardProgressCallback>,
+}
+
+impl Upload {
+    pub(crate) fn new(
+        client: Hosts<Client>,
+        app_key: Arc<AppKey>,
+        options: UploadOptions,
+    ) -> Result<Self, UploadError> {
+        options.validate()?;
+        let total_shards = options.data_shards as usize + options.parity_shards as usize;
+        if client.available_for_upload() < total_shards {
+            return Err(QueueError::InsufficientHosts.into());
+        }
+        let erasure_coder =
+            ErasureCoder::new(options.data_shards as usize, options.parity_shards as usize)
+                .map_err(|e| {
+                    UploadError::InvalidOptions(format!("failed to create erasure coder: {e}"))
+                })?;
+
+        let total_shards = options.data_shards as usize + options.parity_shards as usize;
+        // cap number of active slabs to limit memory usage.
+        let max_slabs = options
+            .max_inflight
+            .div_ceil(total_shards)
+            .saturating_add(1);
+        Ok(Self {
+            client,
+            app_key,
+            slab_buffer: Some(SlabReader::new(
+                options.data_shards as usize,
+                options.parity_shards as usize,
+            )),
+            erasure_coder: Arc::new(erasure_coder),
+            slab_sema: Arc::new(Semaphore::new(max_slabs)),
+            shard_sema: Arc::new(Semaphore::new(options.max_inflight)),
+            slab_tasks: VecDeque::new(),
+            shard_uploaded: options.shard_uploaded,
+        })
+    }
+
+    async fn spawn_slab(&mut self, slab: ReadSlab) -> Result<(), UploadError> {
+        let client = self.client.clone();
+        let rs = self.erasure_coder.clone();
+        let shard_sema = self.shard_sema.clone();
+        let app_key = self.app_key.clone();
+        let progress_callback = self.shard_uploaded.clone();
+        let slab_index = self.slab_tasks.len();
+        let permit = self.slab_sema.clone().acquire_owned().await?;
+        let handle = AbortOnDropHandle::new(maybe_spawn!(async move {
+            let _permit = permit;
+            let total_shards = slab.shards.len();
+            let slab_key: EncryptionKey = rand::random::<[u8; 32]>().into();
+
+            // Encode parity shards on a blocking thread; encryption runs
+            // per-shard below so it parallelizes across the blocking pool.
+            let mut shards = slab.shards;
+            let shards = maybe_spawn_blocking!({
+                let start = Instant::now();
+                rs.encode_shards(&mut shards)?;
+                debug!("slab {} encoded in {:?}", slab_index, start.elapsed());
+                Ok::<_, UploadError>(shards)
+            })?;
+
+            let hosts = client.upload_queue();
+            let initial_hosts = hosts.pop_n(total_shards)?;
+            let owned_slab_key = Arc::new(slab_key.clone());
+            let mut shard_tasks: JoinSet<Result<SectorUploadResult, UploadError>> = JoinSet::new();
+            for (shard_index, (mut shard, initial_host)) in shards
+                .into_iter()
+                .zip(initial_hosts.into_iter())
+                .enumerate()
+            {
+                let owned_slab_key = owned_slab_key.clone();
+                let shard_client = client.clone();
+                let shard_hosts = hosts.clone();
+                let shard_account_key = app_key.clone();
+                let shard_sema_inner = shard_sema.clone();
+                join_set_spawn!(shard_tasks, async move {
+                    let shard = maybe_spawn_blocking!({
+                        encrypt_shard(&owned_slab_key, shard_index as u8, 0, &mut shard);
+                        shard
+                    });
+                    let shard_upload = ShardUpload {
+                        semaphore: shard_sema_inner,
+                        client: shard_client,
+                        hosts: shard_hosts,
+                        account_key: shard_account_key,
+                        data: shard.freeze(),
+                        slab_index,
+                        shard_index,
+                    };
+                    shard_upload.upload_shard(initial_host).await
+                });
+            }
+
+            let mut slab_out = UploadedSlab {
+                encryption_key: slab_key,
+                length: slab.length as u32,
+                shards: vec![None; total_shards],
+            };
+            while let Some(res) = shard_tasks.join_next().await {
+                let result: SectorUploadResult = res??;
+                if let Some(callback) = &progress_callback {
+                    callback(ShardProgress {
+                        host_key: result.sector.host_key,
+                        shard_index: result.shard_index,
+                        slab_index,
+                        shard_size: SECTOR_SIZE,
+                        elapsed: result.elapsed,
+                    });
+                }
+                slab_out.shards[result.shard_index] = Some(result.sector);
+            }
+            Ok(slab_out)
+        }));
+        self.slab_tasks.push_back(handle);
+        Ok(())
+    }
+
+    /// Reads from the provided reader, buffering data into slabs and spawning
+    /// slab-upload tasks as they fill. Returns the number of bytes read.
+    pub(crate) async fn read<R: AsyncRead + Unpin>(
+        &mut self,
+        reader: &mut R,
+    ) -> Result<u64, UploadError> {
+        // buffer the reader since SlabReader reads 64 bytes at a time
+        let mut reader = BufReader::new(reader);
+        let mut total_length: u64 = 0;
+        loop {
+            let (n, slab) = self
+                .slab_buffer
+                .as_mut()
+                .unwrap()
+                .read_slab(&mut reader)
+                .await?;
+            if n == 0 {
+                return Ok(total_length);
+            }
+            total_length += n as u64;
+
+            if let Some(slab) = slab {
+                self.spawn_slab(slab).await?;
+            }
+        }
+    }
+
+    /// Finalizes the pipeline, flushing any trailing partial slab and awaiting
+    /// all in-flight uploads. Returns the uploaded slabs in order.
+    pub(crate) async fn finish(mut self) -> Result<Vec<Slab>, UploadError> {
+        let last_slab = self.slab_buffer.take().unwrap().finish();
+        if let Some(slab) = last_slab {
+            self.spawn_slab(slab).await?;
+        }
+        let min_shards = self.erasure_coder.data_shards() as u8;
+        let mut slabs = Vec::with_capacity(self.slab_tasks.len());
+        while let Some(handle) = self.slab_tasks.pop_front() {
+            let slab = handle.await??;
+            slabs.push(Slab {
+                encryption_key: slab.encryption_key,
+                offset: 0,
+                min_shards,
+                length: slab.length,
+                sectors: slab.shards.into_iter().map(|s| s.unwrap()).collect(),
+            });
+        }
+        Ok(slabs)
+    }
+
+    /// Returns the number of bytes remaining until reaching the optimal
+    /// packed size. Adding objects larger than this will start a new slab.
+    pub(crate) fn remaining(&self) -> usize {
+        let slab_buffer = self.slab_buffer.as_ref().unwrap();
+        slab_buffer.slab_size().saturating_sub(slab_buffer.length())
+    }
+
+    /// Returns the optimal size of each slab.
+    pub(crate) fn slab_size(&self) -> usize {
+        self.slab_buffer.as_ref().unwrap().slab_size()
+    }
+}
+
+/// Reads from the provided reader until EOF and uploads its contents as a
+/// sequence of slabs. Convenience wrapper around [Upload].
+pub(crate) async fn upload_slabs<R: AsyncRead + Unpin>(
+    hosts: Hosts<Client>,
+    app_key: Arc<AppKey>,
+    mut reader: R,
+    options: UploadOptions,
+) -> Result<Vec<Slab>, UploadError> {
+    let mut upload = Upload::new(hosts, app_key, options)?;
+    upload.read(&mut reader).await?;
+    upload.finish().await
+}
+
 struct ObjectUpload {
     start: u64,
     end: u64,
@@ -131,369 +414,116 @@ struct ObjectUpload {
 ///
 /// The caller must call [finalize](Self::finalize) to complete the upload.
 pub struct PackedUpload {
-    slab_size: u64,
-    length: u64,
-    writer: WriteHalf<SimplexStream>,
+    total_length: u64,
+    upload: Upload,
     objects: Vec<ObjectUpload>,
-    upload_handle: AbortOnDropHandle<Result<Vec<Slab>, UploadError>>,
 }
 
 impl PackedUpload {
+    pub(crate) fn new(
+        client: Hosts<Client>,
+        app_key: Arc<AppKey>,
+        options: UploadOptions,
+    ) -> Result<Self, UploadError> {
+        Ok(Self {
+            total_length: 0,
+            upload: Upload::new(client, app_key, options)?,
+            objects: Vec::new(),
+        })
+    }
+
     /// Returns the number of bytes remaining until reaching the optimal
     /// packed size. Adding objects larger than this will start a new slab.
     /// To minimize padding, prioritize objects that fit within the
     /// remaining size.
     pub fn remaining(&self) -> u64 {
-        if self.length == 0 {
-            return self.slab_size;
-        }
-        (self.slab_size - (self.length % self.slab_size)) % self.slab_size
+        self.upload.remaining() as u64
     }
 
     /// Returns the cumulative length of all objects currently in the upload.
     pub fn length(&self) -> u64 {
-        self.length
+        self.total_length
     }
 
     /// Returns the optimal size of each slab.
     pub fn slab_size(&self) -> u64 {
-        self.slab_size
+        self.upload.slab_size() as u64
     }
 
     /// Returns the number of slabs after the upload is finalized.
     pub fn slabs(&self) -> u64 {
-        self.length.div_ceil(self.slab_size)
+        self.length().div_ceil(self.slab_size())
     }
 
-    /// Cancels the upload.
-    pub fn cancel(self) {
-        self.upload_handle.abort();
+    /// Adds a new object to the upload. The data will be read until EOF and packed into
+    /// the upload. The resulting object will contain the metadata needed to download the object. The caller
+    /// must call [finalize](Self::finalize) to get the resulting objects after all objects have been added.
+    pub async fn add<R: AsyncRead + Unpin>(&mut self, r: R) -> Result<u64, UploadError> {
+        let object = Object::default();
+
+        let start = self.total_length;
+        let n = self.upload.read(&mut object.reader(r, 0)).await?;
+        self.total_length += n;
+        let end = self.total_length;
+        self.objects.push(ObjectUpload { start, end, object });
+        Ok(n)
     }
 
     /// Finalizes the upload and returns the resulting objects. This will wait for all readers
     /// to finish and all slabs to be uploaded before returning. The resulting objects will contain the metadata needed to download the objects.
     ///
     /// The caller must pin the resulting objects to the indexer when ready.
-    pub async fn finalize(mut self) -> Result<Vec<Object>, UploadError> {
-        let _ = self.writer.shutdown().await; // ignore error
-        let uploaded_slabs = self.upload_handle.await??;
+    pub async fn finalize(self) -> Result<Vec<Object>, UploadError> {
+        let slab_size = self.slab_size();
+        let uploaded_slabs = self.upload.finish().await?;
         self.objects
             .into_iter()
             .map(|upload| {
                 let mut object = upload.object;
+                if upload.start == upload.end {
+                    // empty object: nothing to splice in, leave it with zero slabs
+                    return Ok(object);
+                }
                 let slabs = object.slabs_mut();
-                let slabs_start = upload.start / self.slab_size;
-                let slabs_end = upload.end.div_ceil(self.slab_size);
+                let slabs_start = (upload.start / slab_size) as usize;
+                let slabs_end = upload.end.div_ceil(slab_size) as usize;
                 let n = slabs_end - slabs_start;
-                slabs.extend_from_slice(&uploaded_slabs[slabs_start as usize..slabs_end as usize]);
+                slabs.extend_from_slice(&uploaded_slabs[slabs_start..slabs_end]);
 
-                slabs[0].offset = (upload.start % self.slab_size) as u32;
+                slabs[0].offset = (upload.start % slab_size) as u32;
                 if slabs.len() > 1 {
                     // if spanning multiple slabs, adjust first slab's length
-                    slabs[0].length = (self.slab_size - slabs[0].offset as u64) as u32;
+                    slabs[0].length = (slab_size - slabs[0].offset as u64) as u32;
                 }
-                let last_slab_index = (n - 1) as usize;
+                let last_slab_index = n - 1;
                 let last_slab_offset = slabs[last_slab_index].offset as u64;
                 slabs[last_slab_index].length =
-                    (upload.end - ((slabs_end - 1) * self.slab_size) - last_slab_offset) as u32;
+                    (upload.end - ((slabs_end as u64 - 1) * slab_size) - last_slab_offset) as u32;
 
                 Ok(object)
             })
             .collect()
     }
-
-    /// Adds a new object to the upload. The data will be read until EOF and packed into
-    /// the upload. The resulting object will contain the metadata needed to download the object. The caller
-    /// must call [finalize](Self::finalize) to get the resulting objects after all objects have been added.
-    pub async fn add<R: AsyncRead + Unpin>(&mut self, r: R) -> io::Result<u64> {
-        if self.upload_handle.is_finished() {
-            // should only happen if the upload errored; callers can get the error by calling finalize
-            return Err(io::Error::other("cannot add object to finalized upload"));
-        }
-        let object = Object::default();
-        let mut r = object.reader(r, 0);
-        let object_length = copy(&mut r, &mut self.writer).await?;
-        let start = self.length;
-        let end = start + object_length;
-        self.objects.push(ObjectUpload { start, end, object });
-        self.length += object_length;
-        Ok(object_length)
-    }
 }
 
-#[derive(Clone)]
-pub(crate) struct Uploader<T: Transport> {
+/// Reads until EOF and uploads all slabs. The data will be erasure coded,
+/// encrypted, and uploaded.
+///
+/// Pass [`Object::default()`] for new uploads. To resume a previous upload,
+/// pass the object returned from the earlier call. Appending data changes
+/// an object's ID. It must be re-pinned afterward and any references to
+/// the previous ID must be updated.
+pub(crate) async fn upload_object<R: AsyncRead + Unpin>(
+    hosts: Hosts<Client>,
     app_key: Arc<AppKey>,
-    hosts: Hosts<T>,
-}
-
-impl<T: Transport> Uploader<T> {
-    pub fn new(hosts: Hosts<T>, app_key: Arc<AppKey>) -> Self {
-        Uploader { app_key, hosts }
-    }
-
-    fn upload_timeout(attempts: usize) -> Duration {
-        Duration::from_secs((10 + (5 * attempts as u64)).min(120))
-    }
-
-    async fn upload_slab_shard(
-        shard: ShardUpload<T>,
-        permit: OwnedSemaphorePermit,
-        progress_callback: Option<ShardProgressCallback>,
-        initial_host: (PublicKey, usize),
-    ) -> Result<(usize, Sector), UploadError> {
-        let (host_key, attempts) = initial_host;
-        let write_timeout = Self::upload_timeout(attempts);
-        let semaphore = permit.semaphore().clone();
-        let mut tasks = JoinSet::new();
-        shard.spawn_write(&mut tasks, host_key, write_timeout, permit);
-        loop {
-            let active = tasks.len();
-            tokio::select! {
-                biased;
-                Some(res) = tasks.join_next() => {
-                    match res.unwrap() {
-                        Ok((sector, elapsed)) => {
-                            if sector.host_key != host_key {
-                                debug!("slab {} shard {} penalizing original host {}", shard.slab_index, shard.shard_index, host_key);
-                                shard.client.add_failure(host_key)
-                            }
-                            if let Some(progress_callback) = progress_callback {
-                                progress_callback(ShardProgress {
-                                    host_key: sector.host_key,
-                                    shard_index: shard.shard_index,
-                                    slab_index: shard.slab_index,
-                                    shard_size: SECTOR_SIZE,
-                                    elapsed,
-                                });
-                            }
-                            return Ok((shard.shard_index, sector));
-                        }
-                        Err(_) => {
-                            if tasks.is_empty() {
-                                let (host_key, attempts) = shard.hosts.pop_front()?;
-                                let write_timeout = Self::upload_timeout(attempts);
-                                let permit = semaphore.clone().acquire_owned().await?;
-                                shard.spawn_write(&mut tasks, host_key, write_timeout, permit);
-                            }
-                        }
-                    }
-                },
-                _ = sleep(Duration::from_secs(active.max(1) as u64)) => {
-                    if let Ok(racer) = semaphore.clone().try_acquire_owned()
-                        && let Ok((host_key, attempts)) = shard.hosts.pop_front() {
-                            debug!("slab {} shard {} racing slow host", shard.slab_index, shard.shard_index);
-                            let write_timeout = Self::upload_timeout(attempts);
-                            shard.spawn_write(&mut tasks, host_key, write_timeout, racer);
-                        }
-                }
-            }
-        }
-    }
-
-    pub(crate) async fn upload_slabs<R: AsyncRead + Unpin + 'static>(
-        client: Hosts<T>,
-        app_key: Arc<AppKey>,
-        r: R,
-        options: UploadOptions,
-    ) -> Result<Vec<Slab>, UploadError> {
-        options.validate()?;
-        let data_shards = options.data_shards as usize;
-        let parity_shards = options.parity_shards as usize;
-        let total_shards = data_shards + parity_shards;
-
-        // fail fast if there aren't enough hosts before doing any encoding
-        if client.available_for_upload() < total_shards {
-            return Err(QueueError::InsufficientHosts.into());
-        }
-
-        // hard cap all shard uploads including races
-        let shard_sema = Arc::new(Semaphore::new(options.max_inflight));
-        // cap number of "active" slabs to limit memory usage.
-        let slab_sema = Arc::new(Semaphore::new(
-            options
-                .max_inflight
-                .div_ceil(total_shards)
-                .saturating_add(1),
-        ));
-
-        // use a buffered reader since the erasure coder reads 64 bytes at a time.
-        let mut r = BufReader::new(r);
-        let mut slab_upload_tasks = JoinSet::new();
-        let rs = Arc::new(ErasureCoder::new(data_shards, parity_shards).unwrap());
-        let mut slab_index: usize = 0;
-        loop {
-            let slab_permit = slab_sema.clone().acquire_owned().await?;
-            let mut shards = vec![BytesMut::zeroed(SECTOR_SIZE); total_shards];
-            let length =
-                ErasureCoder::read_slab_shards(&mut r, options.data_shards as usize, &mut shards)
-                    .await?;
-            if length == 0 {
-                break; // EoF
-            }
-
-            let app_key = app_key.clone();
-            let client = client.clone();
-            let progress_tx = options.shard_uploaded.clone();
-            let rs = rs.clone();
-            let shard_sema = shard_sema.clone();
-
-            join_set_spawn!(slab_upload_tasks, async move {
-                let _slab_guard = slab_permit;
-
-                // note: it may seem like a good idea to start uploading the data shards
-                // while the parity shards are being calculated, but this also forces
-                // cloning the rather large shards and ends up being a net performance
-                // decrease (~8%).
-                //
-                // It could probably be resolved by using a pool, but leaving that as a
-                // future optimization for now.
-                let shards = maybe_spawn_blocking!({
-                    rs.encode_shards(&mut shards)?;
-                    Ok::<_, erasure_coding::Error>(shards)
-                })?;
-
-                // generate a unique encryption key for the slab
-                let slab_key: EncryptionKey = rand::random::<[u8; 32]>().into();
-
-                let host_queue = client.upload_queue();
-                // reserve one host per shard upfront to guarantee each shard has at least one host
-                let reserved_hosts = host_queue.pop_n(shards.len())?;
-                let owned_slab_key = Arc::new(slab_key.clone());
-                let start_time = Instant::now();
-                let mut shard_upload_tasks = JoinSet::new();
-                for (shard_index, mut shard) in shards.into_iter().enumerate() {
-                    let app_key = app_key.clone();
-                    let owned_slab_key = owned_slab_key.clone();
-                    let permit = shard_sema.clone().acquire_owned().await?;
-                    let host_queue = host_queue.clone();
-                    let progress_tx = progress_tx.clone();
-                    let initial_host = reserved_hosts[shard_index];
-                    let client = client.clone();
-                    // spawn a task to encrypt and upload each shard for this slab.
-                    join_set_spawn!(shard_upload_tasks, async move {
-                        let shard = maybe_spawn_blocking!({
-                            encrypt_shard(&owned_slab_key, shard_index as u8, 0, &mut shard);
-                            shard
-                        });
-                        Self::upload_slab_shard(
-                            ShardUpload {
-                                client,
-                                hosts: host_queue,
-                                account_key: app_key,
-                                data: shard.into(),
-                                slab_index,
-                                shard_index,
-                            },
-                            permit,
-                            progress_tx,
-                            initial_host,
-                        )
-                        .await
-                    });
-                }
-
-                let mut slab_sectors = vec![None; data_shards + parity_shards];
-                while let Some(res) = shard_upload_tasks.join_next().await {
-                    match res {
-                        Ok(Ok((shard_index, sector))) => {
-                            slab_sectors[shard_index] = Some(sector);
-                        }
-                        Ok(Err(e)) => {
-                            return Err(e);
-                        }
-                        Err(e) => {
-                            return Err(e.into());
-                        }
-                    };
-                }
-                debug!(
-                    "slab {slab_index} uploaded in {:?}",
-                    Instant::now().duration_since(start_time)
-                );
-                Ok((
-                    slab_index,
-                    Slab {
-                        sectors: slab_sectors.into_iter().map(|s| s.unwrap()).collect(),
-                        encryption_key: slab_key,
-                        offset: 0,
-                        length: length as u32,
-                        min_shards: options.data_shards,
-                    },
-                ))
-            });
-            slab_index += 1;
-        }
-
-        let num_slabs = slab_upload_tasks.len();
-        let mut slabs: Vec<Option<Slab>> = vec![None; num_slabs];
-        while let Some(res) = slab_upload_tasks.join_next().await {
-            match res {
-                Ok(Ok((slab_index, slab))) => {
-                    slabs[slab_index] = Some(slab);
-                }
-                Ok(Err(e)) => return Err(e),
-                Err(e) => return Err(e.into()),
-            };
-        }
-        let slabs = slabs.into_iter().map(|s| s.unwrap()).collect();
-        Ok(slabs)
-    }
-
-    /// Reads until EOF and uploads all slabs. The data will be erasure coded,
-    /// encrypted, and uploaded.
-    ///
-    /// Pass [`Object::default()`] for new uploads. To resume a previous upload,
-    /// pass the object returned from the earlier call. Appending data changes
-    /// an object's ID. It must be re-pinned afterward and any references to
-    /// the previous ID must be updated.
-    ///
-    /// # Arguments
-    /// * `object` - The object to upload into. Use `Object::default()` for new uploads.
-    /// * `r` - The reader to read the data from. It will be read until EOF.
-    /// * `options` - The [UploadOptions] to use for the upload.
-    ///
-    /// # Returns
-    /// The object containing the metadata needed to download. The caller must
-    /// pin the object to the indexer after uploading.
-    pub async fn upload<R: AsyncRead + Unpin + 'static>(
-        &self,
-        mut object: Object,
-        r: R,
-        options: UploadOptions,
-    ) -> Result<Object, UploadError> {
-        // use a buffered reader since the erasure coder reads 64 bytes at a time.
-        let r = object.reader(BufReader::new(r), object.size());
-        let new_slabs =
-            Self::upload_slabs(self.hosts.clone(), self.app_key.clone(), r, options).await?;
-        let slabs = object.slabs_mut();
-        slabs.extend(new_slabs);
-        Ok(object)
-    }
-
-    /// Creates a new packed upload. This allows multiple objects to be packed together
-    /// for more efficient uploads. The returned `PackedUpload` can be used to add objects to the upload, and then finalized to get the resulting objects.
-    ///
-    /// # Arguments
-    /// * `options` - The [UploadOptions] to use for the upload.
-    ///
-    /// # Returns
-    /// A [PackedUpload] that can be used to add objects and finalize the upload.
-    pub fn upload_packed(&self, options: UploadOptions) -> PackedUpload {
-        let app_key = self.app_key.clone();
-        let (reader, writer) = simplex(1024 * 1024);
-        let client = self.hosts.clone();
-        PackedUpload {
-            slab_size: options.data_shards as u64 * rhp::SECTOR_SIZE as u64,
-            length: 0,
-            writer,
-            objects: Vec::new(),
-            upload_handle: AbortOnDropHandle::new(maybe_spawn!(async move {
-                let slabs = Self::upload_slabs(client, app_key, reader, options).await?;
-                Ok(slabs)
-            })),
-        }
-    }
+    mut object: Object,
+    reader: R,
+    options: UploadOptions,
+) -> Result<Object, UploadError> {
+    let reader = object.reader(reader, object.size());
+    let new_slabs = upload_slabs(hosts, app_key, reader, options).await?;
+    object.slabs_mut().extend(new_slabs);
+    Ok(object)
 }
 
 #[cfg(test)]

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -12,6 +12,7 @@ use std::time::SystemTime;
 use thiserror::Error;
 use tokio::runtime::{self, Runtime};
 use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
 
 mod logging;
@@ -679,7 +680,7 @@ impl PackedUpload {
 #[derive(uniffi::Object)]
 pub struct Download {
     inner: Arc<tokio::sync::Mutex<Option<sia_storage::Download>>>,
-    cancel: tokio_util::sync::CancellationToken,
+    cancel: CancellationToken,
 }
 
 #[uniffi::export]
@@ -827,17 +828,18 @@ impl Sdk {
     ///
     /// # Returns
     /// A [PackedUpload] that can be used to add objects and finalize the upload.
-    pub async fn upload_packed(&self, options: UploadOptions) -> PackedUpload {
-        let sdk = self.inner.clone();
-        let (action_tx, mut action_rx) = mpsc::channel(10);
+    pub async fn upload_packed(&self, options: UploadOptions) -> Result<PackedUpload, UploadError> {
         let options: sia_storage::UploadOptions = options.into();
         let slab_size = options.data_shards as u64 * SECTOR_SIZE as u64;
+        let mut packed_upload = self
+            .inner
+            .upload_packed(options)
+            .map_err(UploadError::from)?;
+        let (action_tx, mut action_rx) = mpsc::channel(10);
         let length = Arc::new(AtomicU64::new(0));
         let closed = Arc::new(AtomicBool::new(false));
-
         let task_length = length.clone();
         let upload_task = spawn(async move {
-            let mut packed_upload = sdk.upload_packed(options);
             while let Some(action) = action_rx.recv().await {
                 match action {
                     PackedUploadAction::Add(reader, add_tx) => {
@@ -858,14 +860,13 @@ impl Sdk {
                 }
             }
         });
-
-        PackedUpload {
+        Ok(PackedUpload {
             upload_task,
             tx: action_tx,
             slab_size,
             length,
             closed,
-        }
+        })
     }
 
     /// Uploads data to the Sia network.
@@ -914,7 +915,7 @@ impl Sdk {
         let reader = self.inner.download(&object.object(), options.into())?;
         Ok(Download {
             inner: Arc::new(tokio::sync::Mutex::new(Some(reader))),
-            cancel: tokio_util::sync::CancellationToken::new(),
+            cancel: CancellationToken::new(),
         })
     }
 

--- a/sia_storage_napi/package.json
+++ b/sia_storage_napi/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "napi build --release --esm --platform -o examples",
-    "test": "node examples/test.mjs"
+    "test": "node examples/test.mjs",
+    "benchmark": "node examples/benchmark.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3"

--- a/sia_storage_napi/src/lib.rs
+++ b/sia_storage_napi/src/lib.rs
@@ -660,24 +660,22 @@ impl Sdk {
     /// Creates a new packed upload for efficiently uploading multiple small
     /// objects together. Returns a `PackedUpload` handle.
     #[napi(ts_args_type = "options?: UploadOptions")]
-    pub fn upload_packed(&self, options: Option<SendableUploadOptions>) -> PackedUpload {
+    pub fn upload_packed(&self, options: Option<SendableUploadOptions>) -> Result<PackedUpload> {
         let options: sia_storage::UploadOptions = options.map(|o| o.0).unwrap_or_default();
-        let sdk = self.inner.clone();
+        let slab_size = SECTOR_SIZE as u64 * options.data_shards as u64;
+        let mut packed_upload = self
+            .inner
+            .upload_packed(options)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let (action_tx, mut action_rx) = mpsc::channel(10);
         let length = Arc::new(AtomicU64::new(0));
         let closed = Arc::new(AtomicBool::new(false));
-        let (action_tx, mut action_rx) = mpsc::channel(10);
-        let slab_size = SECTOR_SIZE as u64 * options.data_shards as u64;
         let task_length = length.clone();
-        let upload_task = spawn(async move {
-            let mut packed_upload = sdk.upload_packed(options);
-
+        let upload_task = tokio::spawn(async move {
             while let Some(action) = action_rx.recv().await {
                 match action {
                     PackedUploadAction::Add(reader, add_tx) => {
-                        let res = packed_upload
-                            .add(reader)
-                            .await
-                            .map_err(sia_storage::UploadError::from);
+                        let res = packed_upload.add(reader).await;
                         if let Ok(size) = res {
                             task_length.fetch_add(size, Ordering::AcqRel);
                         }
@@ -691,14 +689,13 @@ impl Sdk {
                 }
             }
         });
-
-        PackedUpload {
+        Ok(PackedUpload {
             upload_task,
             tx: action_tx,
             slab_size,
             length,
             closed,
-        }
+        })
     }
 
     /// Uploads data to the Sia network.

--- a/sia_storage_wasm/examples/main.js
+++ b/sia_storage_wasm/examples/main.js
@@ -1,6 +1,5 @@
 import init, {
   Builder,
-  setLogger,
   generateRecoveryPhrase,
   PinnedObject,
 } from './pkg/sia_storage_wasm.js';
@@ -45,7 +44,6 @@ function askUser(label) {
 
 async function main() {
   await init();
-  setLogger((msg) => console.log(msg), 'info');
 
   // -- builder flow --
   const builder = new Builder(INDEXER_URL, {

--- a/sia_storage_wasm/src/packed.rs
+++ b/sia_storage_wasm/src/packed.rs
@@ -1,13 +1,23 @@
 use std::cell::Cell;
-use std::sync::Arc;
-use tokio::sync::{Mutex, Notify};
-use tokio_util::compat::FuturesAsyncReadCompatExt;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt};
+use wasm_streams::readable::IntoAsyncRead;
 
 use sia_storage::PackedUpload as CorePackedUpload;
 use wasm_bindgen::prelude::*;
 
 use crate::helpers::to_js_err;
 use crate::object::PinnedObject;
+
+type PackedReader = Compat<IntoAsyncRead<'static>>;
+
+enum PackedUploadAction {
+    Add(
+        PackedReader,
+        oneshot::Sender<Result<u64, sia_storage::UploadError>>,
+    ),
+    Finalize(oneshot::Sender<Result<Vec<sia_storage::Object>, sia_storage::UploadError>>),
+}
 
 /// A packed upload handle for efficiently uploading multiple objects
 /// together. Objects are packed into shared slabs to avoid wasting storage.
@@ -21,20 +31,39 @@ use crate::object::PinnedObject;
 /// ```
 #[wasm_bindgen]
 pub struct PackedUpload {
-    inner: Arc<Mutex<Option<CorePackedUpload>>>,
-    cancelled: Arc<Notify>,
+    upload_task: tokio::task::JoinHandle<()>,
+    tx: mpsc::Sender<PackedUploadAction>,
     slab_size: f64,
     length: Cell<f64>,
+    closed: Cell<bool>,
 }
 
 impl PackedUpload {
     pub(crate) fn new(inner: CorePackedUpload) -> Self {
         let slab_size = inner.slab_size() as f64;
+        let (action_tx, mut action_rx) = mpsc::channel(10);
+        let upload_task = tokio::task::spawn_local(async move {
+            let mut packed_upload = inner;
+            while let Some(action) = action_rx.recv().await {
+                match action {
+                    PackedUploadAction::Add(reader, add_tx) => {
+                        let res = packed_upload.add(reader).await;
+                        let _ = add_tx.send(res);
+                    }
+                    PackedUploadAction::Finalize(finalize_tx) => {
+                        let result = packed_upload.finalize().await;
+                        let _ = finalize_tx.send(result);
+                        return;
+                    }
+                }
+            }
+        });
         Self {
-            inner: Arc::new(Mutex::new(Some(inner))),
-            cancelled: Arc::new(Notify::new()),
+            upload_task,
+            tx: action_tx,
             slab_size,
             length: Cell::new(0.0),
+            closed: Cell::new(false),
         }
     }
 }
@@ -81,54 +110,52 @@ impl PackedUpload {
     /// await packed.add(blob.stream());
     /// ```
     pub async fn add(&self, stream: web_sys::ReadableStream) -> Result<f64, JsError> {
+        if self.closed.get() {
+            return Err(JsError::new("upload already finalized"));
+        }
         let reader = wasm_streams::ReadableStream::from_raw(stream)
             .into_async_read()
             .compat();
-        let inner = self.inner.clone();
-        let cancelled = self.cancelled.clone();
-        let (size, length) = crate::run_local(async move {
-            let mut guard = tokio::select! {
-                _ = cancelled.notified() => {
-                    return Err(JsError::new("upload cancelled"));
-                }
-                guard = inner.lock() => guard,
-            };
-            let packed = guard
-                .as_mut()
-                .ok_or_else(|| JsError::new("upload already finalized"))?;
-            let size = tokio::select! {
-                _ = cancelled.notified() => {
-                    guard.take();
-                    return Err(JsError::new("upload cancelled"));
-                }
-                result = packed.add(reader) => result.map_err(to_js_err)?,
-            };
-            let length = packed.length() as f64;
-            Ok((size as f64, length))
-        })
-        .await?;
-        self.length.set(length);
+        let (add_tx, add_rx) = oneshot::channel();
+        self.tx
+            .send(PackedUploadAction::Add(reader, add_tx))
+            .await
+            .map_err(|_| JsError::new("upload closed"))?;
+        let size = add_rx
+            .await
+            .map_err(|_| JsError::new("upload closed"))?
+            .map_err(to_js_err)?;
+        let size = size as f64;
+        self.length.set(self.length.get() + size);
         Ok(size)
     }
 
     /// Finalizes the packed upload and returns the resulting objects.
     /// Each object must be pinned separately with `sdk.pinObject()`.
     pub async fn finalize(self) -> Result<Vec<PinnedObject>, JsError> {
-        let inner = self.inner.clone();
-        let objects = crate::run_local(async move {
-            let packed = inner
-                .lock()
-                .await
-                .take()
-                .ok_or_else(|| JsError::new("upload already finalized"))?;
-            packed.finalize().await.map_err(to_js_err)
-        })
-        .await?;
+        if self.closed.replace(true) {
+            return Err(JsError::new("upload already finalized"));
+        }
+        let (finalize_tx, finalize_rx) = oneshot::channel();
+        self.tx
+            .send(PackedUploadAction::Finalize(finalize_tx))
+            .await
+            .map_err(|_| JsError::new("upload closed"))?;
+        let objects = finalize_rx
+            .await
+            .map_err(|_| JsError::new("upload closed"))?
+            .map_err(to_js_err)?;
         Ok(objects.into_iter().map(PinnedObject).collect())
     }
 
-    /// Cancels the packed upload. Immediately interrupts any in-flight `add`.
+    /// Cancels the packed upload. Immediately interrupts any in-flight `add`
+    /// and aborts all pending slab uploads.
     pub fn cancel(&self) {
-        self.cancelled.notify_waiters();
+        if self.closed.replace(true) {
+            return;
+        }
+        // Aborting the task drops the owned PackedUpload, which aborts every
+        // pending slab task via AbortOnDropHandle inside the core upload.
+        self.upload_task.abort();
     }
 }

--- a/sia_storage_wasm/src/sdk.rs
+++ b/sia_storage_wasm/src/sdk.rs
@@ -203,7 +203,9 @@ impl Sdk {
     #[wasm_bindgen(js_name = "uploadPacked")]
     pub fn upload_packed(&self, options: Option<JsValue>) -> Result<PackedUpload, JsError> {
         let opts = options.map(upload_options_from_js).unwrap_or_default();
-        Ok(PackedUpload::new(self.inner.upload_packed(opts)))
+        Ok(PackedUpload::new(
+            self.inner.upload_packed(opts).map_err(to_js_err)?,
+        ))
     }
 
     /// Generates a signed share URL for an object. Anyone with the URL can


### PR DESCRIPTION
Replaces the `Uploader` struct with a single use upload pipeline, similar to downloads. Removes the need for the additional simplex pipelining in upload packing. Changes WASM upload packing to use a spawned task and channel to drive actions to bring its behavior in line with the other platforms.

Partially ported from #306.  

```
Benchmarking 120MiB/upload/10 inflight: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 62.0s, or reduce sample count to 10.
120MiB/upload/10 inflight
                        time:   [618.85 ms 621.83 ms 625.34 ms]
                        thrpt:  [191.90 MiB/s 192.98 MiB/s 193.91 MiB/s]
                 change:
                        time:   [−6.3331% −5.8011% −5.2430%] (p = 0.00 < 0.05)
                        thrpt:  [+5.5331% +6.1584% +6.7614%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
Benchmarking 120MiB/upload/default: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 66.9s, or reduce sample count to 10.
120MiB/upload/default   time:   [637.57 ms 639.80 ms 642.18 ms]
                        thrpt:  [186.86 MiB/s 187.56 MiB/s 188.21 MiB/s]
                 change:
                        time:   [−5.0503% −4.5590% −4.0524%] (p = 0.00 < 0.05)
                        thrpt:  [+4.2235% +4.7768% +5.3190%]
                        Performance has improved.
```