### PR TITLE
wasm: read struct params via js_sys::Reflect

### DIFF
--- a/.changeset/wasm_read_struct_params_via_js_sysreflect.md
+++ b/.changeset/wasm_read_struct_params_via_js_sysreflect.md
@@ -1,0 +1,5 @@
+---
+sia_storage_wasm: patch
+---
+
+# wasm: read struct params via js_sys::Reflect

--- a/sia_storage_wasm/src/builder.rs
+++ b/sia_storage_wasm/src/builder.rs
@@ -9,7 +9,6 @@ use crate::app_key::AppKey;
 use crate::helpers::{make_app_metadata, to_js_err};
 use crate::run_local;
 use crate::sdk::Sdk;
-use crate::types::AppMetadata;
 
 enum BuilderState {
     Disconnected(StorageBuilder<DisconnectedState>),
@@ -27,15 +26,11 @@ pub struct Builder {
 #[wasm_bindgen]
 impl Builder {
     #[wasm_bindgen(constructor)]
-    pub fn new(indexer_url: &str, app: AppMetadata) -> Result<Builder, JsError> {
-        let meta = make_app_metadata(
-            &app.app_id,
-            &app.name,
-            &app.description,
-            &app.service_url,
-            app.logo_url,
-            app.callback_url,
-        )?;
+    pub fn new(
+        indexer_url: &str,
+        #[wasm_bindgen(unchecked_param_type = "AppMetadata")] app: JsValue,
+    ) -> Result<Builder, JsError> {
+        let meta = make_app_metadata(&app)?;
         let builder = StorageBuilder::new(indexer_url, meta).map_err(to_js_err)?;
         Ok(Builder {
             state: RefCell::new(Some(BuilderState::Disconnected(builder))),

--- a/sia_storage_wasm/src/helpers.rs
+++ b/sia_storage_wasm/src/helpers.rs
@@ -1,9 +1,25 @@
+use js_sys::Reflect;
 use sia_core::types::Hash256;
 use sia_storage::AppMetadata;
 use wasm_bindgen::prelude::*;
 
 pub(crate) fn to_js_err(e: impl std::fmt::Display) -> JsError {
     JsError::new(&e.to_string())
+}
+
+/// Read a required string field from a JS object.
+pub(crate) fn js_get_string(obj: &JsValue, key: &str) -> Result<String, JsError> {
+    let val = Reflect::get(obj, &JsValue::from_str(key))
+        .map_err(|e| JsError::new(&format!("read field `{key}`: {e:?}")))?;
+    val.as_string()
+        .ok_or_else(|| JsError::new(&format!("field `{key}` missing or not a string")))
+}
+
+/// Read an optional string field from a JS object.
+pub(crate) fn js_get_opt_string(obj: &JsValue, key: &str) -> Option<String> {
+    Reflect::get(obj, &JsValue::from_str(key))
+        .ok()
+        .and_then(|v| v.as_string())
 }
 
 /// Cached leaked strings for app metadata. Set once on first call;
@@ -27,21 +43,25 @@ thread_local! {
     static CACHED_META: std::cell::RefCell<Option<CachedMeta>> = const { std::cell::RefCell::new(None) };
 }
 
-/// Constructs an [`AppMetadata`] from JS-provided strings.
+/// Constructs an [`AppMetadata`] from a JS object matching the
+/// `AppMetadata` TS interface declared in `types.rs`. Fields are read
+/// via `js_sys::Reflect` instead of `#[tsify(from_wasm_abi)]` because
+/// that path is broken for plain-JS-constructed inputs. Field names
+/// here must stay in sync with the TS interface.
 ///
 /// `AppMetadata` requires `&'static str` fields, but strings from JS are
 /// temporary. We use `Box::leak` to promote each string to `'static`
 /// references. The leaked strings are cached so this only happens once —
 /// subsequent calls with the same app ID reuse the cached references.
-pub(crate) fn make_app_metadata(
-    id_hex: &str,
-    name: &str,
-    description: &str,
-    service_url: &str,
-    logo_url: Option<String>,
-    callback_url: Option<String>,
-) -> Result<AppMetadata, JsError> {
-    let id_bytes = hex::decode(id_hex).map_err(to_js_err)?;
+pub(crate) fn make_app_metadata(app: &JsValue) -> Result<AppMetadata, JsError> {
+    let id_hex = js_get_string(app, "appId")?;
+    let name = js_get_string(app, "name")?;
+    let description = js_get_string(app, "description")?;
+    let service_url = js_get_string(app, "serviceUrl")?;
+    let logo_url = js_get_opt_string(app, "logoUrl");
+    let callback_url = js_get_opt_string(app, "callbackUrl");
+
+    let id_bytes = hex::decode(&id_hex).map_err(to_js_err)?;
     if id_bytes.len() != 32 {
         return Err(JsError::new("app ID must be 32 bytes (64 hex chars)"));
     }

--- a/sia_storage_wasm/src/sdk.rs
+++ b/sia_storage_wasm/src/sdk.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use js_sys::Reflect;
 use sia_core::types::Hash256;
 use sia_core::types::v2::Protocol;
 use sia_storage::{self, HostQuery as StorageHostQuery, Sdk as StorageSdk};
@@ -13,8 +14,7 @@ use crate::packed::PackedUpload;
 use crate::run_local;
 use crate::stream_reader::js_stream_reader;
 use crate::types::{
-    self, HostQuery, ObjectEvent, ObjectsCursor, download_options_from_js, ms_to_chrono,
-    upload_options_from_js,
+    self, HostQuery, ObjectEvent, download_options_from_js, ms_to_chrono, upload_options_from_js,
 };
 
 /// The main Sia storage SDK. Provides methods for uploading, downloading,
@@ -85,16 +85,27 @@ impl Sdk {
     #[wasm_bindgen(js_name = "objectEvents")]
     pub async fn object_events(
         &self,
-        cursor: Option<ObjectsCursor>,
+        #[wasm_bindgen(unchecked_param_type = "ObjectsCursor | null | undefined")] cursor: JsValue,
         limit: u32,
     ) -> Result<Vec<ObjectEvent>, JsError> {
         let sdk = self.inner.clone();
-        let cursor = match cursor {
-            Some(c) => Some(sia_storage::ObjectsCursor {
-                id: Hash256::from_str(&c.id).map_err(to_js_err)?,
-                after: ms_to_chrono(c.after.get_time())?,
-            }),
-            None => None,
+        let cursor = if cursor.is_null() || cursor.is_undefined() {
+            None
+        } else {
+            let id_js = Reflect::get(&cursor, &JsValue::from_str("id"))
+                .map_err(|e| JsError::new(&format!("read cursor.id: {e:?}")))?;
+            let id = id_js
+                .as_string()
+                .ok_or_else(|| JsError::new("cursor.id must be a string"))?;
+            let after_js = Reflect::get(&cursor, &JsValue::from_str("after"))
+                .map_err(|e| JsError::new(&format!("read cursor.after: {e:?}")))?;
+            let after: js_sys::Date = after_js
+                .dyn_into()
+                .map_err(|_| JsError::new("cursor.after must be a Date"))?;
+            Some(sia_storage::ObjectsCursor {
+                id: Hash256::from_str(&id).map_err(to_js_err)?,
+                after: ms_to_chrono(after.get_time())?,
+            })
         };
         let events =
             run_local(async move { sdk.object_events(cursor, Some(limit as usize)).await })

--- a/sia_storage_wasm/src/types.rs
+++ b/sia_storage_wasm/src/types.rs
@@ -85,10 +85,12 @@ impl From<sia_storage::Account> for Account {
     }
 }
 
-/// Application metadata deserialized from a plain JS object.
-#[derive(serde::Deserialize, tsify::Tsify)]
-#[tsify(from_wasm_abi)]
+/// TS interface for `Builder::new`'s `app` parameter. Field names must
+/// match the Reflect reads in `helpers::make_app_metadata`.
+// dead_code because it exists only for tsify.
+#[derive(serde::Serialize, tsify::Tsify)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 pub struct AppMetadata {
     pub app_id: String,
     pub name: String,
@@ -203,15 +205,15 @@ pub(crate) fn ms_to_chrono(ms: f64) -> Result<chrono::DateTime<chrono::Utc>, JsE
     chrono::DateTime::from_timestamp(secs, nanos).ok_or_else(|| JsError::new("invalid timestamp"))
 }
 
-/// A cursor for paginating through object events.
-#[derive(serde::Deserialize, tsify::Tsify)]
-#[tsify(from_wasm_abi)]
-#[serde(rename_all = "camelCase")]
+/// TS interface for `Sdk::objectEvents`'s `cursor` parameter. Field
+/// names must match the Reflect reads in `sdk.rs`.
+// dead_code because it exists only for tsify.
+#[derive(serde::Serialize, tsify::Tsify)]
+#[allow(dead_code)]
 pub struct ObjectsCursor {
     pub id: String,
     #[tsify(type = "Date")]
-    #[serde(with = "serde_wasm_bindgen::preserve")]
-    pub after: js_sys::Date,
+    pub after: f64,
 }
 
 /// An object event from the indexer.


### PR DESCRIPTION
Fixes two runtime failures in `sia_storage_wasm` where plain JS object literals passed into `#[tsify(from_wasm_abi)]`-bound functions hit serde-wasm-bindgen bugs:

- `Sdk::objectEvents` threw `invalid type: JsValue(Date), expected tuple struct PreservedValueDeWrapper` for any cursor with a `Date`.
- `Builder::new` reported `"missing field `appId`"` on release (wasm-opt) builds.

Both entry points now accept `JsValue` and read fields via `js_sys::Reflect`.

The `AppMetadata` and `ObjectsCursor` tsify structs are kept without `#[tsify(from_wasm_abi)]` — the derive still emits the TS interfaces, the broken deserialization path is just never instantiated. TypeScript surface unchanged.