### PR TITLE
More consistent timeouts

### DIFF
--- a/.changeset/uploads_will_no_longer_block_indefinitely_until_completion.md
+++ b/.changeset/uploads_will_no_longer_block_indefinitely_until_completion.md
@@ -1,0 +1,11 @@
+---
+default: minor
+---
+
+# Uploads will no longer block indefinitely until completion.
+
+Removed the progressive upload timeout and hosts are now retried a maximum of 3 times before giving up. The default 
+timeout is now 1.5m per shard per attempt. This should give enough time on slow connections. Racing and prioritization
+will still prioritize faster hosts after warming up.
+
+Users can still manually timeout 

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -506,14 +506,11 @@ impl<T: Transport> Hosts<T> {
         {
             Ok((prices, false))
         } else {
-            let start = Instant::now();
-            let prices = timeout(fetch_timeout, transport.host_prices(host_endpoint))
+            let (prices, elapsed) = timeout(fetch_timeout, transport.host_prices(host_endpoint))
                 .await
                 .inspect_err(|_| hosts.add_failure(host_endpoint.public_key))?
-                .inspect_err(|_| hosts.add_failure(host_endpoint.public_key))
-                .inspect(|_| {
-                    hosts.add_settings_sample(host_endpoint.public_key, start.elapsed())
-                })?;
+                .inspect_err(|_| hosts.add_failure(host_endpoint.public_key))?;
+            hosts.add_settings_sample(host_endpoint.public_key, elapsed);
             cache.set(host_endpoint.public_key, prices.clone());
             Ok((prices, true))
         }
@@ -537,14 +534,13 @@ impl<T: Transport> Hosts<T> {
                 false,
             )
             .await?;
-            let start = Instant::now();
-            let root = self
+            let (root, elapsed) = self
                 .transport
                 .write_sector(&host, prices, account_key, sector)
                 .await
                 .inspect_err(|_| self.hosts.add_failure(host_key))
                 .map_err(RPCError::Rhp)?;
-            self.hosts.add_write_sample(host_key, start.elapsed());
+            self.hosts.add_write_sample(host_key, elapsed);
             Ok(root)
         })
         .await?
@@ -570,14 +566,13 @@ impl<T: Transport> Hosts<T> {
                 false,
             )
             .await?;
-            let start = Instant::now();
-            let data = self
+            let (data, elapsed) = self
                 .transport
                 .read_sector(&host, prices, account_key, root, offset, length)
                 .await
                 .inspect_err(|_| self.hosts.add_failure(host_key))
                 .map_err(RPCError::Rhp)?;
-            self.hosts.add_read_sample(host_key, start.elapsed());
+            self.hosts.add_read_sample(host_key, elapsed);
             Ok(data)
         })
         .await?
@@ -599,7 +594,14 @@ pub enum QueueError {
     /// An internal mutex was poisoned.
     #[error("internal mutex error")]
     MutexError,
+    /// The host has been retried too many times.
+    #[error("host retry limit exceeded")]
+    MaxRetriesExceeded,
 }
+
+/// Maximum number of times a single host may be re-queued via
+/// [`HostQueue::retry`] before it is dropped.
+const MAX_RETRIES: usize = 3;
 
 #[derive(Debug)]
 struct HostQueueInner {
@@ -617,7 +619,7 @@ impl Iterator for HostQueue {
     type Item = PublicKey;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.pop_front().ok().map(|(host, _)| host)
+        self.pop_front().ok()
     }
 }
 
@@ -631,15 +633,12 @@ impl HostQueue {
         }
     }
 
-    pub fn pop_front(&self) -> Result<(PublicKey, usize), QueueError> {
+    pub fn pop_front(&self) -> Result<PublicKey, QueueError> {
         let mut inner = self.inner.lock().map_err(|_| QueueError::MutexError)?;
-        let host_key = inner.hosts.pop_front().ok_or(QueueError::NoMoreHosts)?;
-
-        let attempts = inner.attempts.get(&host_key).cloned().unwrap_or(0);
-        Ok((host_key, attempts + 1))
+        inner.hosts.pop_front().ok_or(QueueError::NoMoreHosts)
     }
 
-    pub fn pop_n(&self, n: usize) -> Result<Vec<(PublicKey, usize)>, QueueError> {
+    pub fn pop_n(&self, n: usize) -> Result<Vec<PublicKey>, QueueError> {
         let mut inner = self.inner.lock().map_err(|_| QueueError::MutexError)?;
         if inner.hosts.len() < n {
             return Err(QueueError::NoMoreHosts);
@@ -647,14 +646,17 @@ impl HostQueue {
         let mut result = Vec::with_capacity(n);
         for _ in 0..n {
             let host_key = inner.hosts.pop_front().ok_or(QueueError::NoMoreHosts)?;
-            let attempts = inner.attempts.get(&host_key).cloned().unwrap_or(0);
-            result.push((host_key, attempts + 1));
+            result.push(host_key);
         }
         Ok(result)
     }
 
     pub fn retry(&self, host: PublicKey) -> Result<(), QueueError> {
         let mut inner = self.inner.lock().map_err(|_| QueueError::MutexError)?;
+        let attempts = inner.attempts.get(&host).copied().unwrap_or(0);
+        if attempts >= MAX_RETRIES {
+            return Err(QueueError::MaxRetriesExceeded);
+        }
         inner.hosts.push_back(host);
         inner
             .attempts
@@ -862,7 +864,7 @@ mod test {
         );
 
         let queue = hosts_manager.upload_queue();
-        let (first, _) = queue.pop_front().unwrap();
+        let first = queue.pop_front().unwrap();
         assert_eq!(first, hk2);
         assert!(
             queue.pop_front().is_err(),
@@ -879,18 +881,15 @@ mod test {
         // pop 3 hosts
         let popped = queue.pop_n(3).expect("should pop 3 hosts");
         assert_eq!(popped.len(), 3);
-        assert_eq!(popped[0].0, hosts[0]);
-        assert_eq!(popped[1].0, hosts[1]);
-        assert_eq!(popped[2].0, hosts[2]);
-
-        // all should have attempts = 1
-        assert!(popped.iter().all(|(_, attempts)| *attempts == 1));
+        assert_eq!(popped[0], hosts[0]);
+        assert_eq!(popped[1], hosts[1]);
+        assert_eq!(popped[2], hosts[2]);
 
         // pop remaining 2
         let popped = queue.pop_n(2).expect("should pop 2 hosts");
         assert_eq!(popped.len(), 2);
-        assert_eq!(popped[0].0, hosts[3]);
-        assert_eq!(popped[1].0, hosts[4]);
+        assert_eq!(popped[0], hosts[3]);
+        assert_eq!(popped[1], hosts[4]);
 
         // queue should be empty
         assert!(matches!(queue.pop_front(), Err(QueueError::NoMoreHosts)));

--- a/sia_storage/src/rhp4.rs
+++ b/sia_storage/src/rhp4.rs
@@ -7,7 +7,7 @@ use sia_core::types::Hash256;
 use sia_core::types::v2::NetAddress;
 use thiserror::Error;
 
-use crate::time::Elapsed;
+use crate::time::{Duration, Elapsed};
 
 #[cfg(not(any(test, feature = "mock", target_arch = "wasm32")))]
 mod siamux;
@@ -59,18 +59,23 @@ pub(crate) struct HostEndpoint {
 }
 
 /// Trait defining the operations that can be performed on a host.
+///
+/// Each RPC returns the on-wire duration of the RPC alongside its result. The
+/// duration measures only the time spent exchanging request/response bytes —
+/// it excludes connection setup and stream opening. Callers can feed it into
+/// host performance tracking without contamination from pool-miss costs.
 pub(crate) trait Transport: Clone + Unpin + MaybeSendSync + 'static {
     fn host_prices(
         &self,
         host: &HostEndpoint,
-    ) -> impl Future<Output = Result<HostPrices, Error>> + MaybeSendSync;
+    ) -> impl Future<Output = Result<(HostPrices, Duration), Error>> + MaybeSendSync;
     fn write_sector(
         &self,
         host: &HostEndpoint,
         prices: HostPrices,
         account_key: &PrivateKey,
         sector: Bytes,
-    ) -> impl Future<Output = Result<Hash256, Error>> + MaybeSendSync;
+    ) -> impl Future<Output = Result<(Hash256, Duration), Error>> + MaybeSendSync;
     fn read_sector(
         &self,
         host: &HostEndpoint,
@@ -79,7 +84,7 @@ pub(crate) trait Transport: Clone + Unpin + MaybeSendSync + 'static {
         root: Hash256,
         offset: usize,
         length: usize,
-    ) -> impl Future<Output = Result<Bytes, Error>> + MaybeSendSync;
+    ) -> impl Future<Output = Result<(Bytes, Duration), Error>> + MaybeSendSync;
 }
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) trait MaybeSendSync: Send + Sync {}

--- a/sia_storage/src/rhp4/mock.rs
+++ b/sia_storage/src/rhp4/mock.rs
@@ -8,7 +8,7 @@ use sia_core::signing::{PrivateKey, PublicKey, Signature};
 use sia_core::types::{Currency, Hash256};
 
 use super::{Error as RHP4Error, HostEndpoint, Transport};
-use crate::time::{Duration, sleep};
+use crate::time::{Duration, Instant, sleep};
 
 #[derive(Clone)]
 pub struct Client {
@@ -67,8 +67,9 @@ impl Client {
 }
 
 impl Transport for Client {
-    async fn host_prices(&self, _: &HostEndpoint) -> Result<HostPrices, RHP4Error> {
-        Ok(HostPrices {
+    async fn host_prices(&self, _: &HostEndpoint) -> Result<(HostPrices, Duration), RHP4Error> {
+        let start = Instant::now();
+        let prices = HostPrices {
             contract_price: Currency::zero(),
             collateral: Currency::zero(),
             ingress_price: Currency::zero(),
@@ -78,7 +79,8 @@ impl Transport for Client {
             tip_height: 1,
             signature: Signature::default(),
             valid_until: Utc::now() + chrono::Duration::days(1),
-        })
+        };
+        Ok((prices, start.elapsed()))
     }
 
     async fn write_sector(
@@ -87,10 +89,11 @@ impl Transport for Client {
         _: HostPrices,
         _: &PrivateKey,
         sector: Bytes,
-    ) -> Result<Hash256, RHP4Error> {
+    ) -> Result<(Hash256, Duration), RHP4Error> {
         if host.addresses.is_empty() {
             return Err(RHP4Error::Transport("host has no addresses".to_string()));
         }
+        let start = Instant::now();
         // Check if this host is configured as slow
         let slow_delay = {
             let slow_hosts = self.slow_hosts.read().unwrap();
@@ -112,7 +115,7 @@ impl Transport for Client {
         if let Some(delay) = *self.initial_read_delay.read().unwrap() {
             self.read_delays.write().unwrap().insert(sector_root, delay);
         }
-        Ok(sector_root)
+        Ok((sector_root, start.elapsed()))
     }
 
     async fn read_sector(
@@ -123,10 +126,11 @@ impl Transport for Client {
         root: Hash256,
         offset: usize,
         length: usize,
-    ) -> Result<Bytes, RHP4Error> {
+    ) -> Result<(Bytes, Duration), RHP4Error> {
         if host.addresses.is_empty() {
             return Err(RHP4Error::Transport("host has no addresses".to_string()));
         }
+        let start = Instant::now();
         // Check if this host is configured as slow
         let slow_delay = {
             let slow_hosts = self.slow_hosts.read().unwrap();
@@ -162,6 +166,6 @@ impl Transport for Client {
             Bytes::copy_from_slice(&sector[offset..offset + length])
         };
         sleep(Duration::from_nanos(sector.len() as u64 * 8 / 10)).await; // simulate network latency ~ 10Gbps
-        Ok(sector)
+        Ok((sector, start.elapsed()))
     }
 }

--- a/sia_storage/src/rhp4/siamux.rs
+++ b/sia_storage/src/rhp4/siamux.rs
@@ -1,4 +1,4 @@
-use crate::time::{Elapsed, timeout};
+use crate::time::{Elapsed, Instant, timeout};
 
 use bytes::Bytes;
 use core::fmt::Debug;
@@ -123,7 +123,7 @@ impl Client {
         };
         let conn = cell
             .get_or_try_init(|| async {
-                let mux = timeout(Duration::from_secs(5), self.new_conn(host))
+                let mux = timeout(Duration::from_secs(10), self.new_conn(host))
                     .await
                     .inspect_err(|e| {
                         debug!("siamux connection to {} timed out: {e}", host.public_key);
@@ -142,16 +142,20 @@ impl Client {
 }
 
 impl Transport for Client {
-    async fn host_prices(&self, host: &HostEndpoint) -> Result<HostPrices, TransportError> {
+    async fn host_prices(
+        &self,
+        host: &HostEndpoint,
+    ) -> Result<(HostPrices, Duration), TransportError> {
         let mut stream = self
             .host_stream(host)
             .await
             .map_err(|e| TransportError::Transport(e.to_string()))?;
+        let start = Instant::now();
         let resp = RPCSettings::send_request(&mut stream)
             .await?
             .complete(&mut stream)
             .await?;
-        Ok(resp.settings.prices)
+        Ok((resp.settings.prices, start.elapsed()))
     }
 
     async fn write_sector(
@@ -160,17 +164,18 @@ impl Transport for Client {
         prices: HostPrices,
         account_key: &PrivateKey,
         data: Bytes,
-    ) -> Result<Hash256, TransportError> {
+    ) -> Result<(Hash256, Duration), TransportError> {
         let token = AccountToken::new(account_key, host.public_key);
         let mut stream = self
             .host_stream(host)
             .await
             .map_err(|e| TransportError::Transport(e.to_string()))?;
+        let start = Instant::now();
         let resp = RPCWriteSector::send_request(&mut stream, prices, token, data)
             .await?
             .complete(&mut stream)
             .await?;
-        Ok(resp.root)
+        Ok((resp.root, start.elapsed()))
     }
 
     async fn read_sector(
@@ -181,16 +186,17 @@ impl Transport for Client {
         root: Hash256,
         offset: usize,
         length: usize,
-    ) -> Result<Bytes, TransportError> {
+    ) -> Result<(Bytes, Duration), TransportError> {
         let token = AccountToken::new(account_key, host.public_key);
         let mut stream = self
             .host_stream(host)
             .await
             .map_err(|e| TransportError::Transport(e.to_string()))?;
+        let start = Instant::now();
         let resp = RPCReadSector::send_request(&mut stream, prices, token, root, offset, length)
             .await?
             .complete(&mut stream)
             .await?;
-        Ok(resp.data)
+        Ok((resp.data, start.elapsed()))
     }
 }

--- a/sia_storage/src/rhp4/web_transport.rs
+++ b/sia_storage/src/rhp4/web_transport.rs
@@ -28,6 +28,8 @@ use tokio::sync::{OnceCell, Semaphore};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
+use crate::time::{Duration, Instant, timeout};
+
 use super::{Error, HostEndpoint, Transport};
 
 #[wasm_bindgen]
@@ -48,6 +50,11 @@ const RHP4_PATH: &str = "/sia/rhp/v4";
 /// connections; gating dials here prevents the browser from rejecting or
 /// stalling when many hosts are contacted at once.
 const MAX_PENDING_CONNS: usize = 64;
+
+/// Timeout for opening a bidirectional stream on an established connection.
+/// Independent of the per-RPC timeout so a hung `create_bidirectional_stream`
+/// can't consume the caller's full RPC budget.
+const OPEN_STREAM_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn js_err_message(e: &JsValue) -> String {
     if let Some(err) = e.dyn_ref::<js_sys::Error>() {
@@ -76,13 +83,16 @@ impl Drop for Connection {
 
 impl Connection {
     async fn open_stream(&self) -> Result<Stream, Error> {
-        let bidi: web_sys::WebTransportBidirectionalStream =
-            JsFuture::from(self.transport.create_bidirectional_stream())
-                .await
-                .map_err(|e| {
-                    Error::Transport(format!("createBidirectionalStream: {}", js_err_message(&e)))
-                })?
-                .unchecked_into();
+        let bidi: web_sys::WebTransportBidirectionalStream = timeout(
+            OPEN_STREAM_TIMEOUT,
+            JsFuture::from(self.transport.create_bidirectional_stream()),
+        )
+        .await
+        .map_err(|_| Error::Transport("createBidirectionalStream: timeout".into()))?
+        .map_err(|e| {
+            Error::Transport(format!("createBidirectionalStream: {}", js_err_message(&e)))
+        })?
+        .unchecked_into();
         let reader = bidi
             .readable()
             .get_reader()
@@ -310,15 +320,16 @@ impl Client {
 // returns large chunks from the network buffer, which Stream stores in
 // self.buf and serves to subsequent poll_read calls without further JS calls.
 impl Transport for Client {
-    async fn host_prices(&self, host: &HostEndpoint) -> Result<HostPrices, Error> {
+    async fn host_prices(&self, host: &HostEndpoint) -> Result<(HostPrices, Duration), Error> {
         let conn = self.connection(host).await?;
-        let result: Result<HostPrices, Error> = async {
+        let result: Result<(HostPrices, Duration), Error> = async {
             let mut stream = conn.open_stream().await?;
             let mut buf = Vec::new();
             let req = RPCSettings::send_request(&mut buf).await?;
+            let start = Instant::now();
             stream.write_all_async(&buf).await?;
             let resp = req.complete(&mut stream).await?;
-            Ok(resp.settings.prices)
+            Ok((resp.settings.prices, start.elapsed()))
         }
         .await;
         if let Err(e) = &result
@@ -335,16 +346,17 @@ impl Transport for Client {
         prices: HostPrices,
         account_key: &PrivateKey,
         data: Bytes,
-    ) -> Result<Hash256, Error> {
+    ) -> Result<(Hash256, Duration), Error> {
         let token = AccountToken::new(account_key, host.public_key);
         let conn = self.connection(host).await?;
-        let result: Result<Hash256, Error> = async {
+        let result: Result<(Hash256, Duration), Error> = async {
             let mut stream = conn.open_stream().await?;
             let mut buf = Vec::new();
             let req = RPCWriteSector::send_request(&mut buf, prices, token, data.clone()).await?;
+            let start = Instant::now();
             stream.write_all_async(&buf).await?;
             let resp = req.complete(&mut stream).await?;
-            Ok(resp.root)
+            Ok((resp.root, start.elapsed()))
         }
         .await;
         if let Err(e) = &result
@@ -363,17 +375,18 @@ impl Transport for Client {
         root: Hash256,
         offset: usize,
         length: usize,
-    ) -> Result<Bytes, Error> {
+    ) -> Result<(Bytes, Duration), Error> {
         let token = AccountToken::new(account_key, host.public_key);
         let conn = self.connection(host).await?;
-        let result: Result<Bytes, Error> = async {
+        let result: Result<(Bytes, Duration), Error> = async {
             let mut stream = conn.open_stream().await?;
             let mut buf = Vec::new();
             let req =
                 RPCReadSector::send_request(&mut buf, prices, token, root, offset, length).await?;
+            let start = Instant::now();
             stream.write_all_async(&buf).await?;
             let resp = req.complete(&mut stream).await?;
-            Ok(resp.data)
+            Ok((resp.data, start.elapsed()))
         }
         .await;
         if let Err(e) = &result

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -36,11 +36,9 @@ struct SectorUploadResult {
     elapsed: Duration,
 }
 
-impl ShardUpload {
-    fn upload_timeout(attempts: usize) -> Duration {
-        Duration::from_secs((10 + (5 * attempts as u64)).min(120))
-    }
+const UPLOAD_TIMEOUT: Duration = Duration::from_secs(90);
 
+impl ShardUpload {
     fn spawn_write(
         &self,
         tasks: &mut JoinSet<Result<SectorUploadResult, UploadError>>,
@@ -78,15 +76,10 @@ impl ShardUpload {
         });
     }
 
-    async fn upload_shard(
-        self,
-        initial_host: (PublicKey, usize),
-    ) -> Result<SectorUploadResult, UploadError> {
-        let (host_key, attempts) = initial_host;
-        let write_timeout = Self::upload_timeout(attempts);
+    async fn upload_shard(self, host_key: PublicKey) -> Result<SectorUploadResult, UploadError> {
         let permit = self.semaphore.clone().acquire_owned().await?;
         let mut tasks = JoinSet::new();
-        self.spawn_write(&mut tasks, host_key, write_timeout, permit);
+        self.spawn_write(&mut tasks, host_key, UPLOAD_TIMEOUT, permit);
         loop {
             let active = tasks.len();
             tokio::select! {
@@ -105,23 +98,21 @@ impl ShardUpload {
                         }
                         Err(_) => {
                             if tasks.is_empty() {
-                                let (host_key, attempts) = self.hosts.pop_front()?;
-                                let write_timeout = Self::upload_timeout(attempts);
+                                let host_key = self.hosts.pop_front()?;
                                 let permit = self.semaphore.clone().acquire_owned().await?;
-                                self.spawn_write(&mut tasks, host_key, write_timeout, permit);
+                                self.spawn_write(&mut tasks, host_key, UPLOAD_TIMEOUT, permit);
                             }
                         }
                     }
                 },
                 _ = sleep(Duration::from_secs(active.max(1) as u64)) => {
                     if let Ok(racer) = self.semaphore.clone().try_acquire_owned()
-                        && let Ok((host_key, attempts)) = self.hosts.pop_front() {
+                        && let Ok(host_key) = self.hosts.pop_front() {
                             debug!(
                                 "slab {} shard {} racing slow host",
                                 self.slab_index, self.shard_index
                             );
-                            let write_timeout = Self::upload_timeout(attempts);
-                            self.spawn_write(&mut tasks, host_key, write_timeout, racer);
+                            self.spawn_write(&mut tasks, host_key, UPLOAD_TIMEOUT, racer);
                         }
                 }
             }

--- a/sia_storage_wasm/examples/main.js
+++ b/sia_storage_wasm/examples/main.js
@@ -2,6 +2,7 @@ import init, {
   Builder,
   generateRecoveryPhrase,
   PinnedObject,
+  setLogger,
 } from './pkg/sia_storage_wasm.js';
 
 const INDEXER_URL = 'https://sia.storage';
@@ -44,6 +45,7 @@ function askUser(label) {
 
 async function main() {
   await init();
+  setLogger((msg) => log('[wasm]', msg), 'debug');
 
   // -- builder flow --
   const builder = new Builder(INDEXER_URL, {


### PR DESCRIPTION
Removed the progressive upload timeout and set a limit of 3 retries per host before giving up. The default 
timeout is now 1.5m per shard per attempt. This should give enough time on slow connections. Racing and prioritization
will still prioritize faster hosts after warming up.