### PR TITLE
Make packed uploads recoverable on reader error

### DIFF
--- a/.changeset/packed_upload_recovers_from_read_errors.md
+++ b/.changeset/packed_upload_recovers_from_read_errors.md
@@ -1,0 +1,10 @@
+---
+sia_storage: minor
+sia_storage_ffi: minor
+sia_storage_napi: minor
+sia_storage_wasm: minor
+---
+
+# `PackedUpload` stays usable after a reader error
+
+If the reader passed to `add` errored mid-stream, bytes it had already buffered were silently attributed to the next object, corrupting it. Partial reads now become dead padding in the slab and subsequent objects stay aligned.

--- a/.changeset/rename_appmeta_to_appmetadata.md
+++ b/.changeset/rename_appmeta_to_appmetadata.md
@@ -1,0 +1,7 @@
+---
+sia_storage_ffi: major
+---
+
+# Rename `AppMeta` to `AppMetadata`
+
+The uniffi struct accepted by `Builder::new` is now named `AppMetadata`, matching the Rust SDK and the WASM binding.

--- a/.changeset/rename_slab_size_to_optimal_data_size.md
+++ b/.changeset/rename_slab_size_to_optimal_data_size.md
@@ -10,5 +10,3 @@ sia_storage_wasm: major
 Methods and fields that previously returned or stored `data_shards * SECTOR_SIZE` (the packing period for `PackedUpload`) are now named `optimal_data_size` to distinguish them from the true encoded slab size (`total_shards * SECTOR_SIZE`, which remains `slab_size`). Affects `PackedUpload::slab_size()` (Rust, FFI, NAPI) and the `slabSize` JS getter (now `optimalDataSize`).
 
 `UploadOptions::slab_size()`, `UploadOptions::optimal_data_size()`, `PackedUpload::optimal_data_size()`, and `PackedUpload::slabs()` now return `usize` instead of `u64`.
-
-Also fixes a NAPI bug where `upload_packed` was storing the total slab size (including parity) into the field used as the slab size, causing `remaining` / `slabs` to report incorrect values.

--- a/.changeset/rename_slab_size_to_optimal_data_size.md
+++ b/.changeset/rename_slab_size_to_optimal_data_size.md
@@ -1,0 +1,8 @@
+---
+sia_storage: major
+sia_storage_ffi: major
+sia_storage_napi: major
+sia_storage_wasm: major
+---
+
+# Rename `slab_size` to `optimal_data_size` where it refers to the data-only portion

--- a/.changeset/rename_slab_size_to_optimal_data_size.md
+++ b/.changeset/rename_slab_size_to_optimal_data_size.md
@@ -6,3 +6,9 @@ sia_storage_wasm: major
 ---
 
 # Rename `slab_size` to `optimal_data_size` where it refers to the data-only portion
+
+Methods and fields that previously returned or stored `data_shards * SECTOR_SIZE` (the packing period for `PackedUpload`) are now named `optimal_data_size` to distinguish them from the true encoded slab size (`total_shards * SECTOR_SIZE`, which remains `slab_size`). Affects `PackedUpload::slab_size()` (Rust, FFI, NAPI) and the `slabSize` JS getter (now `optimalDataSize`).
+
+`UploadOptions::slab_size()`, `UploadOptions::optimal_data_size()`, `PackedUpload::optimal_data_size()`, and `PackedUpload::slabs()` now return `usize` instead of `u64`.
+
+Also fixes a NAPI bug where `upload_packed` was storing the total slab size (including parity) into the field used as the slab size, causing `remaining` / `slabs` to report incorrect values.

--- a/.changeset/simplify_packed_upload_bindings.md
+++ b/.changeset/simplify_packed_upload_bindings.md
@@ -1,0 +1,9 @@
+---
+sia_storage_ffi: patch
+sia_storage_napi: patch
+sia_storage_wasm: patch
+---
+
+# Simplify `PackedUpload` binding internals
+
+Replaced the per-upload mpsc actor with a mutex and a cancellation token. Errors from `add` and `finalize` now propagate directly instead of through a oneshot that could swallow them, and no background task is kept per upload. No public API change.

--- a/.changeset/simplify_packed_upload_bindings.md
+++ b/.changeset/simplify_packed_upload_bindings.md
@@ -1,9 +1,11 @@
 ---
-sia_storage_ffi: patch
-sia_storage_napi: patch
+sia_storage_ffi: major
+sia_storage_napi: major
 sia_storage_wasm: patch
 ---
 
 # Simplify `PackedUpload` binding internals
 
-Replaced the per-upload mpsc actor with a mutex and a cancellation token. Errors from `add` and `finalize` now propagate directly instead of through a oneshot that could swallow them, and no background task is kept per upload. No public API change.
+Replaced the per-upload mpsc actor with a mutex and a cancellation token. Errors from `add` and `finalize` now propagate directly instead of through a oneshot that could swallow them, and no background task is kept per upload.
+
+`cancel` is now sync (`fn cancel(&self)`) on the FFI and NAPI bindings, dropping the `async` and `Result` return — flipping a token and aborting in-flight tasks is fast and cannot fail. WASM was already sync.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -914,7 +914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1597,7 +1597,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1849,7 +1849,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2411,7 +2411,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2875,7 +2875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2956,10 +2956,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3310,9 +3310,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
+checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
 dependencies = [
  "anyhow",
  "camino",
@@ -3327,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
+checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
 dependencies = [
  "anyhow",
  "askama",
@@ -3353,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78fd9271a4c2e85bd2c266c5a9ede1fac676eb39fd77f636c27eaf67426fd5f"
+checksum = "4c39413c43b955e4aa8a4e2b34bbd1b6b5ff6bd85532b52f9eb92fbe88c14458"
 dependencies = [
  "anyhow",
  "camino",
@@ -3364,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
+checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -3377,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
+checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -3390,9 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
+checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
 dependencies = [
  "camino",
  "fs-err",
@@ -3407,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
+checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -3419,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
+checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
 dependencies = [
  "anyhow",
  "heck",
@@ -3432,9 +3432,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
+checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -3733,7 +3733,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -549,7 +549,7 @@ mod test {
     cross_target_tests! {
         async fn test_out_of_order_download() { run_local(async {
             let upload_options = UploadOptions::default();
-            let slab_size = upload_options.data_shards as usize * SECTOR_SIZE;
+            let optimal_data_size = upload_options.data_shards as usize * SECTOR_SIZE;
 
             let transport = Client::new();
             let hosts = Hosts::new(transport.clone());
@@ -569,7 +569,7 @@ mod test {
                     .collect(),
                 true,
             );
-            let mut data = BytesMut::zeroed(slab_size);
+            let mut data = BytesMut::zeroed(optimal_data_size);
             rand::rng().fill_bytes(&mut data);
             let data = data.freeze();
             let app_key = Arc::new(AppKey::import(rand::random()));
@@ -588,7 +588,7 @@ mod test {
             .await
             .unwrap();
 
-            let mut recovered_data = Vec::with_capacity(slab_size);
+            let mut recovered_data = Vec::with_capacity(optimal_data_size);
             let mut download = Download::new(
                 &obj,
                 hosts.clone(),
@@ -605,7 +605,7 @@ mod test {
 
         async fn test_slab_recovery() { run_local(async {
             let upload_options = UploadOptions::default();
-            let slab_size = upload_options.data_shards as usize * SECTOR_SIZE;
+            let optimal_data_size = upload_options.data_shards as usize * SECTOR_SIZE;
 
             let transport = Client::new();
             let hosts = Hosts::new(transport.clone());
@@ -625,7 +625,7 @@ mod test {
                     .collect(),
                 true,
             );
-            let mut data = BytesMut::zeroed(slab_size);
+            let mut data = BytesMut::zeroed(optimal_data_size);
             rand::rng().fill_bytes(&mut data);
             let data = data.freeze();
             let app_key = Arc::new(AppKey::import(rand::random()));
@@ -640,15 +640,15 @@ mod test {
             .unwrap();
 
             let test_cases: Vec<(&str, usize, usize)> = vec![
-                ("full slab", 0, slab_size),
-                ("first half", 0, slab_size / 2),
-                ("second half", slab_size / 2, slab_size / 2),
+                ("full slab", 0, optimal_data_size),
+                ("first half", 0, optimal_data_size / 2),
+                ("second half", optimal_data_size / 2, optimal_data_size / 2),
                 ("first 30 bytes", 0, 30),
-                ("middle 30 bytes", slab_size / 2 - 15, 30),
-                ("last 30 bytes", slab_size - 30, 30),
+                ("middle 30 bytes", optimal_data_size / 2 - 15, 30),
+                ("last 30 bytes", optimal_data_size - 30, 30),
                 ("first 4KiB", 0, 4096),
-                ("middle 4KiB", slab_size / 2 - 2048, 4096),
-                ("last 4KiB", slab_size - 4096, 4096),
+                ("middle 4KiB", optimal_data_size / 2 - 2048, 4096),
+                ("last 4KiB", optimal_data_size - 4096, 4096),
             ];
 
             for (name, offset, length) in test_cases {
@@ -679,7 +679,7 @@ mod test {
             let upload_options = UploadOptions::default();
             let min_shards = upload_options.data_shards as usize;
             let total_shards = min_shards + upload_options.parity_shards as usize;
-            let slab_size = min_shards * SECTOR_SIZE;
+            let optimal_data_size = upload_options.optimal_data_size();
             let num_slabs = 3;
 
             let transport = Client::new();
@@ -701,7 +701,7 @@ mod test {
                 true,
             );
             // upload enough data for multiple slabs
-            let data_size = slab_size * num_slabs;
+            let data_size = optimal_data_size * num_slabs;
             let mut data = BytesMut::zeroed(data_size);
             rand::rng().fill_bytes(&mut data);
             let data = data.freeze();
@@ -737,7 +737,7 @@ mod test {
             let events = progress.lock().unwrap();
             // each slab is split into CHUNK_SIZE (256 KiB) chunks for download.
             // each chunk recovers min_shards shards independently.
-            let chunks_per_slab = slab_size.div_ceil(CHUNK_SIZE);
+            let chunks_per_slab = optimal_data_size.div_ceil(CHUNK_SIZE);
             let expected_total = chunks_per_slab * min_shards * num_slabs;
             assert_eq!(
                 events.len(),

--- a/sia_storage/src/erasure_coding.rs
+++ b/sia_storage/src/erasure_coding.rs
@@ -87,6 +87,7 @@ pub(crate) struct SlabReader {
     data_shards: usize,
     shards: Vec<BytesMut>,
     length: usize,
+    total_length: u64,
 }
 
 pub(crate) struct ReadSlab {
@@ -101,6 +102,7 @@ impl SlabReader {
             data_shards,
             shards: vec![BytesMut::zeroed(SECTOR_SIZE); total_shards],
             length: 0,
+            total_length: 0,
         }
     }
 
@@ -108,7 +110,16 @@ impl SlabReader {
         self.length
     }
 
-    pub fn slab_size(&self) -> usize {
+    /// Cumulative bytes that have landed in the pipeline across all
+    /// `read_slab` calls, including bytes from reads that errored part-way.
+    /// Unlike [length](Self::length), this never resets when a slab is
+    /// finalized.
+    pub fn total_length(&self) -> u64 {
+        self.total_length
+    }
+
+    /// The optimal slab size for streaming reads
+    pub fn optimal_data_size(&self) -> usize {
         self.data_shards * SECTOR_SIZE
     }
 
@@ -132,14 +143,14 @@ impl SlabReader {
         &mut self,
         r: &mut R,
     ) -> io::Result<(usize, Option<ReadSlab>)> {
-        let remaining = self.slab_size() - self.length;
+        let remaining = self.optimal_data_size() - self.length;
         if remaining == 0 {
             return Ok((0, None));
         }
         let mut r = r.take(remaining as u64);
         let mut total_read = 0;
         loop {
-            if self.length == self.slab_size() {
+            if self.length == self.optimal_data_size() {
                 break;
             }
 
@@ -156,9 +167,10 @@ impl SlabReader {
                 break;
             }
             self.length += n;
+            self.total_length += n as u64;
             total_read += n;
         }
-        let slab = if self.length == self.slab_size() {
+        let slab = if self.length == self.optimal_data_size() {
             let length = mem::take(&mut self.length);
             let total_shards = self.shards.len();
             let shards = mem::replace(

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -377,13 +377,13 @@ impl UploadOptions {
 
 impl UploadOptions {
     /// Returns the optimal data size per slab in bytes.
-    pub fn optimal_data_size(&self) -> u64 {
-        SECTOR_SIZE as u64 * self.data_shards as u64
+    pub fn optimal_data_size(&self) -> usize {
+        SECTOR_SIZE * self.data_shards as usize
     }
 
     /// Returns the total slab size including parity shards in bytes.
-    pub fn slab_size(&self) -> u64 {
-        SECTOR_SIZE as u64 * (self.data_shards as u64 + self.parity_shards as u64)
+    pub fn slab_size(&self) -> usize {
+        SECTOR_SIZE * (self.data_shards as usize + self.parity_shards as usize)
     }
 
     /// Validates the upload options and erasure coding parameters to ensure
@@ -508,7 +508,7 @@ mod test {
 
     use super::*;
 
-    const SLAB_SIZE: u64 = SECTOR_SIZE as u64 * 10; // 10 sectors per slab
+    const OPTIMAL_DATA_SIZE: u64 = SECTOR_SIZE as u64 * 10; // 10 sectors per slab
 
     fn random_seed() -> [u8; 32] {
         let mut seed = [0u8; 32];
@@ -549,7 +549,7 @@ mod test {
             let input: Bytes = Bytes::from("Hello, world!");
 
             let mut packed_upload = PackedUpload::new(hosts.clone(), app_key.clone(), UploadOptions::default()).unwrap();
-            assert_eq!(packed_upload.remaining(), SLAB_SIZE);
+            assert_eq!(packed_upload.remaining(), OPTIMAL_DATA_SIZE);
 
             packed_upload
                 .add(Cursor::new(input.clone()))
@@ -562,7 +562,7 @@ mod test {
 
             assert_eq!(
                 packed_upload.remaining(),
-                SLAB_SIZE - (input.len() * 2) as u64
+                OPTIMAL_DATA_SIZE - (input.len() * 2) as u64
             );
 
             let objects = packed_upload.finalize().await.expect("upload to finish");
@@ -631,7 +631,7 @@ mod test {
             );
             let small_input = Bytes::from("Hello, world!");
 
-            let mut large_input = BytesMut::zeroed(SLAB_SIZE as usize + 18); // 1 full slab + 18 bytes
+            let mut large_input = BytesMut::zeroed(OPTIMAL_DATA_SIZE as usize + 18); // 1 full slab + 18 bytes
             random_bytes(&mut large_input);
             let large_input = large_input.freeze();
 
@@ -658,10 +658,10 @@ mod test {
             assert_eq!(objects[0].slabs()[0].length, 13);
 
             // obj 1 should be the large input. The first slab starts at offset 13 so
-            // its length must be SLAB_SIZE - 13. The second slab has the remaining bytes.
-            assert_eq!(objects[1].size(), SLAB_SIZE + 18);
+            // its length must be OPTIMAL_DATA_SIZE - 13. The second slab has the remaining bytes.
+            assert_eq!(objects[1].size(), OPTIMAL_DATA_SIZE + 18);
             assert_eq!(objects[1].slabs()[0].offset, 13);
-            assert_eq!(objects[1].slabs()[0].length, (SLAB_SIZE - 13) as u32);
+            assert_eq!(objects[1].slabs()[0].length, (OPTIMAL_DATA_SIZE - 13) as u32);
             assert_eq!(objects[1].slabs()[1].offset, 0);
             assert_eq!(objects[1].slabs()[1].length, 18 + 13);
 
@@ -713,7 +713,7 @@ mod test {
                     .collect(),
                 true,
             );
-            let mut exact_input = BytesMut::zeroed(SLAB_SIZE as usize); // 1 full slab
+            let mut exact_input = BytesMut::zeroed(OPTIMAL_DATA_SIZE as usize); // 1 full slab
             random_bytes(&mut exact_input);
             let exact_input = exact_input.freeze();
 
@@ -729,9 +729,9 @@ mod test {
             // The first object should have 1 slab, since it fits exactly
             assert_eq!(objects[0].slabs().len(), 1);
             // the first slab of obj[0] should be the full length. the second slab should be the remaining 18 bytes.
-            assert_eq!(objects[0].size(), SLAB_SIZE);
+            assert_eq!(objects[0].size(), OPTIMAL_DATA_SIZE);
             assert_eq!(objects[0].slabs()[0].offset, 0);
-            assert_eq!(objects[0].slabs()[0].length, SLAB_SIZE as u32);
+            assert_eq!(objects[0].slabs()[0].length, OPTIMAL_DATA_SIZE as u32);
 
             let mut output = BytesMut::zeroed(objects[0].size() as usize);
             let mut download = Download::new(
@@ -810,6 +810,93 @@ mod test {
                 .await
                 .expect("download to complete");
             assert_eq!(output.freeze(), non_empty);
+        }).await }
+
+    async fn test_upload_packed_add_error_is_recoverable() { run_local(async {
+            let app_key = Arc::new(AppKey::import(random_seed()));
+            let hosts = Hosts::new(Client::new());
+            hosts.update(
+                (0..60)
+                    .map(|_| Host {
+                        public_key: PrivateKey::from_seed(&random_seed()).public_key(),
+                        addresses: vec![NetAddress {
+                            protocol: sia_core::types::v2::Protocol::QUIC,
+                            address: "localhost:1234".to_string(),
+                        }],
+                        country_code: "US".to_string(),
+                        latitude: 0.0,
+                        longitude: 0.0,
+                        good_for_upload: true,
+                    })
+                    .collect(),
+                true,
+            );
+
+            // reader that delivers `data` then errors on the next poll.
+            struct ErrAfter {
+                data: Vec<u8>,
+                pos: usize,
+            }
+            impl tokio::io::AsyncRead for ErrAfter {
+                fn poll_read(
+                    mut self: std::pin::Pin<&mut Self>,
+                    _cx: &mut std::task::Context<'_>,
+                    buf: &mut tokio::io::ReadBuf<'_>,
+                ) -> std::task::Poll<std::io::Result<()>> {
+                    if self.pos >= self.data.len() {
+                        return std::task::Poll::Ready(Err(std::io::Error::other("boom")));
+                    }
+                    let n = (self.data.len() - self.pos).min(buf.remaining());
+                    buf.put_slice(&self.data[self.pos..self.pos + n]);
+                    self.pos += n;
+                    std::task::Poll::Ready(Ok(()))
+                }
+            }
+
+            let partial: Vec<u8> = (0..100u8).collect();
+            let good: Bytes = Bytes::from_static(b"recoverable object data after the hole");
+
+            let mut packed_upload = PackedUpload::new(
+                hosts.clone(),
+                app_key.clone(),
+                UploadOptions::default(),
+            )
+            .unwrap();
+            packed_upload
+                .add(ErrAfter { data: partial.clone(), pos: 0 })
+                .await
+                .expect_err("erroring reader should fail the add");
+
+            // errored add left `partial.len()` bytes as dead padding in the slab;
+            // the packer stays usable and subsequent adds stay aligned.
+            assert_eq!(packed_upload.length(), partial.len() as u64);
+
+            packed_upload
+                .add(Cursor::new(good.clone()))
+                .await
+                .expect("subsequent add after errored add must succeed");
+
+            let objects = packed_upload.finalize().await.expect("finalize");
+            // only the successful add registered an object
+            assert_eq!(objects.len(), 1);
+            assert_eq!(objects[0].size(), good.len() as u64);
+            // the good object's bytes start *after* the padding from the errored add
+            assert_eq!(objects[0].slabs().len(), 1);
+            assert_eq!(objects[0].slabs()[0].offset, partial.len() as u32);
+            assert_eq!(objects[0].slabs()[0].length, good.len() as u32);
+
+            let mut output = BytesMut::zeroed(good.len());
+            let mut download = Download::new(
+                &objects[0],
+                hosts.clone(),
+                app_key.clone(),
+                DownloadOptions::default(),
+            )
+            .unwrap();
+            copy(&mut download, &mut Cursor::new(&mut output[..]))
+                .await
+                .expect("download to complete");
+            assert_eq!(output.freeze(), good);
         }).await }
 
     async fn test_upload_download() { run_local(async {
@@ -937,9 +1024,9 @@ mod test {
                     .collect(),
                 true,
             );
-            // Use default 10 data shards, so slab_size = 10 * SECTOR_SIZE
-            let slab_size = 10 * SECTOR_SIZE as u64;
-            let data_size = slab_size * 3; // 3 slabs
+            // Use default 10 data shards, so optimal_data_size = 10 * SECTOR_SIZE
+            let optimal_data_size = 10 * SECTOR_SIZE as u64;
+            let data_size = optimal_data_size * 3; // 3 slabs
 
             let mut data = BytesMut::zeroed(data_size as usize);
             random_bytes(&mut data);
@@ -958,7 +1045,7 @@ mod test {
                 (SEGMENT_SIZE, SEGMENT_SIZE),                         // one leaf
                 (SEGMENT_SIZE + 1, SEGMENT_SIZE / 2),                 // within a leaf
                 (SEGMENT_SIZE + SEGMENT_SIZE / 2, SEGMENT_SIZE),      // across leaves
-                (slab_size / 2, 2 * slab_size),                       // across slabs
+                (optimal_data_size / 2, 2 * optimal_data_size),       // across slabs
                 (data_size - SECTOR_SIZE as u64, SECTOR_SIZE as u64), // last sector
                 (data_size - SEGMENT_SIZE, SEGMENT_SIZE),             // last leaf
                 (data_size - 100, 200),                               // past end
@@ -1217,7 +1304,7 @@ mod test {
                     .collect(),
                 true,
             );
-            let data_size = SLAB_SIZE as usize * num_slabs;
+            let data_size = OPTIMAL_DATA_SIZE as usize * num_slabs;
             let mut data = BytesMut::zeroed(data_size);
             random_bytes(&mut data);
             let data = data.freeze();
@@ -1263,7 +1350,7 @@ mod test {
             assert_eq!(data, recovered_data);
 
             let download_progress = download_progress.lock().unwrap();
-            let chunks_per_slab = SLAB_SIZE as usize / (1 << 18);
+            let chunks_per_slab = OPTIMAL_DATA_SIZE as usize / (1 << 18);
             let expected_total = chunks_per_slab * min_shards * num_slabs;
             let actual_total: usize = download_progress.values().sum();
             assert_eq!(actual_total, expected_total,

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -318,6 +318,17 @@ impl Upload {
         Ok(())
     }
 
+    /// Returns the cumulative number of bytes that have landed in the pipeline
+    /// across all [read](Self::read) calls, including bytes from reads that
+    /// errored part-way. Callers can diff this across a call to recover a
+    /// partial count on error and treat the bytes as dead padding.
+    pub(crate) fn length(&self) -> u64 {
+        self.slab_buffer
+            .as_ref()
+            .map(|b| b.total_length())
+            .unwrap_or(0)
+    }
+
     /// Reads from the provided reader, buffering data into slabs and spawning
     /// slab-upload tasks as they fill. Returns the number of bytes read.
     pub(crate) async fn read<R: AsyncRead + Unpin>(
@@ -371,12 +382,14 @@ impl Upload {
     /// packed size. Adding objects larger than this will start a new slab.
     pub(crate) fn remaining(&self) -> usize {
         let slab_buffer = self.slab_buffer.as_ref().unwrap();
-        slab_buffer.slab_size().saturating_sub(slab_buffer.length())
+        slab_buffer
+            .optimal_data_size()
+            .saturating_sub(slab_buffer.length())
     }
 
     /// Returns the optimal size of each slab.
-    pub(crate) fn slab_size(&self) -> usize {
-        self.slab_buffer.as_ref().unwrap().slab_size()
+    pub(crate) fn optimal_data_size(&self) -> usize {
+        self.slab_buffer.as_ref().unwrap().optimal_data_size()
     }
 }
 
@@ -405,7 +418,6 @@ struct ObjectUpload {
 ///
 /// The caller must call [finalize](Self::finalize) to complete the upload.
 pub struct PackedUpload {
-    total_length: u64,
     upload: Upload,
     objects: Vec<ObjectUpload>,
 }
@@ -417,7 +429,6 @@ impl PackedUpload {
         options: UploadOptions,
     ) -> Result<Self, UploadError> {
         Ok(Self {
-            total_length: 0,
             upload: Upload::new(client, app_key, options)?,
             objects: Vec::new(),
         })
@@ -433,29 +444,33 @@ impl PackedUpload {
 
     /// Returns the cumulative length of all objects currently in the upload.
     pub fn length(&self) -> u64 {
-        self.total_length
+        self.upload.length()
     }
 
     /// Returns the optimal size of each slab.
-    pub fn slab_size(&self) -> u64 {
-        self.upload.slab_size() as u64
+    pub fn optimal_data_size(&self) -> usize {
+        self.upload.optimal_data_size()
     }
 
     /// Returns the number of slabs after the upload is finalized.
-    pub fn slabs(&self) -> u64 {
-        self.length().div_ceil(self.slab_size())
+    pub fn slabs(&self) -> usize {
+        self.length().div_ceil(self.optimal_data_size() as u64) as usize
     }
 
-    /// Adds a new object to the upload. The data will be read until EOF and packed into
-    /// the upload. The resulting object will contain the metadata needed to download the object. The caller
-    /// must call [finalize](Self::finalize) to get the resulting objects after all objects have been added.
+    /// Adds a new object to the upload. The data is read until EOF and packed into
+    /// the current slab. Returns the number of bytes consumed; call
+    /// [finalize](Self::finalize) once all objects have been added to get the
+    /// resulting objects.
+    ///
+    /// If the reader errors part-way, it's safe to continue calling
+    /// [add](Self::add); no object is registered for the failed call. Or call
+    /// [finalize](Self::finalize) to collect the objects added so far.
     pub async fn add<R: AsyncRead + Unpin>(&mut self, r: R) -> Result<u64, UploadError> {
         let object = Object::default();
 
-        let start = self.total_length;
+        let start = self.upload.length();
         let n = self.upload.read(&mut object.reader(r, 0)).await?;
-        self.total_length += n;
-        let end = self.total_length;
+        let end = self.upload.length();
         self.objects.push(ObjectUpload { start, end, object });
         Ok(n)
     }
@@ -465,7 +480,7 @@ impl PackedUpload {
     ///
     /// The caller must pin the resulting objects to the indexer when ready.
     pub async fn finalize(self) -> Result<Vec<Object>, UploadError> {
-        let slab_size = self.slab_size();
+        let optimal_data_size = self.optimal_data_size() as u64;
         let uploaded_slabs = self.upload.finish().await?;
         self.objects
             .into_iter()
@@ -476,20 +491,21 @@ impl PackedUpload {
                     return Ok(object);
                 }
                 let slabs = object.slabs_mut();
-                let slabs_start = (upload.start / slab_size) as usize;
-                let slabs_end = upload.end.div_ceil(slab_size) as usize;
+                let slabs_start = (upload.start / optimal_data_size) as usize;
+                let slabs_end = upload.end.div_ceil(optimal_data_size) as usize;
                 let n = slabs_end - slabs_start;
                 slabs.extend_from_slice(&uploaded_slabs[slabs_start..slabs_end]);
 
-                slabs[0].offset = (upload.start % slab_size) as u32;
+                slabs[0].offset = (upload.start % optimal_data_size) as u32;
                 if slabs.len() > 1 {
                     // if spanning multiple slabs, adjust first slab's length
-                    slabs[0].length = (slab_size - slabs[0].offset as u64) as u32;
+                    slabs[0].length = (optimal_data_size - slabs[0].offset as u64) as u32;
                 }
                 let last_slab_index = n - 1;
                 let last_slab_offset = slabs[last_slab_index].offset as u64;
-                slabs[last_slab_index].length =
-                    (upload.end - ((slabs_end as u64 - 1) * slab_size) - last_slab_offset) as u32;
+                slabs[last_slab_index].length = (upload.end
+                    - ((slabs_end as u64 - 1) * optimal_data_size)
+                    - last_slab_offset) as u32;
 
                 Ok(object)
             })

--- a/sia_storage_ffi/Cargo.toml
+++ b/sia_storage_ffi/Cargo.toml
@@ -22,12 +22,12 @@ sia_core = { version = "0.3.1", path = "../sia_core" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.0", features = ["rt-multi-thread", "sync"] }
 tokio-util = "0.7.18"
-uniffi = { version = "=0.31.0", features = ["cli", "tokio"] } # be careful updating as it may break uniffi-react-native-bindgen
+uniffi = { version = "0.31.0", features = ["cli", "tokio"] } # be careful updating as it may break uniffi-react-native-bindgen
 zeroize = "1.8.1"
 
 
 [build-dependencies]
-uniffi = { version = "=0.31.0", features = ["build"] }
+uniffi = { version = "0.31.0", features = ["build"] }
 tokio = { version = "1.52.0", features = ["rt-multi-thread", "sync", "io-util"] }
 
 [[bin]]

--- a/sia_storage_ffi/examples/python/example.py
+++ b/sia_storage_ffi/examples/python/example.py
@@ -7,7 +7,7 @@ from random import randint
 from sys import stdin
 
 from sia_storage_ffi import (
-    AppMeta,
+    AppMetadata,
     Builder,
     DownloadOptions,
     Logger,
@@ -52,7 +52,7 @@ async def main():
     uniffi_set_event_loop(asyncio.get_running_loop())  # type: ignore[arg-type]
     app_id = b"\x01" * 32
 
-    builder = Builder("https://sia.storage", AppMeta(
+    builder = Builder("https://sia.storage", AppMetadata(
         id=app_id,
         name="python example",
         description="an example app",

--- a/sia_storage_ffi/src/builder.rs
+++ b/sia_storage_ffi/src/builder.rs
@@ -5,7 +5,7 @@ use sia_core::signing::Signature;
 use sia_storage::{self, Hash256};
 use thiserror::Error;
 
-use crate::{AppMeta, Sdk, spawn};
+use crate::{AppMetadata, Sdk, spawn};
 
 #[derive(Debug, Error, uniffi::Error)]
 #[uniffi(flat_error)]
@@ -197,7 +197,7 @@ impl Builder {
     /// to connect using an existing app key, or [Builder::request_connection]
     /// to request a new connection.
     #[uniffi::constructor]
-    pub fn new(indexer_url: String, app_meta: AppMeta) -> Result<Self, BuilderError> {
+    pub fn new(indexer_url: String, app_meta: AppMetadata) -> Result<Self, BuilderError> {
         if app_meta.id.len() != 32 {
             return Err(BuilderError::Custom("app ID must be 32 bytes".to_string()));
         }

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -1,18 +1,16 @@
 uniffi::setup_scaffolding!();
 
-use log::debug;
 use sia_core::encoding;
 use sia_core::rhp4::SECTOR_SIZE;
 use sia_core::signing::{PublicKey, Signature};
 use sia_core::types::{self, Hash256, HexParseError};
 use sia_storage::{SealedObjectError, Url};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::SystemTime;
 use thiserror::Error;
 use tokio::runtime::{self, Runtime};
-use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
 
@@ -121,7 +119,7 @@ pub enum DownloadError {
 
 /// Metadata about an application connecting to the indexer.
 #[derive(uniffi::Record)]
-pub struct AppMeta {
+pub struct AppMetadata {
     pub id: Vec<u8>,
     pub name: String,
     pub description: String,
@@ -578,21 +576,15 @@ impl From<sia_storage::Account> for Account {
     }
 }
 
-enum PackedUploadAction {
-    Add(Arc<dyn Reader>, oneshot::Sender<Result<u64, UploadError>>),
-    Finalize(oneshot::Sender<Result<Vec<sia_storage::Object>, UploadError>>),
-}
-
 /// A packed upload allows multiple objects to be uploaded together in a single upload. This can be more
 /// efficient than uploading each object separately if the size of the object is less than the minimum
 /// slab size.
 #[derive(uniffi::Object)]
 pub struct PackedUpload {
-    upload_task: AbortOnDropHandle<()>,
-    tx: mpsc::Sender<PackedUploadAction>,
-    slab_size: u64,
+    inner: Arc<tokio::sync::Mutex<Option<sia_storage::PackedUpload>>>,
+    cancel: CancellationToken,
+    optimal_data_size: u64,
     length: Arc<AtomicU64>,
-    closed: Arc<AtomicBool>,
 }
 
 #[uniffi::export]
@@ -604,9 +596,9 @@ impl PackedUpload {
     pub fn remaining(&self) -> u64 {
         let length = self.length.load(Ordering::Acquire);
         if length == 0 {
-            return self.slab_size;
+            return self.optimal_data_size;
         }
-        (self.slab_size - (length % self.slab_size)) % self.slab_size
+        (self.optimal_data_size - (length % self.optimal_data_size)) % self.optimal_data_size
     }
 
     /// Returns the number of bytes added so far.
@@ -616,35 +608,50 @@ impl PackedUpload {
 
     /// Returns the number of slabs in the upload.
     pub fn slabs(&self) -> u64 {
-        self.length.load(Ordering::Acquire).div_ceil(self.slab_size)
+        self.length
+            .load(Ordering::Acquire)
+            .div_ceil(self.optimal_data_size)
     }
 
     /// Adds a new object to the upload. The data will be read until EOF and packed into
     /// the upload. The resulting object will contain the metadata needed to download the object. The caller
     /// must call [finalize](Self::finalize) to get the resulting objects after all objects have been added.
     pub async fn add(&self, reader: Arc<dyn Reader>) -> Result<u64, UploadError> {
-        if self.closed.load(Ordering::Acquire) {
+        if self.cancel.is_cancelled() {
             return Err(UploadError::Closed);
         }
-        let tx = self.tx.clone();
-
+        let inner = self.inner.clone();
+        let cancel = self.cancel.clone();
+        let length = self.length.clone();
         spawn(async move {
-            let (add_tx, add_rx) = oneshot::channel();
-            tx.send(PackedUploadAction::Add(reader, add_tx))
-                .await
-                .map_err(|_| UploadError::Closed)?;
-            add_rx.await.map_err(|_| UploadError::Closed)?
+            tokio::select! {
+                _ = cancel.cancelled() => Err(UploadError::Closed),
+                r = async {
+                    let mut guard = inner.lock().await;
+                    // take ownership so cancelled in-flight adds
+                    // will immediately drop.
+                    let mut pu = guard.take().ok_or(UploadError::Closed)?;
+                    let res = pu.add(FFIReader::new(reader)).await.map_err(UploadError::from);
+                    let total = pu.length();
+                    *guard = Some(pu);
+                    length.store(total, Ordering::Release);
+                    res
+                } => r,
+            }
         })
         .await?
     }
 
-    /// Cancels the upload. This will immediately cancel the upload and return.
-    pub async fn cancel(&self) -> Result<(), UploadError> {
-        if self.closed.swap(true, Ordering::AcqRel) {
-            return Err(UploadError::Closed);
+    /// Cancels the upload. This will immediately cancel any in-progress [add](Self::add) or [finalize](Self::finalize) operations and prevent
+    /// any new ones from starting. Any in-flight operations will return an error once cancelled.
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+        // If no add/finalize is holding the lock, drop pu here to abort any
+        // background slab uploads. If one is holding it, its select! will
+        // drop pu when it observes the cancel token.
+        if let Ok(mut guard) = self.inner.try_lock() {
+            guard.take();
         }
-        self.upload_task.abort();
-        Ok(())
     }
 
     /// Finalizes the upload and returns the resulting objects. This will wait for all readers
@@ -652,16 +659,20 @@ impl PackedUpload {
     ///
     /// The caller must pin the resulting objects to the indexer when ready.
     pub async fn finalize(&self) -> Result<Vec<Arc<PinnedObject>>, UploadError> {
-        if self.closed.swap(true, Ordering::AcqRel) {
+        if self.cancel.is_cancelled() {
             return Err(UploadError::Closed);
         }
-        let tx = self.tx.clone();
+        let inner = self.inner.clone();
+        let cancel = self.cancel.clone();
         let objects = spawn(async move {
-            let (finalize_tx, finalize_rx) = oneshot::channel();
-            tx.send(PackedUploadAction::Finalize(finalize_tx))
-                .await
-                .map_err(|_| UploadError::Closed)?;
-            finalize_rx.await.map_err(|_| UploadError::Closed)?
+            tokio::select! {
+                _ = cancel.cancelled() => Err(UploadError::Closed),
+                r = async {
+                    let mut guard = inner.lock().await;
+                    let pu = guard.take().ok_or(UploadError::Closed)?;
+                    pu.finalize().await.map_err(UploadError::from)
+                } => r,
+            }
         })
         .await??;
         Ok(objects
@@ -831,58 +842,16 @@ impl Sdk {
     /// A [PackedUpload] that can be used to add objects and finalize the upload.
     pub async fn upload_packed(&self, options: UploadOptions) -> Result<PackedUpload, UploadError> {
         let options: sia_storage::UploadOptions = options.into();
-        let slab_size = options.data_shards as u64 * SECTOR_SIZE as u64;
-        let mut packed_upload = self
+        let packed_upload = self
             .inner
             .upload_packed(options)
             .map_err(UploadError::from)?;
-        let (action_tx, mut action_rx) = mpsc::channel(10);
-        let length = Arc::new(AtomicU64::new(0));
-        let closed = Arc::new(AtomicBool::new(false));
-        let task_length = length.clone();
-        let upload_task = spawn(async move {
-            debug!(
-                "packed upload task started with slab size {} bytes",
-                slab_size
-            );
-            while let Some(action) = action_rx.recv().await {
-                match action {
-                    PackedUploadAction::Add(reader, add_tx) => {
-                        let res = packed_upload
-                            .add(FFIReader::new(reader))
-                            .await
-                            .map_err(UploadError::from);
-                        if let Ok(size) = res {
-                            task_length.fetch_add(size, Ordering::AcqRel);
-                        }
-                        debug!(
-                            "added object of size {} bytes, total length is now {} bytes across {} slabs",
-                            res.as_ref().map(|s| *s).unwrap_or(0),
-                            task_length.load(Ordering::Acquire),
-                            task_length.load(Ordering::Acquire).div_ceil(slab_size)
-                        );
-                        let _ = add_tx.send(res);
-                    }
-                    PackedUploadAction::Finalize(finalize_tx) => {
-                        debug!(
-                            "finalizing packed upload with length {} bytes across {} slabs",
-                            task_length.load(Ordering::Acquire),
-                            task_length.load(Ordering::Acquire).div_ceil(slab_size)
-                        );
-                        let result = packed_upload.finalize().await.map_err(|e| e.into());
-                        let _ = finalize_tx.send(result);
-                        return;
-                    }
-                }
-            }
-            debug!("packed upload task ending because all senders have been dropped");
-        });
+        let optimal_data_size = packed_upload.optimal_data_size() as u64;
         Ok(PackedUpload {
-            upload_task,
-            tx: action_tx,
-            slab_size,
-            length,
-            closed,
+            inner: Arc::new(tokio::sync::Mutex::new(Some(packed_upload))),
+            cancel: CancellationToken::new(),
+            optimal_data_size,
+            length: Arc::new(AtomicU64::new(0)),
         })
     }
 

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -613,9 +613,14 @@ impl PackedUpload {
             .div_ceil(self.optimal_data_size)
     }
 
-    /// Adds a new object to the upload. The data will be read until EOF and packed into
-    /// the upload. The resulting object will contain the metadata needed to download the object. The caller
-    /// must call [finalize](Self::finalize) to get the resulting objects after all objects have been added.
+    /// Adds a new object to the upload. The data is read until EOF and packed into
+    /// the current slab. Returns the number of bytes consumed; call
+    /// [finalize](Self::finalize) once all objects have been added to get the
+    /// resulting objects.
+    ///
+    /// If the reader errors part-way, it's safe to continue calling
+    /// [add](Self::add); no object is registered for the failed call. Or call
+    /// [finalize](Self::finalize) to collect the objects added so far.
     pub async fn add(&self, reader: Arc<dyn Reader>) -> Result<u64, UploadError> {
         if self.cancel.is_cancelled() {
             return Err(UploadError::Closed);

--- a/sia_storage_napi/src/lib.rs
+++ b/sia_storage_napi/src/lib.rs
@@ -582,8 +582,21 @@ impl PackedUpload {
         )
     }
 
-    /// Adds a new object to the upload. The data will be read until EOF and
-    /// packed into the upload. Call `finalize()` after all objects have been added.
+    /// Adds a new object to the upload. The data is read until EOF and packed into
+    /// the current slab. Returns the number of bytes consumed; call
+    /// [finalize](Self::finalize) once all objects have been added to get the
+    /// resulting objects.
+    ///
+    /// If the reader errors part-way, it's safe to continue calling
+    /// [add](Self::add); no object is registered for the failed call. Or call
+    /// [finalize](Self::finalize) to collect the objects added so far.
+    ///
+    /// ```js
+    /// const packed = sdk.uploadPacked();
+    /// await packed.add(file.stream());
+    /// await packed.add(blob.stream());
+    /// const objects = await packed.finalize();
+    /// ```
     #[napi(ts_args_type = "stream: ReadableStream")]
     pub async fn add(&self, stream: SendableReader) -> Result<BigInt> {
         if self.cancel.is_cancelled() {

--- a/sia_storage_napi/src/lib.rs
+++ b/sia_storage_napi/src/lib.rs
@@ -2,14 +2,13 @@ use chrono::{DateTime, Utc};
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
-use sia_core::rhp4::SECTOR_SIZE;
 use sia_core::signing::{PublicKey, Signature};
 use sia_core::types::{self, Hash256, HexParseError};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
 
 mod builder;
 mod io;
@@ -541,26 +540,15 @@ impl PinnedObject {
     }
 }
 
-enum PackedUploadAction {
-    Add(
-        io::NapiStreamReader,
-        oneshot::Sender<std::result::Result<u64, sia_storage::UploadError>>,
-    ),
-    Finalize(
-        oneshot::Sender<std::result::Result<Vec<sia_storage::Object>, sia_storage::UploadError>>,
-    ),
-}
-
 /// A packed upload allows multiple objects to be uploaded together in a single
 /// upload. This can be more efficient than individual uploads for many small
 /// objects since they share slabs.
 #[napi]
 pub struct PackedUpload {
-    upload_task: tokio::task::JoinHandle<()>,
-    tx: mpsc::Sender<PackedUploadAction>,
-    slab_size: u64,
+    inner: Arc<tokio::sync::Mutex<Option<sia_storage::PackedUpload>>>,
+    cancel: CancellationToken,
+    optimal_data_size: u64,
     length: Arc<AtomicU64>,
-    closed: Arc<AtomicBool>,
 }
 
 #[napi]
@@ -571,9 +559,9 @@ impl PackedUpload {
     pub fn remaining(&self) -> BigInt {
         let length = self.length.load(Ordering::Acquire);
         let remaining = if length == 0 {
-            self.slab_size
+            self.optimal_data_size
         } else {
-            (self.slab_size - (length % self.slab_size)) % self.slab_size
+            (self.optimal_data_size - (length % self.optimal_data_size)) % self.optimal_data_size
         };
         BigInt::from(remaining)
     }
@@ -587,55 +575,71 @@ impl PackedUpload {
     /// Returns the number of slabs in the upload.
     #[napi]
     pub fn slabs(&self) -> BigInt {
-        BigInt::from(self.length.load(Ordering::Acquire).div_ceil(self.slab_size))
+        BigInt::from(
+            self.length
+                .load(Ordering::Acquire)
+                .div_ceil(self.optimal_data_size),
+        )
     }
 
     /// Adds a new object to the upload. The data will be read until EOF and
     /// packed into the upload. Call `finalize()` after all objects have been added.
     #[napi(ts_args_type = "stream: ReadableStream")]
     pub async fn add(&self, stream: SendableReader) -> Result<BigInt> {
-        if self.closed.load(Ordering::Acquire) {
-            return Err(Error::from_reason("upload already closed"));
+        if self.cancel.is_cancelled() {
+            return Err(Error::from_reason("upload closed"));
         }
-        let (add_tx, add_rx) = oneshot::channel();
-        self.tx
-            .send(PackedUploadAction::Add(stream.0, add_tx))
-            .await
-            .map_err(|_| Error::from_reason("upload closed"))?;
-        let size = add_rx
-            .await
-            .map_err(|_| Error::from_reason("upload closed"))?
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let inner = self.inner.clone();
+        let cancel = self.cancel.clone();
+        let length = self.length.clone();
+        let result: Result<u64> = tokio::select! {
+            _ = cancel.cancelled() => Err(Error::from_reason("upload closed")),
+            r = async {
+                let mut guard = inner.lock().await;
+                // Take ownership so cancel's drop-cascade can abort in-flight
+                // slab uploads (they're held as AbortOnDropHandles inside pu).
+                let mut pu = guard.take().ok_or_else(|| Error::from_reason("upload closed"))?;
+                let res = pu.add(stream.0).await.map_err(|e| Error::from_reason(e.to_string()));
+                let total = pu.length();
+                *guard = Some(pu);
+                length.store(total, Ordering::Release);
+                res
+            } => r,
+        };
+        let size = result?;
         Ok(BigInt::from(size))
     }
 
     /// Cancels the upload.
     #[napi]
-    pub async fn cancel(&self) -> Result<()> {
-        if self.closed.swap(true, Ordering::AcqRel) {
-            return Err(Error::from_reason("upload already closed"));
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+        // If no add/finalize is holding the lock, drop pu here to abort any
+        // background slab uploads. If one is holding it, its select! will
+        // drop pu when it observes the cancel token.
+        if let Ok(mut guard) = self.inner.try_lock() {
+            guard.take();
         }
-        self.upload_task.abort();
-        Ok(())
     }
 
     /// Finalizes the upload and returns the resulting objects. Each object
     /// must be pinned separately with `sdk.pinObject()`.
     #[napi]
     pub async fn finalize(&self) -> Result<Vec<PinnedObject>> {
-        if self.closed.swap(true, Ordering::AcqRel) {
-            return Err(Error::from_reason("upload already closed"));
+        if self.cancel.is_cancelled() {
+            return Err(Error::from_reason("upload closed"));
         }
-        let (finalize_tx, finalize_rx) = oneshot::channel();
-        self.tx
-            .send(PackedUploadAction::Finalize(finalize_tx))
-            .await
-            .map_err(|_| Error::from_reason("upload closed"))?;
-        let objects = finalize_rx
-            .await
-            .map_err(|_| Error::from_reason("upload closed"))?
-            .map_err(|e| Error::from_reason(e.to_string()))?;
-        Ok(objects
+        let inner = self.inner.clone();
+        let cancel = self.cancel.clone();
+        let objects: Result<Vec<sia_storage::Object>> = tokio::select! {
+            _ = cancel.cancelled() => Err(Error::from_reason("upload closed")),
+            r = async {
+                let mut guard = inner.lock().await;
+                let pu = guard.take().ok_or_else(|| Error::from_reason("upload closed"))?;
+                pu.finalize().await.map_err(|e| Error::from_reason(e.to_string()))
+            } => r,
+        };
+        Ok(objects?
             .into_iter()
             .map(|o| PinnedObject {
                 inner: Mutex::new(o),
@@ -662,39 +666,16 @@ impl Sdk {
     #[napi(ts_args_type = "options?: UploadOptions")]
     pub fn upload_packed(&self, options: Option<SendableUploadOptions>) -> Result<PackedUpload> {
         let options: sia_storage::UploadOptions = options.map(|o| o.0).unwrap_or_default();
-        let slab_size = SECTOR_SIZE as u64 * options.data_shards as u64;
-        let mut packed_upload = self
+        let optimal_data_size = options.optimal_data_size() as u64;
+        let packed_upload = self
             .inner
             .upload_packed(options)
             .map_err(|e| Error::from_reason(e.to_string()))?;
-        let (action_tx, mut action_rx) = mpsc::channel(10);
-        let length = Arc::new(AtomicU64::new(0));
-        let closed = Arc::new(AtomicBool::new(false));
-        let task_length = length.clone();
-        let upload_task = tokio::spawn(async move {
-            while let Some(action) = action_rx.recv().await {
-                match action {
-                    PackedUploadAction::Add(reader, add_tx) => {
-                        let res = packed_upload.add(reader).await;
-                        if let Ok(size) = res {
-                            task_length.fetch_add(size, Ordering::AcqRel);
-                        }
-                        let _ = add_tx.send(res);
-                    }
-                    PackedUploadAction::Finalize(finalize_tx) => {
-                        let result = packed_upload.finalize().await;
-                        let _ = finalize_tx.send(result);
-                        return;
-                    }
-                }
-            }
-        });
         Ok(PackedUpload {
-            upload_task,
-            tx: action_tx,
-            slab_size,
-            length,
-            closed,
+            inner: Arc::new(tokio::sync::Mutex::new(Some(packed_upload))),
+            cancel: CancellationToken::new(),
+            optimal_data_size,
+            length: Arc::new(AtomicU64::new(0)),
         })
     }
 

--- a/sia_storage_wasm/examples/index.html
+++ b/sia_storage_wasm/examples/index.html
@@ -1,8 +1,7 @@
 <!--
   Build and run:
-    cd sia_storage_wasm
-    RUSTFLAGS="--cfg=web_sys_unstable_apis" wasm-pack build --target web --release --out-dir examples/pkg
-    python3 -m http.server 8080 --directory examples
+    (cd sia_storage_wasm && RUSTFLAGS="--cfg=web_sys_unstable_apis" wasm-pack build --target web --release --out-dir examples/pkg)
+    python3 -m http.server 8080 --directory sia_storage_wasm/examples
     open http://localhost:8080
 -->
 <!DOCTYPE html>

--- a/sia_storage_wasm/src/packed.rs
+++ b/sia_storage_wasm/src/packed.rs
@@ -75,12 +75,20 @@ impl PackedUpload {
         self.optimal_data_size
     }
 
-    /// Adds an object to the packed upload. Returns the number of bytes written.
+    /// Adds a new object to the upload. The data is read until EOF and packed into
+    /// the current slab. Returns the number of bytes consumed; call
+    /// [finalize](Self::finalize) once all objects have been added to get the
+    /// resulting objects.
+    ///
+    /// If the reader errors part-way, it's safe to continue calling
+    /// [add](Self::add); no object is registered for the failed call. Or call
+    /// [finalize](Self::finalize) to collect the objects added so far.
     ///
     /// ```js
     /// const packed = sdk.uploadPacked();
     /// await packed.add(file.stream());
     /// await packed.add(blob.stream());
+    /// const objects = await packed.finalize();
     /// ```
     pub async fn add(&self, stream: web_sys::ReadableStream) -> Result<f64, JsError> {
         if self.cancel.is_cancelled() {

--- a/sia_storage_wasm/src/packed.rs
+++ b/sia_storage_wasm/src/packed.rs
@@ -1,23 +1,15 @@
 use std::cell::Cell;
-use tokio::sync::{mpsc, oneshot};
-use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt};
+use std::rc::Rc;
+use tokio::sync::Mutex;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
+use tokio_util::sync::CancellationToken;
 
 use sia_storage::PackedUpload as CorePackedUpload;
 use wasm_bindgen::prelude::*;
 
 use crate::helpers::to_js_err;
 use crate::object::PinnedObject;
-use crate::stream_reader::{JsStreamReader, js_stream_reader};
-
-type PackedReader = Compat<JsStreamReader>;
-
-enum PackedUploadAction {
-    Add(
-        PackedReader,
-        oneshot::Sender<Result<u64, sia_storage::UploadError>>,
-    ),
-    Finalize(oneshot::Sender<Result<Vec<sia_storage::Object>, sia_storage::UploadError>>),
-}
+use crate::stream_reader::js_stream_reader;
 
 /// A packed upload handle for efficiently uploading multiple objects
 /// together. Objects are packed into shared slabs to avoid wasting storage.
@@ -31,39 +23,20 @@ enum PackedUploadAction {
 /// ```
 #[wasm_bindgen]
 pub struct PackedUpload {
-    upload_task: tokio::task::JoinHandle<()>,
-    tx: mpsc::Sender<PackedUploadAction>,
-    slab_size: f64,
+    inner: Rc<Mutex<Option<CorePackedUpload>>>,
+    cancel: CancellationToken,
+    optimal_data_size: f64,
     length: Cell<f64>,
-    closed: Cell<bool>,
 }
 
 impl PackedUpload {
     pub(crate) fn new(inner: CorePackedUpload) -> Self {
-        let slab_size = inner.slab_size() as f64;
-        let (action_tx, mut action_rx) = mpsc::channel(10);
-        let upload_task = tokio::task::spawn_local(async move {
-            let mut packed_upload = inner;
-            while let Some(action) = action_rx.recv().await {
-                match action {
-                    PackedUploadAction::Add(reader, add_tx) => {
-                        let res = packed_upload.add(reader).await;
-                        let _ = add_tx.send(res);
-                    }
-                    PackedUploadAction::Finalize(finalize_tx) => {
-                        let result = packed_upload.finalize().await;
-                        let _ = finalize_tx.send(result);
-                        return;
-                    }
-                }
-            }
-        });
+        let optimal_data_size = inner.optimal_data_size() as f64;
         Self {
-            upload_task,
-            tx: action_tx,
-            slab_size,
+            inner: Rc::new(Mutex::new(Some(inner))),
+            cancel: CancellationToken::new(),
+            optimal_data_size,
             length: Cell::new(0.0),
-            closed: Cell::new(false),
         }
     }
 }
@@ -75,9 +48,9 @@ impl PackedUpload {
     pub fn remaining(&self) -> f64 {
         let length = self.length.get();
         if length == 0.0 {
-            self.slab_size
+            self.optimal_data_size
         } else {
-            (self.slab_size - (length % self.slab_size)) % self.slab_size
+            (self.optimal_data_size - (length % self.optimal_data_size)) % self.optimal_data_size
         }
     }
 
@@ -92,14 +65,14 @@ impl PackedUpload {
         if length == 0.0 {
             0.0
         } else {
-            (length / self.slab_size).ceil()
+            (length / self.optimal_data_size).ceil()
         }
     }
 
     /// Optimal size of each slab in bytes.
-    #[wasm_bindgen(js_name = "slabSize")]
-    pub fn slab_size(&self) -> f64 {
-        self.slab_size
+    #[wasm_bindgen(js_name = "optimalDataSize")]
+    pub fn optimal_data_size(&self) -> f64 {
+        self.optimal_data_size
     }
 
     /// Adds an object to the packed upload. Returns the number of bytes written.
@@ -110,50 +83,60 @@ impl PackedUpload {
     /// await packed.add(blob.stream());
     /// ```
     pub async fn add(&self, stream: web_sys::ReadableStream) -> Result<f64, JsError> {
-        if self.closed.get() {
-            return Err(JsError::new("upload already finalized"));
+        if self.cancel.is_cancelled() {
+            return Err(JsError::new("upload closed"));
         }
         let reader = js_stream_reader(stream).compat();
-        let (add_tx, add_rx) = oneshot::channel();
-        self.tx
-            .send(PackedUploadAction::Add(reader, add_tx))
-            .await
-            .map_err(|_| JsError::new("upload closed"))?;
-        let size = add_rx
-            .await
-            .map_err(|_| JsError::new("upload closed"))?
-            .map_err(to_js_err)?;
-        let size = size as f64;
-        self.length.set(self.length.get() + size);
-        Ok(size)
+        let inner = self.inner.clone();
+        let cancel = self.cancel.clone();
+        let result: Result<u64, JsError> = tokio::select! {
+            _ = cancel.cancelled() => Err(JsError::new("upload closed")),
+            r = async {
+                let mut guard = inner.lock().await;
+                // Take ownership so cancel's drop-cascade can abort in-flight
+                // slab uploads (they're held as AbortOnDropHandles inside pu).
+                let mut pu = guard.take().ok_or_else(|| JsError::new("upload closed"))?;
+                let res = pu.add(reader).await.map_err(to_js_err);
+                // Mirror pu.length() rather than accumulating the add's
+                // returned size, so partial bytes from an errored add (now
+                // kept in pu.length()) stay accounted for.
+                let total = pu.length() as f64;
+                *guard = Some(pu);
+                self.length.set(total);
+                res
+            } => r,
+        };
+        Ok(result? as f64)
     }
 
     /// Finalizes the packed upload and returns the resulting objects.
     /// Each object must be pinned separately with `sdk.pinObject()`.
     pub async fn finalize(self) -> Result<Vec<PinnedObject>, JsError> {
-        if self.closed.replace(true) {
-            return Err(JsError::new("upload already finalized"));
+        if self.cancel.is_cancelled() {
+            return Err(JsError::new("upload closed"));
         }
-        let (finalize_tx, finalize_rx) = oneshot::channel();
-        self.tx
-            .send(PackedUploadAction::Finalize(finalize_tx))
-            .await
-            .map_err(|_| JsError::new("upload closed"))?;
-        let objects = finalize_rx
-            .await
-            .map_err(|_| JsError::new("upload closed"))?
-            .map_err(to_js_err)?;
-        Ok(objects.into_iter().map(PinnedObject).collect())
+        let inner = self.inner.clone();
+        let cancel = self.cancel.clone();
+        let result: Result<Vec<sia_storage::Object>, JsError> = tokio::select! {
+            _ = cancel.cancelled() => Err(JsError::new("upload closed")),
+            r = async {
+                let mut guard = inner.lock().await;
+                let pu = guard.take().ok_or_else(|| JsError::new("upload closed"))?;
+                pu.finalize().await.map_err(to_js_err)
+            } => r,
+        };
+        Ok(result?.into_iter().map(PinnedObject).collect())
     }
 
     /// Cancels the packed upload. Immediately interrupts any in-flight `add`
     /// and aborts all pending slab uploads.
     pub fn cancel(&self) {
-        if self.closed.replace(true) {
-            return;
+        self.cancel.cancel();
+        // If no add/finalize is holding the lock, drop pu here to abort any
+        // background slab uploads. If one is holding it, its select! will
+        // drop pu when it observes the cancel token.
+        if let Ok(mut guard) = self.inner.try_lock() {
+            guard.take();
         }
-        // Aborting the task drops the owned PackedUpload, which aborts every
-        // pending slab task via AbortOnDropHandle inside the core upload.
-        self.upload_task.abort();
     }
 }


### PR DESCRIPTION
Refactor PackedUpload on native to fix a data-corruption bug on errored reads and clean up inconsistent slab_size naming. Removes the background task and channels from the packed upload bindings to simplify usage and prevent it from swallowing errors.