### PR TITLE
Switch to sia_reed_solomon

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.wasm32-unknown-unknown]
+rustflags = [
+    "-C", "target-feature=+simd128",
+    "--cfg=web_sys_unstable_apis",
+]

--- a/.changeset/output_id_index_u64.md
+++ b/.changeset/output_id_index_u64.md
@@ -1,0 +1,14 @@
+---
+sia_core: major
+---
+
+# Use u64 for output and contract ID derive indices
+
+Changed the index parameter on `TransactionID`, `BlockID`, and `FileContractID`
+ID-derive methods from `usize` to `u64`: `siacoin_output_id`, `siafund_output_id`,
+`file_contract_id`, `miner_output_id`, `v2_siacoin_output_id`, `v2_siafund_output_id`,
+`v2_file_contract_id`, `v2_attestation_id`, `valid_output_id`, and `missed_output_id`.
+
+The hash input was already serialized as a little-endian `u64`, so on-chain IDs
+are unchanged. The previous signature silently truncated indices to 32 bits on
+`wasm32` (where `usize == u32`).

--- a/.changeset/remove_rayon_crate_from_dependencies_on_wasm.md
+++ b/.changeset/remove_rayon_crate_from_dependencies_on_wasm.md
@@ -1,0 +1,5 @@
+---
+sia_core: patch
+---
+
+# Remove rayon crate from dependencies on WASM.

--- a/.changeset/switch_to_sia_reed_solomon.md
+++ b/.changeset/switch_to_sia_reed_solomon.md
@@ -1,0 +1,17 @@
+---
+sia_storage: major
+---
+
+# Switch to sia_reed_solomon for erasure-coding
+
+Replaced `reed-solomon-erasure` with `sia_reed_solomon`. Encoded parity bytes
+are compatible with existing `indexd` slabs.
+
+120 MiB upload against the mock cluster
+(`cargo bench -p sia_storage --all-features`):
+
+| | Before | After | Δ |
+|---|---|---|---|
+| `upload/90 inflight` | ~285 MiB/s | **611 MiB/s** | **+114%** |
+| `upload/10 inflight` | ~175 MiB/s | **595 MiB/s** | **+240%** |
+| `upload/default`     | ~184 MiB/s | **609 MiB/s** | **+231%** |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,3 +69,12 @@ jobs:
         run: cd sia_storage && wasm-pack test --release --headless --${{ matrix.browser }} -- --lib
         env:
           WASM_BINDGEN_TEST_TIMEOUT: '300'
+
+  # Single required check for branch protection. Skipped (and therefore
+  # non-passing) whenever any upstream job fails.
+  success:
+    name: success
+    needs: [lint, test, test-wasm]
+    runs-on: tenki-standard-medium-4c-8g
+    steps:
+      - run: echo success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,32 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: tenki-standard-medium-4c-8g
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Setup Environment
+        run: |
+          rustup update stable
+          rustup toolchain install nightly
+          rustup target add wasm32-unknown-unknown
+          rustup component add rustfmt --toolchain nightly
+      - name: Rustfmt
+        run: cargo +nightly fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+      - name: Clippy (wasm)
+        run: cargo clippy --target wasm32-unknown-unknown --lib --package sia_core --package sia_storage --package sia_storage_wasm --no-default-features -- -D warnings
+      - name: Check all features
+        run: cargo check --all-features --workspace
+      - name: Build docs
+        run: cargo doc --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+
   test:
+    name: Test (native)
     runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -20,35 +45,19 @@ jobs:
           go-version: 'stable'
       - name: Build Go interop helper
         run: cd sia_mux/testutil/go-interop && go build -o interop .
-      - name: Setup Environment
-        run: |
-          rustup update stable
-          rustup toolchain install nightly
-          rustup target add wasm32-unknown-unknown
-          rustup component add rustfmt --toolchain nightly
-      - name: Install wasm-pack
-        shell: bash
-        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | bash
-      - name: Clippy (wasm)
-        run: cargo clippy --target wasm32-unknown-unknown --lib --package sia_core --package sia_storage --package sia_storage_wasm --no-default-features -- -D warnings
-        env:
-          RUSTFLAGS: '--cfg=web_sys_unstable_apis'
-      - name: Rustfmt
-        run: cargo +nightly fmt --all -- --check
-      - name: Clippy
-        run: |
-          cargo clippy -- -D warnings
-          cargo check --all-features --workspace
-      - name: Build docs
-        run: cargo doc --all-features --no-deps
-        env:
-          RUSTDOCFLAGS: "-D warnings"
+      - name: Setup Rust
+        run: rustup update stable
       - name: Build benches
         run: cargo build --benches --features=mock
-      - name: Test (native)
+      - name: Test
         run: cargo test --all-features
 
-  test-wasm-chrome:
+  test-wasm:
+    name: Test WASM (${{ matrix.browser }})
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, firefox]
     runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -56,32 +65,9 @@ jobs:
         run: |
           rustup update stable
           rustup target add wasm32-unknown-unknown
-      - name: Install wasm-pack
-        shell: bash
-        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | bash
-      - name: Test (wasm - sia_storage - chrome)
+          cargo install wasm-pack
+      - name: Test (wasm - sia_storage)
         # --lib skips compiling the native-only benchmark example
-        run: cd sia_storage && wasm-pack test --release --headless --chrome -- --lib
+        run: cd sia_storage && wasm-pack test --release --headless --${{ matrix.browser }} -- --lib
         env:
-          RUSTFLAGS: '--cfg=web_sys_unstable_apis'
-          WASM_BINDGEN_TEST_TIMEOUT: '300'
-
-  test-wasm-firefox:
-    runs-on: tenki-standard-medium-4c-8g
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - name: Setup Environment
-        run: |
-          rustup update stable
-          rustup target add wasm32-unknown-unknown
-      - name: Install wasm-pack
-        shell: bash
-        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | bash
-      - name: Install geckodriver
-        run: curl -sL https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz | tar xz -C /usr/local/bin
-      - name: Test (wasm - sia_storage - firefox)
-        # --lib skips compiling the native-only benchmark example
-        run: cd sia_storage && wasm-pack test --release --headless --firefox -- --lib
-        env:
-          RUSTFLAGS: '--cfg=web_sys_unstable_apis'
           WASM_BINDGEN_TEST_TIMEOUT: '300'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,18 +24,16 @@ jobs:
       - name: Rustfmt
         run: cargo +nightly fmt --all -- --check
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
       - name: Clippy (wasm)
-        run: cargo clippy --target wasm32-unknown-unknown --lib --package sia_core --package sia_storage --package sia_storage_wasm --no-default-features -- -D warnings
-      - name: Check all features
-        run: cargo check --all-features --workspace
+        run: cargo clippy --target wasm32-unknown-unknown --lib --tests --package sia_core --package sia_storage --package sia_storage_wasm --no-default-features -- -D warnings
       - name: Build docs
         run: cargo doc --all-features --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings"
 
   test:
-    name: Test (native)
+    name: Test native
     runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,7 @@ dependencies = [
  "chrono",
  "criterion",
  "ed25519-dalek",
+ "getrandom 0.4.2",
  "hex",
  "num-bigint",
  "num-rational",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,17 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,7 +81,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -103,7 +92,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -249,12 +238,6 @@ dependencies = [
  "bitcoin-internals",
  "hex-conservative",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -914,7 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1172,9 +1155,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1597,7 +1577,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1698,28 +1678,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-dependencies = [
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "lru-slab"
@@ -1772,7 +1734,7 @@ version = "3.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa73b028610e2b26e9e40bd2c8ff8a98e6d7ed5d67d89ebf4bfd2f992616b024"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "chrono",
  "ctor",
  "futures",
@@ -1849,7 +1811,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1929,31 +1891,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
  "winapi",
 ]
 
@@ -2261,28 +2198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "reed-solomon-erasure"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
-dependencies = [
- "libm",
- "lru",
- "parking_lot",
- "smallvec",
- "spin",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,11 +2322,11 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2493,12 +2408,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
@@ -2730,6 +2639,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sia_reed_solomon"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "967b01469aa6c06d6206051341e13559fff7888f5689ff4992f5110cdbda2009"
+dependencies = [
+ "cfg-if",
+ "rayon",
+ "thiserror",
+]
+
+[[package]]
 name = "sia_storage"
 version = "0.8.0"
 dependencies = [
@@ -2755,13 +2675,13 @@ dependencies = [
  "priority-queue",
  "rand 0.10.1",
  "rayon",
- "reed-solomon-erasure",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with",
  "sia_core",
  "sia_mux",
+ "sia_reed_solomon",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2875,14 +2795,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -2956,10 +2870,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3188,7 +3102,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -3667,7 +3581,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.12.0",
  "semver",
@@ -3733,7 +3647,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4036,7 +3950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap 2.12.0",
  "log",
  "serde",

--- a/sia_core/Cargo.toml
+++ b/sia_core/Cargo.toml
@@ -41,12 +41,6 @@ tokio = { version = "1.52.0", features = ["macros", "rt", "sync", "io-util"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["async_tokio"] }
-tokio = { version = "1.50.0", features = [
-    "macros",
-    "rt-multi-thread",
-    "sync",
-    "io-util",
-] }
 rand = "0.10.1"
 
 [[bench]]

--- a/sia_core/Cargo.toml
+++ b/sia_core/Cargo.toml
@@ -24,7 +24,6 @@ hex = "0.4.3"
 num-bigint = "0.4.6"
 num-rational = { version = "0.4.2", features = ["num-bigint"] }
 num-traits = "0.2.19"
-rayon = "1.12.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.10.9"

--- a/sia_core/Cargo.toml
+++ b/sia_core/Cargo.toml
@@ -45,6 +45,9 @@ rand = "0.10.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { version = "0.8", features = ["async_tokio"] }
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+getrandom = { version = "0.4", features = ["wasm_js"] }
+
 [[bench]]
 name = "merkle_root"
 harness = false

--- a/sia_core/Cargo.toml
+++ b/sia_core/Cargo.toml
@@ -40,8 +40,10 @@ tokio = { version = "1.52.0", features = ["macros", "rt", "sync", "io-util", "ti
 tokio = { version = "1.52.0", features = ["macros", "rt", "sync", "io-util"] }
 
 [dev-dependencies]
-criterion = { version = "0.8", features = ["async_tokio"] }
 rand = "0.10.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { version = "0.8", features = ["async_tokio"] }
 
 [[bench]]
 name = "merkle_root"

--- a/sia_core/src/types/common.rs
+++ b/sia_core/src/types/common.rs
@@ -50,10 +50,10 @@ impl BlockID {
         state.finalize().into()
     }
 
-    pub fn miner_output_id(&self, i: usize) -> SiacoinOutputID {
+    pub fn miner_output_id(&self, i: u64) -> SiacoinOutputID {
         let mut state = Params::new().hash_length(32).to_state();
         state.update(self.as_ref());
-        state.update(&(i as u64).to_le_bytes());
+        state.update(&i.to_le_bytes());
         state.finalize().into()
     }
 }
@@ -66,31 +66,31 @@ impl TransactionID {
     const V2_FILE_CONTRACT_PREFIX: &[u8] = b"sia/id/filecontract|";
     const V2_ATTESTATION_PREFIX: &[u8] = b"sia/id/attestation|";
 
-    fn derive_v2_child_id<T: From<blake2b_simd::Hash>>(&self, prefix: &[u8], i: usize) -> T {
+    fn derive_v2_child_id<T: From<blake2b_simd::Hash>>(&self, prefix: &[u8], i: u64) -> T {
         let mut state = Params::new().hash_length(32).to_state();
         state.update(prefix.as_ref());
         state.update(self.as_ref());
-        state.update(&(i as u64).to_le_bytes());
+        state.update(&i.to_le_bytes());
         state.finalize().into()
     }
 
     /// v2_siacoin_output_id returns the SiacoinOutputID for the i-th siacoin output of the V2 transaction
-    pub fn v2_siacoin_output_id(&self, i: usize) -> SiacoinOutputID {
+    pub fn v2_siacoin_output_id(&self, i: u64) -> SiacoinOutputID {
         self.derive_v2_child_id(Self::V2_SIACOIN_OUTPUT_PREFIX, i)
     }
 
     /// v2_siafund_output_id returns the SiafundOutputID for the i-th siafund output of the V2 transaction
-    pub fn v2_siafund_output_id(&self, i: usize) -> SiafundOutputID {
+    pub fn v2_siafund_output_id(&self, i: u64) -> SiafundOutputID {
         self.derive_v2_child_id(Self::V2_SIAFUND_OUTPUT_PREFIX, i)
     }
 
     /// v2_file_contract_id returns the FileContractID for the i-th file contract of the V2 transaction
-    pub fn v2_file_contract_id(&self, i: usize) -> FileContractID {
+    pub fn v2_file_contract_id(&self, i: u64) -> FileContractID {
         self.derive_v2_child_id(Self::V2_FILE_CONTRACT_PREFIX, i)
     }
 
     /// v2_attestation_id returns the AttestationID for the i-th attestation of the V2 transaction
-    pub fn v2_attestation_id(&self, i: usize) -> AttestationID {
+    pub fn v2_attestation_id(&self, i: u64) -> AttestationID {
         self.derive_v2_child_id(Self::V2_ATTESTATION_PREFIX, i)
     }
 }
@@ -102,30 +102,30 @@ impl FileContractID {
     const V2_PROOF_OUTPUT_ID_PREFIX: &[u8] = b"sia/id/v2filecontractoutput|";
     const V2_FILE_CONTRACT_RENEWAL_PREFIX: &[u8] = b"sia/id/v2filecontractrenewal|";
 
-    fn derive_proof_output_id<T: From<blake2b_simd::Hash>>(&self, valid: bool, i: usize) -> T {
+    fn derive_proof_output_id<T: From<blake2b_simd::Hash>>(&self, valid: bool, i: u64) -> T {
         let mut state = Params::new().hash_length(32).to_state();
         state.update(Self::PROOF_OUTPUT_ID_PREFIX.as_ref());
         state.update(self.as_ref());
         state.update(&(valid as u8).to_le_bytes());
-        state.update(&(i as u64).to_le_bytes());
+        state.update(&i.to_le_bytes());
         state.finalize().into()
     }
 
-    fn derive_v2_proof_output_id<T: From<blake2b_simd::Hash>>(&self, i: usize) -> T {
+    fn derive_v2_proof_output_id<T: From<blake2b_simd::Hash>>(&self, i: u64) -> T {
         let mut state = Params::new().hash_length(32).to_state();
         state.update(Self::V2_PROOF_OUTPUT_ID_PREFIX);
         state.update(self.as_ref());
-        state.update(&(i as u64).to_le_bytes());
+        state.update(&i.to_le_bytes());
         state.finalize().into()
     }
 
     /// valid_output_id returns the SiacoinOutputID for the i-th valid output of the contract
-    pub fn valid_output_id(&self, i: usize) -> SiacoinOutputID {
+    pub fn valid_output_id(&self, i: u64) -> SiacoinOutputID {
         self.derive_proof_output_id(true, i)
     }
 
     /// missed_output_id returns the SiacoinOutputID for the i-th missed output of the contract
-    pub fn missed_output_id(&self, i: usize) -> SiacoinOutputID {
+    pub fn missed_output_id(&self, i: u64) -> SiacoinOutputID {
         self.derive_proof_output_id(false, i)
     }
 

--- a/sia_core/src/types/spendpolicy.rs
+++ b/sia_core/src/types/spendpolicy.rs
@@ -591,7 +591,7 @@ mod tests {
 
     #[test]
     fn test_policy_encoding() {
-        let test_cases = vec![
+        let test_cases = [
             (
                 SpendPolicy::above(100),
                 "{\"type\":\"above\",\"policy\":100}",

--- a/sia_core/src/types/v1.rs
+++ b/sia_core/src/types/v1.rs
@@ -1068,8 +1068,7 @@ mod tests {
             key_index: u64,
             expected: &'static str,
         }
-        let test_cases = vec![
-            TestCase{
+        let test_cases = [TestCase{
                 transaction: Transaction {
                     siacoin_inputs: vec![
                         SiacoinInput{
@@ -1110,8 +1109,7 @@ mod tests {
                 timelock: 467251739279473577,
                 key_index: 1493934879227647507,
                 expected: "7aea4ec52e1f7de90261c4448a928081d4be6015252e482ec9c1cfa01663d768",
-            },
-        ];
+            }];
 
         for (i, case) in test_cases.iter().enumerate() {
             let sig_hash = case
@@ -1182,7 +1180,7 @@ mod tests {
         };
         let txn: Transaction = serde_json::from_str("{\"siacoinInputs\":[{\"parentID\":\"750d22eff727689d1d8d1c83e513a30bb68ee7f9125a4dafc882459e34c2069d\",\"unlockConditions\":{\"timelock\":0,\"publicKeys\":[\"ed25519:800ed6c2760e3e4ba1ff00128585c8cf8fed2e3dc1e3da1eb92d49f405bd6360\"],\"signaturesRequired\":6312611591377486220}}],\"siacoinOutputs\":[{\"value\":\"890415399000000000000000000000000\",\"address\":\"480a064b5fca13002a7fe575845154bbf0b3af4cc4f147cbed387d43cce3568ae2497366eaa7\"}],\"fileContracts\":[{\"filesize\":0,\"fileMerkleRoot\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"windowStart\":10536451586783908586,\"windowEnd\":9324702155635244357,\"payout\":\"0\",\"validProofOutputs\":[{\"value\":\"1933513214000000000000000000000000\",\"address\":\"944524fff2c49c401e748db37cfda7569fa6df35b704fe716394f2ac3f40ce87b4506e9906f0\"}],\"missedProofOutputs\":[{\"value\":\"2469287901000000000000000000000000\",\"address\":\"1df67838262d7109ffcd9018f183b1eb33f05659a274b89ea6b52ff3617d34a770e9dd071d2e\"}],\"unlockHash\":\"000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69\",\"revisionNumber\":9657412421282982780}],\"fileContractRevisions\":[{\"parentID\":\"e4e26d93771d3bbb3d9dd306105d77cfb3a6254d1cc3495903af6e013442c63c\",\"unlockConditions\":{\"timelock\":0,\"publicKeys\":[\"ed25519:e6b9cde4eb058f8ecbb083d99779cb0f6d518d5386f019af6ead09fa52de8567\"],\"signaturesRequired\":206644730660526450},\"revisionNumber\":10595710523108536025,\"filesize\":0,\"fileMerkleRoot\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"windowStart\":4348934140507359445,\"windowEnd\":14012366839994454386,\"validProofOutputs\":[{\"value\":\"2435858510000000000000000000000000\",\"address\":\"543bc0eda69f728d0a0fbce08e5bfc5ed7b961300e0af226949e135f7d12e32f0544e5262d6f\"}],\"missedProofOutputs\":[{\"value\":\"880343701000000000000000000000000\",\"address\":\"7b7f9aee981fe0d93bb3f49c6233cf847ebdd39d7dc5253f7fc330df2167073b35f035703237\"}],\"unlockHash\":\"000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69\"}],\"storageProofs\":[{\"parentID\":\"c0b9e98c9e03a2740c75d673871c1ee91f36d1bb329ff3ddbf1dfa8c6e1a64eb\",\"leaf\":\"b78fa521dc62d9ced82bc3b61e0aa5a5c221d6cca5db63d94c9879543fb98c0a971094a89cd4408487ae32902248d321b545f9a051729aa0bb1725b848e3d453\",\"proof\":[\"fe08c0a061475e7e5dec19e717cf98792fa7b555d0b5d3540a05db09f59ab8de\"]}],\"minerFees\":[\"241119475000000000000000000000000\"],\"arbitraryData\":[\"2shzIHEUJYwuNHz6c/gPz+aTEWZRTpDTmemX9yYAKlY=\"],\"signatures\":[{\"parentID\":\"06d1fca03c5ddd9b09116db1b97c5451f7dc792b05362969f83e3e8dc1007f46\",\"publicKeyIndex\":6088345341283457116,\"timelock\":2014247885072555224,\"coveredFields\":{\"wholeTransaction\":true},\"signature\":\"2XNEKGZrl9RhMa2JmGsvcmqQWAIX/uxtMwLnPI6VJPcXqub6qYIuoAThYp9NAwadk+1GG6CXC66g4rOjFYuNSA==\"}]}").expect("valid transaction");
 
-        let test_cases = vec![
+        let test_cases = [
             (
                 CoveredFields {
                     whole_transaction: false,

--- a/sia_core/src/types/v1.rs
+++ b/sia_core/src/types/v1.rs
@@ -473,30 +473,30 @@ impl Transaction {
         state.finalize().into()
     }
 
-    fn derive_child_id<T: From<blake2b_simd::Hash>>(&self, prefix: &Specifier, i: usize) -> T {
+    fn derive_child_id<T: From<blake2b_simd::Hash>>(&self, prefix: &Specifier, i: u64) -> T {
         let mut state = Params::new().hash_length(32).to_state();
         state.update(prefix.as_ref());
         self.encode_no_sigs(&mut state).unwrap();
-        state.update(&(i as u64).to_le_bytes());
+        state.update(&i.to_le_bytes());
         state.finalize().into()
     }
 
     /// siacoin_output_id returns the SiacoinOutputID for the i-th siacoin output of the transaction
-    pub fn siacoin_output_id(&self, i: usize) -> SiacoinOutputID {
+    pub fn siacoin_output_id(&self, i: u64) -> SiacoinOutputID {
         const SIACOIN_OUTPUT_ID_PREFIX: Specifier = specifier!("siacoin output");
 
         self.derive_child_id(&SIACOIN_OUTPUT_ID_PREFIX, i)
     }
 
     /// siafund_output_id returns the SiafundOutputID for the i-th siafund output of the transaction
-    pub fn siafund_output_id(&self, i: usize) -> SiafundOutputID {
+    pub fn siafund_output_id(&self, i: u64) -> SiafundOutputID {
         const SIAFUND_OUTPUT_ID_PREFIX: Specifier = specifier!("siafund output");
 
         self.derive_child_id(&SIAFUND_OUTPUT_ID_PREFIX, i)
     }
 
     /// file_contract_id returns the FileContractID for the i-th file contract of the transaction
-    pub fn file_contract_id(&self, i: usize) -> FileContractID {
+    pub fn file_contract_id(&self, i: u64) -> FileContractID {
         const FILE_CONTRACT_ID_PREFIX: Specifier = specifier!("file contract");
 
         self.derive_child_id(&FILE_CONTRACT_ID_PREFIX, i)

--- a/sia_mux/tests/interop.rs
+++ b/sia_mux/tests/interop.rs
@@ -156,27 +156,22 @@ async fn rust_server_go_client_basic_echo() {
         let mux = sia_mux::accept_anonymous(conn).await.unwrap();
 
         // Accept and echo streams until the mux closes
-        loop {
-            match mux.accept_stream().await {
-                Ok(mut stream) => {
-                    tokio::spawn(async move {
-                        let mut buf = vec![0u8; 65536];
-                        loop {
-                            match stream.read(&mut buf).await {
-                                Ok(0) => break,
-                                Ok(n) => {
-                                    if stream.write_all(&buf[..n]).await.is_err() {
-                                        break;
-                                    }
-                                }
-                                Err(_) => break,
+        while let Ok(mut stream) = mux.accept_stream().await {
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 65536];
+                loop {
+                    match stream.read(&mut buf).await {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            if stream.write_all(&buf[..n]).await.is_err() {
+                                break;
                             }
                         }
-                        let _ = stream.close();
-                    });
+                        Err(_) => break,
+                    }
                 }
-                Err(_) => break,
-            }
+                let _ = stream.close();
+            });
         }
         let _ = mux.close().await;
     });
@@ -222,27 +217,22 @@ async fn rust_server_go_client_many_streams() {
         let (conn, _) = listener.accept().await.unwrap();
         let mux = sia_mux::accept_anonymous(conn).await.unwrap();
 
-        loop {
-            match mux.accept_stream().await {
-                Ok(mut stream) => {
-                    tokio::spawn(async move {
-                        let mut buf = vec![0u8; 65536];
-                        loop {
-                            match stream.read(&mut buf).await {
-                                Ok(0) => break,
-                                Ok(n) => {
-                                    if stream.write_all(&buf[..n]).await.is_err() {
-                                        break;
-                                    }
-                                }
-                                Err(_) => break,
+        while let Ok(mut stream) = mux.accept_stream().await {
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 65536];
+                loop {
+                    match stream.read(&mut buf).await {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            if stream.write_all(&buf[..n]).await.is_err() {
+                                break;
                             }
                         }
-                        let _ = stream.close();
-                    });
+                        Err(_) => break,
+                    }
                 }
-                Err(_) => break,
-            }
+                let _ = stream.close();
+            });
         }
         let _ = mux.close().await;
     });

--- a/sia_storage/Cargo.toml
+++ b/sia_storage/Cargo.toml
@@ -31,7 +31,6 @@ chacha20poly1305 = "0.10.1"
 chacha20 = { version = "0.10.0", features = ["xchacha"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 blake2 = "0.10.6"
-reed-solomon-erasure = "6.0.0"
 zeroize = { version = "1.8.0", features = ["derive"] }
 hkdf = "0.12.4"
 base64 = "0.22.1"
@@ -39,6 +38,7 @@ ed25519-dalek = "2.2.0"
 web-time = "1"
 getrandom = "0.4"
 tokio-util = { version = "0.7.18", features = ["rt"] }
+sia_reed_solomon = "0.3.0"
 
 # --- Native-only dependencies ---
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/sia_storage/README.md
+++ b/sia_storage/README.md
@@ -65,6 +65,17 @@ tokio::io::copy(&mut reader, &mut writer).await?;
 
 The `AppKey` grants full access to a user's data. After connecting, retrieve it with `SDK::app_key()`, then persist it using `AppKey::export()` and restore it with `AppKey::import()` so users don't need to re-approve on every launch.
 
+## Building for WebAssembly
+
+For best performance in the browser, enable the `simd128` target feature:
+
+```bash
+RUSTFLAGS="-C target-feature=+simd128" \
+  cargo build --target wasm32-unknown-unknown --release
+```
+
+The same `RUSTFLAGS` applies to `wasm-pack build`. SIMD-enabled WASM is supported by all modern browsers; no special hosting headers are required.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/sia_storage/benches/upload.rs
+++ b/sia_storage/benches/upload.rs
@@ -177,7 +177,7 @@ fn upload_benchmark(c: &mut Criterion) {
                         .download(&object, DownloadOptions::default())
                         .unwrap();
                     let mut buf = [0u8; 1];
-                    reader.read(&mut buf).await.expect("read to succeed");
+                    reader.read_exact(&mut buf).await.expect("read to succeed");
                     total += start.elapsed();
                 }
                 total
@@ -203,7 +203,7 @@ fn upload_benchmark(c: &mut Criterion) {
                         )
                         .unwrap();
                     let mut buf = [0u8; 1];
-                    reader.read(&mut buf).await.expect("read to succeed");
+                    reader.read_exact(&mut buf).await.expect("read to succeed");
                     total += start.elapsed();
                 }
                 total

--- a/sia_storage/examples/benchmark.rs
+++ b/sia_storage/examples/benchmark.rs
@@ -69,7 +69,7 @@ impl SeededVerifier {
         let now = Instant::now();
         Self {
             rng: SmallRng::seed_from_u64(seed),
-            size: size,
+            size,
             remaining: size,
             start: now,
             ttfb: None,

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -10,7 +10,7 @@ use crate::hosts::{Hosts, RPCError};
 use crate::rhp4::{Client, Transport};
 use crate::time::{Duration, Elapsed, Instant, sleep};
 use crate::{AppKey, DownloadOptions, Object, Sector, ShardProgress, ShardProgressCallback, Slab};
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Buf, Bytes};
 use chacha20::cipher::StreamCipher;
 use sia_core::rhp4::SEGMENT_SIZE;
 use thiserror::Error;
@@ -77,7 +77,7 @@ struct AwaitingRecovery {
 
 struct ShardsRecovered {
     shard_offset: usize,
-    shards: Vec<Option<BytesMut>>,
+    shards: Vec<Option<Vec<u8>>>,
 }
 
 struct SlabDecoded {
@@ -150,7 +150,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         slab_index: usize,
         sector_offset: usize,
         sector_length: usize,
-    ) -> Result<(usize, BytesMut, ShardProgress), DownloadError> {
+    ) -> Result<(usize, Vec<u8>, ShardProgress), DownloadError> {
         let start = Instant::now();
         let data = client
             .read_sector(
@@ -164,9 +164,11 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             )
             .await?;
         let elapsed = start.elapsed();
+        // Bytes -> Vec<u8> is zero-copy when the Bytes is uniquely owned
+        // (true here — no other refs to the response yet).
         Ok((
             task.shard_index,
-            data.try_into_mut().unwrap(),
+            Vec::from(data),
             ShardProgress {
                 host_key: task.sector.host_key,
                 shard_size: sector_length,
@@ -274,7 +276,7 @@ impl<T: Transport> SlabRecovery<ShardsRecovered, T> {
         let data_shards = shards
             .into_iter()
             .take(self.min_shards as usize)
-            .map(|s| s.unwrap().freeze()) // safe because the data shards were just reconstructed
+            .map(|s| Bytes::from(s.unwrap())) // safe: data shards were just reconstructed
             .collect();
         Ok(SlabRecovery {
             client: self.client,

--- a/sia_storage/src/erasure_coding.rs
+++ b/sia_storage/src/erasure_coding.rs
@@ -1,15 +1,15 @@
 use std::mem;
 
-use bytes::{Bytes, BytesMut};
-use reed_solomon_erasure::galois_8::ReedSolomon;
+use bytes::Bytes;
 use sia_core::rhp4::{SECTOR_SIZE, SEGMENT_SIZE};
+use sia_reed_solomon::ReedSolomon;
 use thiserror::Error;
 use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("ReedSolomon error: {0}")]
-    ReedSolomon(#[from] reed_solomon_erasure::Error),
+    ReedSolomon(#[from] sia_reed_solomon::Error),
 
     #[error("IO error: {0}")]
     Io(#[from] io::Error),
@@ -29,18 +29,18 @@ impl ErasureCoder {
     }
 
     pub fn data_shards(&self) -> usize {
-        self.encoder.data_shard_count()
+        self.encoder.data_shards()
     }
 
     /// encodes the shards using reed solomon erasure coding,
     /// computing the parity shards and overwriting their values.
-    pub fn encode_shards(&self, shards: &mut [BytesMut]) -> Result<()> {
+    pub fn encode_shards(&self, shards: &mut [Vec<u8>]) -> Result<()> {
         self.encoder.encode(shards)?;
         Ok(())
     }
 
     /// reconstructs the missing datashards from the available ones.
-    pub fn reconstruct_data_shards(&self, shards: &mut [Option<BytesMut>]) -> Result<()> {
+    pub fn reconstruct_data_shards(&self, shards: &mut [Option<Vec<u8>>]) -> Result<()> {
         self.encoder.reconstruct_data(shards)?;
         Ok(())
     }
@@ -85,14 +85,14 @@ impl ErasureCoder {
 /// partial slab.
 pub(crate) struct SlabReader {
     data_shards: usize,
-    shards: Vec<BytesMut>,
+    shards: Vec<Vec<u8>>,
     length: usize,
     total_length: u64,
 }
 
 pub(crate) struct ReadSlab {
     pub length: usize,
-    pub shards: Vec<BytesMut>,
+    pub shards: Vec<Vec<u8>>,
 }
 
 impl SlabReader {
@@ -100,7 +100,7 @@ impl SlabReader {
         let total_shards = data_shards + parity_shards;
         Self {
             data_shards,
-            shards: vec![BytesMut::zeroed(SECTOR_SIZE); total_shards],
+            shards: vec![vec![0u8; SECTOR_SIZE]; total_shards],
             length: 0,
             total_length: 0,
         }
@@ -173,10 +173,7 @@ impl SlabReader {
         let slab = if self.length == self.optimal_data_size() {
             let length = mem::take(&mut self.length);
             let total_shards = self.shards.len();
-            let shards = mem::replace(
-                &mut self.shards,
-                vec![BytesMut::zeroed(SECTOR_SIZE); total_shards],
-            );
+            let shards = mem::replace(&mut self.shards, vec![vec![0u8; SECTOR_SIZE]; total_shards]);
             Some(ReadSlab { length, shards })
         } else {
             None
@@ -191,10 +188,8 @@ mod tests {
 
     use super::*;
 
-    fn init_shard(i: u8) -> BytesMut {
-        let mut buf = BytesMut::with_capacity(SECTOR_SIZE);
-        buf.resize(SECTOR_SIZE, i);
-        buf
+    fn init_shard(i: u8) -> Vec<u8> {
+        vec![i; SECTOR_SIZE]
     }
 
     cross_target_tests! {
@@ -203,7 +198,7 @@ mod tests {
         let parity_shards = 3;
         let coder = ErasureCoder::new(data_shards, parity_shards).unwrap();
 
-        let mut shards: Vec<BytesMut> = [
+        let mut shards: Vec<Vec<u8>> = [
             init_shard(1),
             init_shard(2),
             init_shard(0),
@@ -214,7 +209,7 @@ mod tests {
 
         coder.encode_shards(&mut shards).unwrap();
 
-        let expected_shards: Vec<BytesMut> = vec![
+        let expected_shards: Vec<Vec<u8>> = vec![
             init_shard(1),
             init_shard(2),
             init_shard(7),  // parity shard 1
@@ -225,10 +220,10 @@ mod tests {
 
         // reconstruct data shards
         for i in 0..data_shards {
-            let mut shards: Vec<Option<BytesMut>> = shards.iter().cloned().map(Some).collect();
+            let mut shards: Vec<Option<Vec<u8>>> = shards.iter().cloned().map(Some).collect();
             shards[i] = None;
             coder.reconstruct_data_shards(&mut shards).unwrap();
-            let shards: Vec<BytesMut> = shards.into_iter().map(|s| s.unwrap()).collect();
+            let shards: Vec<Vec<u8>> = shards.into_iter().map(|s| s.unwrap()).collect();
             assert_eq!(shards, expected_shards);
         }
     }
@@ -292,12 +287,12 @@ mod tests {
         const PARITY_SHARDS: usize = 1;
         let coder = ErasureCoder::new(DATA_SHARDS, PARITY_SHARDS).unwrap();
 
-        let mut data = BytesMut::zeroed(SECTOR_SIZE * 7 / 2); // 3.5 shards of data
+        let mut data = vec![0u8; SECTOR_SIZE * 7 / 2]; // 3.5 shards of data
         data[..SECTOR_SIZE].fill(1);
         data[SECTOR_SIZE..2 * SECTOR_SIZE].fill(2);
         data[2 * SECTOR_SIZE..3 * SECTOR_SIZE].fill(3);
         data[3 * SECTOR_SIZE..].fill(4);
-        let data = data.freeze();
+        let data = Bytes::from(data);
 
         let mut reader = SlabReader::new(DATA_SHARDS, PARITY_SHARDS);
         let (n, slab) = reader
@@ -314,7 +309,7 @@ mod tests {
         // we expect 5 shards and the last one is an empty parity shard
         assert_eq!(shards.len(), 5);
         assert_eq!(size as usize, SECTOR_SIZE * 7 / 2);
-        assert_eq!(shards[4], BytesMut::zeroed(SECTOR_SIZE)); // parity shard should be empty
+        assert_eq!(shards[4], vec![0u8; SECTOR_SIZE]); // parity shard should be empty
 
         for shard in &shards[..4] {
             // every shard should be of SECTOR_SIZE
@@ -348,10 +343,10 @@ mod tests {
         // encoding the read shards should succeed without errors and cause the
         // parity shard to be filled
         coder.encode_shards(&mut shards).unwrap();
-        assert_ne!(shards[4], BytesMut::zeroed(SECTOR_SIZE));
+        assert_ne!(shards[4], vec![0u8; SECTOR_SIZE]);
 
         // joining the shards back together should result in the original data
-        let shards: Vec<Bytes> = shards.iter().cloned().map(|s| s.freeze()).collect();
+        let shards: Vec<Bytes> = shards.into_iter().map(Bytes::from).collect();
         let mut joined_data = Vec::new();
         ErasureCoder::write_data_shards(&mut joined_data, &shards[..DATA_SHARDS], 0, data.len())
             .await
@@ -381,6 +376,101 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(joined_data, data[data.len() / 2..]);
+    }
+
+    async fn test_erasure_code_golden() {
+        use sia_core::blake2::{Blake2b256, Digest};
+        use sia_core::hash_256;
+        use sia_core::types::Hash256;
+
+        // Golden hashes generated by a 10-of-30 RS slab with klauspost/reedsolomon in Go.
+        // The data shards are generated using a simple xorshift64 PRNG since Go and Rust
+        // do not share a PRNG that would guarantee parity.
+        const EXPECTED_SHARD_HASHES: [Hash256; 30] = [
+            // data shards
+            hash_256!("5f9133b3f31ca9e40e029fd0b0fc31127803ba39bbc6393da17f201c2b320bc0"),
+            hash_256!("873f9a6c0bfb4063b3125f034b0adbafec4c6a3cf4855381640612d3bdb52c52"),
+            hash_256!("addeec9b79e16ef8b73faa44acdd8bce937baf4261e0a2960fad431378163c9a"),
+            hash_256!("99c7af0efa1aee38039171a95550735f7ba85f2cc53b5d211177a4714261067f"),
+            hash_256!("7c6619b96e1518270e8a6098558d92c6f599500a4c4a07c2b1c378f1c28f81d2"),
+            hash_256!("e4a27ad70588b5fe9b1eab2c3e90b2400f9b835870314d5462af677fa0194b65"),
+            hash_256!("28fde42094bb60c92aef3f4c1b76ef3b41407b4f32980d1487bacd3439fc1c38"),
+            hash_256!("49a89238c935b6dbfae3081785ce008b1e6c5b17e64e87e6a977146956708e95"),
+            hash_256!("fe4604077368a0da69257ad0f6d4a81c1d2ecb95100b320f837c190aee42197a"),
+            hash_256!("80bed93006c4e0a4f2aca7ee2da737271d6df50b117c1ba4012ad06381b45a84"),
+            // parity shards
+            hash_256!("d0820641e4a40d01aa61812561717a45681e0d9d990daff41971e0e4bbb9596f"),
+            hash_256!("c93ede3459a43f28a73d6b54618891d218fe2a6fff72e8a2e11ddcc8f3c03ce3"),
+            hash_256!("240cb1f10fb2539f287af32dab1271b37896dd72ce63e9df4dc528abe65a260c"),
+            hash_256!("85315fa52dcc04496815bc6d988a0b2caa7a872957739fd2e1aac5189e756fcf"),
+            hash_256!("7c5c6545793751788dd8e401d46b0567cb34bc2ee31097e1ec2108c6e01511a6"),
+            hash_256!("24bfd4acab06d4976f08219b6fb5dc872b1382f39961f23b5d09065d137f423f"),
+            hash_256!("fd3140df262ab81f99f1f5a4ee83a2d06f2f361b538a4949b651ad2bc24e7be5"),
+            hash_256!("46cab3709634583d2fe357d62f8a30c4797ea26696ecfb7957b3bb5168787cfc"),
+            hash_256!("babf9e26da954f409e2fb8834fddf2c075daa8789c62c03a2cc649296b3ad0ee"),
+            hash_256!("08cd570feba44f78705f0b3fd5fc973bcd62beb16567c700a3671a316af6a71b"),
+            hash_256!("a56df2e4f7be6626861da81b83e812315870ff89d0854cf290a2e42ccb64358f"),
+            hash_256!("5264c29cfd9fe9c63cdefed4ca20c790ed30c9ff2bfd9c167bf5205d797f9f00"),
+            hash_256!("9f1c15a3a5514581eb0e20b3811b92fcf4f59cdbd986ea2677d40f65e728aa33"),
+            hash_256!("aaaa12e1c177e5e52012068462b83e9a0ce2c6d74d089cbdf4b370186ac386ad"),
+            hash_256!("99f837946ab86c68b451693685041b88aa66ff1330ff2d0c54c87e87cec5640b"),
+            hash_256!("7fc2ffab8e8c85898b2d6a225b85771cd8ceeea61306710f14f07c94076e267c"),
+            hash_256!("9ff3bfbd1f282f9ef3705715321a687cfe7f1f8d623ef153e1ebbdb9ad4493db"),
+            hash_256!("a922d41284f8c6c8c0d764fcd0df2f5313e84abd594787e94a097ceded6dd912"),
+            hash_256!("4b8f9c5558cd26029a120b30b8429a28f17869c283402c0dd8e8c390fb7639c7"),
+            hash_256!("1bdc7fdb4c601c503bf12a833a12a0a41ed717db7ee1c99ce3176ba8afeb2684"),
+        ];
+        const DATA_SHARDS: usize = 10;
+        const PARITY_SHARDS: usize = 20;
+
+        fn fill_shard(buf: &mut [u8], seed: u64) {
+            let mut state = seed;
+            for chunk in buf.chunks_exact_mut(8) {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                chunk.copy_from_slice(&state.to_le_bytes());
+            }
+        }
+
+        let mut shards: Vec<Vec<u8>> = (0..DATA_SHARDS + PARITY_SHARDS)
+            .map(|_| vec![0u8; SECTOR_SIZE])
+            .collect();
+        for (i, shard) in shards[..DATA_SHARDS].iter_mut().enumerate() {
+            fill_shard(shard, i as u64 + 1);
+        }
+
+        let coder = ErasureCoder::new(DATA_SHARDS, PARITY_SHARDS).unwrap();
+        coder.encode_shards(&mut shards).unwrap();
+
+        for (i, shard) in shards.iter().enumerate() {
+            let got: Hash256 = Blake2b256::new().chain_update(shard).finalize().into();
+            assert_eq!(got, EXPECTED_SHARD_HASHES[i], "shard {i} hash mismatch");
+        }
+
+        let check_reconstruct = |dropped: &[usize], label: &str| {
+            let mut opt: Vec<Option<Vec<u8>>> = shards.iter().cloned().map(Some).collect();
+            for &i in dropped {
+                opt[i] = None;
+            }
+            coder.reconstruct_data_shards(&mut opt).unwrap();
+            for i in 0..DATA_SHARDS {
+                let shard = opt[i].as_ref().expect("data shard reconstructed");
+                let got: Hash256 = Blake2b256::new().chain_update(shard).finalize().into();
+                assert_eq!(got, EXPECTED_SHARD_HASHES[i], "{label}: shard {i} mismatch");
+            }
+        };
+
+        // each data shard dropped individually
+        for drop in 0..DATA_SHARDS {
+            check_reconstruct(&[drop], &format!("drop_{drop}"));
+        }
+        // every data shard missing, rebuild from parity alone
+        let all_data: Vec<usize> = (0..DATA_SHARDS).collect();
+        check_reconstruct(&all_data, "all_data");
+        // minimum remaining: drop 20 shards (all data + half of parity), leaving DATA_SHARDS parity shards
+        let min_remaining: Vec<usize> = (0..PARITY_SHARDS).collect();
+        check_reconstruct(&min_remaining, "min_remaining");
     }
     }
 }

--- a/sia_storage/src/erasure_coding.rs
+++ b/sia_storage/src/erasure_coding.rs
@@ -308,7 +308,7 @@ mod tests {
 
         // we expect 5 shards and the last one is an empty parity shard
         assert_eq!(shards.len(), 5);
-        assert_eq!(size as usize, SECTOR_SIZE * 7 / 2);
+        assert_eq!(size, SECTOR_SIZE * 7 / 2);
         assert_eq!(shards[4], vec![0u8; SECTOR_SIZE]); // parity shard should be empty
 
         for shard in &shards[..4] {

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -1324,15 +1324,17 @@ mod test {
                 .unwrap();
             assert_eq!(obj.slabs().len(), num_slabs);
 
-            let upload_progress = upload_progress.lock().unwrap();
-            // verify upload callbacks: exactly one per (slab_index, shard_index)
-            assert_eq!(upload_progress.len(), total_shards * num_slabs,
-                "upload: expected {} callbacks, got {}",
-                total_shards * num_slabs, upload_progress.len());
-            for i in 0..num_slabs {
-                for j in 0..total_shards {
-                    assert!(upload_progress.contains_key(&(i, j)),
-                        "missing upload callback for slab {}, shard {}", i, j);
+            {
+                let upload_progress = upload_progress.lock().unwrap();
+                // verify upload callbacks: exactly one per (slab_index, shard_index)
+                assert_eq!(upload_progress.len(), total_shards * num_slabs,
+                    "upload: expected {} callbacks, got {}",
+                    total_shards * num_slabs, upload_progress.len());
+                for i in 0..num_slabs {
+                    for j in 0..total_shards {
+                        assert!(upload_progress.contains_key(&(i, j)),
+                            "missing upload callback for slab {}, shard {}", i, j);
+                    }
                 }
             }
 

--- a/sia_storage/src/sdk.rs
+++ b/sia_storage/src/sdk.rs
@@ -370,6 +370,7 @@ impl Sdk {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod test {
     use super::*;
@@ -380,7 +381,6 @@ mod test {
         seed
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn test_refresh_task_periodic_and_abort() {
         use std::sync::Arc;

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -286,7 +286,7 @@ impl Upload {
                         client: shard_client,
                         hosts: shard_hosts,
                         account_key: shard_account_key,
-                        data: shard.freeze(),
+                        data: Bytes::from(shard),
                         slab_index,
                         shard_index,
                     };


### PR DESCRIPTION
Replaced `reed-solomon-erasure` with [`sia_reed_solomon`](https://github.com/SiaFoundation/reed_solomon_rs). Encoded parity bytes are compatible with existing `indexd` slabs.

120 MiB upload against the mock hosts
(`cargo bench -p sia_storage --features mock`):

| | Before | After | Δ |
|---|---|---|---|
| `upload/90 inflight` | ~285 MiB/s | **469 MiB/s** | **+67%** |
| `upload/10 inflight` | ~175 MiB/s | **457 MiB/s** | **+161%** |
| `upload/default`     | ~184 MiB/s | **471 MiB/s** | **+155%** |

*note: thorough testing on real data is needed before merge*