### PR TITLE
Measure throughput rather than latency 

### DIFF
--- a/.changeset/measure_rpcaverage_in_throughput_instead_of_latency_to_take_into_account_transmitted_bytes.md
+++ b/.changeset/measure_rpcaverage_in_throughput_instead_of_latency_to_take_into_account_transmitted_bytes.md
@@ -1,0 +1,5 @@
+---
+sia_storage: patch
+---
+
+# Measure RPCAverage in throughput instead of latency to take into account transmitted bytes.

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -176,7 +176,8 @@ impl HostMetric {
 }
 
 // Computes throughput in bytes/sec, returning None when elapsed is zero so that
-// the sample is skipped instead of producing a division by zero panic.
+// the sample is skipped instead of producing an invalid/infinite throughput
+// value that would skew the moving average.
 fn bytes_per_sec(bytes: u64, elapsed: Duration) -> Option<u64> {
     if elapsed.is_zero() {
         return None;

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -39,17 +39,20 @@ pub struct Host {
 }
 
 #[derive(Debug, Default, Clone)]
-struct RPCAverage(Option<f64>); // exponential moving average of throughput in bps
+struct RPCAverage(Option<f64>); // exponential moving average of throughput in bytes/sec
 
 impl RPCAverage {
     const ALPHA: f64 = 0.2;
-    fn add_sample(&mut self, throughput: u64) {
+    // Default throughput in bytes/sec if no samples; equivalent to 1 Gbps.
+    const DEFAULT_BYTES_PER_SEC: u64 = 125_000_000;
+
+    fn add_sample(&mut self, bytes_per_sec: u64) {
         match self.0 {
             Some(avg) => {
-                self.0 = Some(Self::ALPHA * (throughput as f64) + (1.0 - Self::ALPHA) * avg);
+                self.0 = Some(Self::ALPHA * (bytes_per_sec as f64) + (1.0 - Self::ALPHA) * avg);
             }
             None => {
-                self.0 = Some(throughput as f64);
+                self.0 = Some(bytes_per_sec as f64);
             }
         }
     }
@@ -57,7 +60,7 @@ impl RPCAverage {
     fn avg(&self) -> u64 {
         match self.0 {
             Some(avg) => avg as u64,
-            None => 125000000, // default to 1 Gbps if no samples
+            None => Self::DEFAULT_BYTES_PER_SEC,
         }
     }
 }
@@ -143,7 +146,6 @@ impl Ord for FailureRate {
 
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 struct HostMetric {
-    rpc_settings_avg: RPCAverage,
     rpc_write_avg: RPCAverage,
     rpc_read_avg: RPCAverage,
     failure_rate: FailureRate,
@@ -151,14 +153,16 @@ struct HostMetric {
 
 impl HostMetric {
     fn add_write_sample(&mut self, bytes: u64, elapsed: Duration) {
-        self.rpc_write_avg
-            .add_sample((bytes as f64 / elapsed.as_secs_f64()) as u64);
+        if let Some(bps) = bytes_per_sec(bytes, elapsed) {
+            self.rpc_write_avg.add_sample(bps);
+        }
         self.failure_rate.add_sample(true);
     }
 
     fn add_read_sample(&mut self, bytes: u64, elapsed: Duration) {
-        self.rpc_read_avg
-            .add_sample((bytes as f64 / elapsed.as_secs_f64()) as u64);
+        if let Some(bps) = bytes_per_sec(bytes, elapsed) {
+            self.rpc_read_avg.add_sample(bps);
+        }
         self.failure_rate.add_sample(true);
     }
 
@@ -171,24 +175,31 @@ impl HostMetric {
     }
 }
 
+// Computes throughput in bytes/sec, returning None when elapsed is zero so that
+// the sample is skipped instead of producing a division by zero panic.
+fn bytes_per_sec(bytes: u64, elapsed: Duration) -> Option<u64> {
+    if elapsed.is_zero() {
+        return None;
+    }
+    Some((bytes as f64 / elapsed.as_secs_f64()) as u64)
+}
+
 impl Ord for HostMetric {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match other.failure_rate.cmp(&self.failure_rate) {
             // lower failure rate is higher priority
             std::cmp::Ordering::Equal => {
-                // use average of read, write, and settings RPC times as tiebreaker
-                let avg_self = (self
+                // use average of read and write throughput as tiebreaker
+                let avg_self = self
                     .rpc_write_avg
                     .avg()
-                    .saturating_add(self.rpc_read_avg.avg()))
-                .saturating_add(self.rpc_settings_avg.avg())
-                    / 3;
-                let avg_other = (other
+                    .saturating_add(self.rpc_read_avg.avg())
+                    / 2;
+                let avg_other = other
                     .rpc_write_avg
                     .avg()
-                    .saturating_add(other.rpc_read_avg.avg()))
-                .saturating_add(other.rpc_settings_avg.avg())
-                    / 3;
+                    .saturating_add(other.rpc_read_avg.avg())
+                    / 2;
                 avg_self.cmp(&avg_other) // higher average throughput is higher priority
             }
             ord => ord,

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -39,33 +39,32 @@ pub struct Host {
 }
 
 #[derive(Debug, Default, Clone)]
-struct RPCAverage(Option<f64>); // exponential moving average of latency in milliseconds
+struct RPCAverage(Option<f64>); // exponential moving average of throughput in bps
 
 impl RPCAverage {
     const ALPHA: f64 = 0.2;
-    fn add_sample(&mut self, sample: Duration) {
+    fn add_sample(&mut self, throughput: u64) {
         match self.0 {
             Some(avg) => {
-                self.0 =
-                    Some(Self::ALPHA * (sample.as_millis() as f64) + (1.0 - Self::ALPHA) * avg);
+                self.0 = Some(Self::ALPHA * (throughput as f64) + (1.0 - Self::ALPHA) * avg);
             }
             None => {
-                self.0 = Some(sample.as_millis() as f64);
+                self.0 = Some(throughput as f64);
             }
         }
     }
 
-    fn avg(&self) -> Duration {
+    fn avg(&self) -> u64 {
         match self.0 {
-            Some(avg) => Duration::from_millis(avg as u64),
-            None => Duration::from_secs(3600), // 1h if no samples
+            Some(avg) => avg as u64,
+            None => 125000000, // default to 1 Gbps if no samples
         }
     }
 }
 
 impl Display for RPCAverage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.avg().fmt(f)
+        Display::fmt(&self.avg(), f)
     }
 }
 
@@ -151,19 +150,20 @@ struct HostMetric {
 }
 
 impl HostMetric {
-    fn add_write_sample(&mut self, d: Duration) {
-        self.rpc_write_avg.add_sample(d);
+    fn add_write_sample(&mut self, bytes: u64, elapsed: Duration) {
+        self.rpc_write_avg
+            .add_sample((bytes as f64 / elapsed.as_secs_f64()) as u64);
         self.failure_rate.add_sample(true);
     }
 
-    fn add_read_sample(&mut self, d: Duration) {
-        self.rpc_read_avg.add_sample(d);
+    fn add_read_sample(&mut self, bytes: u64, elapsed: Duration) {
+        self.rpc_read_avg
+            .add_sample((bytes as f64 / elapsed.as_secs_f64()) as u64);
         self.failure_rate.add_sample(true);
     }
 
-    fn add_settings_sample(&mut self, d: Duration) {
-        self.rpc_settings_avg.add_sample(d);
-        self.failure_rate.add_sample(true);
+    fn add_settings_sample(&mut self, elapsed: Duration) {
+        self.add_read_sample(270, elapsed); // serialized settings response is ~270 bytes
     }
 
     fn add_failure(&mut self) {
@@ -189,7 +189,7 @@ impl Ord for HostMetric {
                     .saturating_add(other.rpc_read_avg.avg()))
                 .saturating_add(other.rpc_settings_avg.avg())
                     / 3;
-                avg_other.cmp(&avg_self) // lower average latency is higher priority
+                avg_self.cmp(&avg_other) // higher average throughput is higher priority
             }
             ord => ord,
         }
@@ -302,31 +302,31 @@ impl HostList {
     }
 
     /// Adds a read sample for the given host, updating its metrics and priority.
-    fn add_read_sample(&self, host_key: PublicKey, duration: Duration) {
+    fn add_read_sample(&self, host_key: PublicKey, bytes: u64, elapsed: Duration) {
         self.preferred_hosts
             .write()
             .unwrap()
             .change_priority_by(&host_key, |metric| {
-                metric.add_read_sample(duration);
+                metric.add_read_sample(bytes, elapsed);
             });
     }
 
     /// Adds a write sample for the given host, updating its metrics and priority.
-    fn add_write_sample(&self, host_key: PublicKey, duration: Duration) {
+    fn add_write_sample(&self, host_key: PublicKey, bytes: u64, elapsed: Duration) {
         self.preferred_hosts
             .write()
             .unwrap()
             .change_priority_by(&host_key, |metric| {
-                metric.add_write_sample(duration);
+                metric.add_write_sample(bytes, elapsed);
             });
     }
 
-    fn add_settings_sample(&self, host_key: PublicKey, duration: Duration) {
+    fn add_settings_sample(&self, host_key: PublicKey, elapsed: Duration) {
         self.preferred_hosts
             .write()
             .unwrap()
             .change_priority_by(&host_key, |metric| {
-                metric.add_settings_sample(duration);
+                metric.add_settings_sample(elapsed);
             });
     }
 }
@@ -534,13 +534,14 @@ impl<T: Transport> Hosts<T> {
                 false,
             )
             .await?;
+            let bytes = sector.len() as u64;
             let (root, elapsed) = self
                 .transport
                 .write_sector(&host, prices, account_key, sector)
                 .await
                 .inspect_err(|_| self.hosts.add_failure(host_key))
                 .map_err(RPCError::Rhp)?;
-            self.hosts.add_write_sample(host_key, elapsed);
+            self.hosts.add_write_sample(host_key, bytes, elapsed);
             Ok(root)
         })
         .await?
@@ -556,6 +557,7 @@ impl<T: Transport> Hosts<T> {
         read_timeout: Duration,
     ) -> Result<bytes::Bytes, RPCError> {
         let host = self.host_endpoint(host_key)?;
+        let bytes = length as u64;
         timeout(read_timeout, async {
             let (prices, _) = Self::fetch_prices(
                 self.transport.clone(),
@@ -572,7 +574,7 @@ impl<T: Transport> Hosts<T> {
                 .await
                 .inspect_err(|_| self.hosts.add_failure(host_key))
                 .map_err(RPCError::Rhp)?;
-            self.hosts.add_read_sample(host_key, elapsed);
+            self.hosts.add_read_sample(host_key, bytes, elapsed);
             Ok(data)
         })
         .await?
@@ -713,27 +715,23 @@ mod test {
 
     async fn test_rpc_average() {
         let mut avg = RPCAverage::default();
-        avg.add_sample(Duration::from_millis(100));
         assert_eq!(
             avg.avg(),
-            Duration::from_millis(100),
-            "initial average should be first sample"
+            125000000,
+            "default average should be 1 Gbps before any samples"
         );
 
-        avg.add_sample(Duration::from_millis(200));
-        assert!(
-            avg.avg() > Duration::from_millis(100),
-            "average should increase after higher sample"
-        );
+        avg.add_sample(100);
+        assert_eq!(avg.avg(), 100, "initial average should be first sample");
 
-        avg.add_sample(Duration::from_millis(50));
-        assert!(
-            avg.avg() < Duration::from_millis(200),
-            "average should decrease after lower sample"
-        );
+        avg.add_sample(200);
+        assert!(avg.avg() > 100, "average should increase after higher sample");
+
+        avg.add_sample(50);
+        assert!(avg.avg() < 200, "average should decrease after lower sample");
 
         let mut avg2 = RPCAverage::default();
-        avg2.add_sample(Duration::from_millis(150));
+        avg2.add_sample(150);
         assert_eq!(
             avg.cmp(&avg2),
             std::cmp::Ordering::Less,
@@ -773,15 +771,9 @@ mod test {
             HostMetric::default(),
             HostMetric::default(),
         ];
-        hosts[0]
-            .rpc_write_avg
-            .add_sample(Duration::from_millis(100));
-        hosts[1]
-            .rpc_write_avg
-            .add_sample(Duration::from_millis(1000));
-        hosts[2]
-            .rpc_write_avg
-            .add_sample(Duration::from_millis(500));
+        hosts[0].rpc_write_avg.add_sample(100);
+        hosts[1].rpc_write_avg.add_sample(1000);
+        hosts[2].rpc_write_avg.add_sample(500);
         hosts.sort();
 
         let rates = hosts
@@ -790,7 +782,7 @@ mod test {
             .map(|h| h.rpc_write_avg)
             .collect::<Vec<RPCAverage>>();
         assert!(
-            rates.is_sorted(),
+            rates.is_sorted_by(|a, b| a >= b),
             "hosts should be sorted by rpc write avg desc"
         );
     }
@@ -807,23 +799,24 @@ mod test {
         // initially, the order is the same as insertion
         assert_eq!(pq.peek().unwrap().0, &hosts[0]);
 
-        // fourth host has a sample, should have highest priority
+        // fourth host gets a sample with throughput below the 1Gbps default,
+        // dropping its priority below the other hosts
         pq.change_priority_by(&hosts[3], |metric| {
-            metric.add_write_sample(Duration::from_millis(100));
+            metric.add_write_sample(100, Duration::from_secs(1));
         });
-        assert_eq!(pq.peek().unwrap().0, &hosts[3]);
+        assert_ne!(pq.peek().unwrap().0, &hosts[3]);
 
         // add a faster sample to second host, should have higher priority than fourth
         pq.change_priority_by(&hosts[1], |metric| {
-            metric.add_read_sample(Duration::from_millis(50));
+            metric.add_read_sample(200, Duration::from_secs(1));
         });
-        assert_eq!(pq.peek().unwrap().0, &hosts[1]);
+        assert!(pq.get_priority(&hosts[1]).unwrap() > pq.get_priority(&hosts[3]).unwrap());
 
         // add a failure to the second host, should lower its priority below fourth
         pq.change_priority_by(&hosts[1], |metric| {
             metric.add_failure();
         });
-        assert_eq!(pq.peek().unwrap().0, &hosts[3]);
+        assert!(pq.get_priority(&hosts[1]).unwrap() < pq.get_priority(&hosts[3]).unwrap());
     }
 
     async fn test_upload_queue() {


### PR DESCRIPTION
Closes https://github.com/SiaFoundation/sia-sdk-rs/issues/327

This PR updates the SDK to measure throughput rather than latency, assuming a size of ~270 bytes for host settings and a 1Gbps throughput for unknown hosts. It also condenses the `rpc_settings_avg´ field into the `rpc_read_avg` since we can compare throughput more easily.

Theoretically there should be no unknown hosts after the warmup but if there were, this would lead to trying all unknown hosts before zoning in on the fastest known ones. 