### PR TITLE
Take into account inflight uploads/downloads in host queue

### DIFF
--- a/.changeset/take_into_account_inflight_uploads_and_downloads_when_ranking_hosts.md
+++ b/.changeset/take_into_account_inflight_uploads_and_downloads_when_ranking_hosts.md
@@ -1,0 +1,5 @@
+---
+sia_storage: minor
+---
+
+# Take into account inflight uploads and downloads when ranking hosts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,17 +2010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "priority-queue"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
-dependencies = [
- "equivalent",
- "indexmap 2.12.0",
- "serde",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,7 +2635,6 @@ dependencies = [
  "instant",
  "js-sys",
  "log",
- "priority-queue",
  "rand 0.10.1",
  "rayon",
  "reqwest",

--- a/sia_storage/Cargo.toml
+++ b/sia_storage/Cargo.toml
@@ -24,7 +24,6 @@ blake2b_simd = "1.0.4"
 url = { version = "2.5.8", features = ["serde"] }
 log = "0.4.30"
 bytes = "1.11.1"
-priority-queue = "2.7.0"
 serde_with = { version = "3.20.0", features = ["base64"] }
 hex = "0.4.3"
 chacha20poly1305 = "0.10.1"

--- a/sia_storage/examples/benchmark.rs
+++ b/sia_storage/examples/benchmark.rs
@@ -206,6 +206,17 @@ async fn main() {
 
     let reader = SeededReader::new(seed, args.size);
 
+    // delete all existing objects
+    println!("Deleting existing objects...");
+    let objects = sdk
+        .object_events(None, Some(100))
+        .await
+        .expect("failed to list objects");
+    for obj in objects {
+        sdk.delete_object(&obj.id).await;
+    }
+    sdk.prune_slabs().await.expect("pruning failed");
+
     // upload the data to the network
     println!("Uploading random data...");
     let start = Instant::now();

--- a/sia_storage/examples/benchmark.rs
+++ b/sia_storage/examples/benchmark.rs
@@ -214,17 +214,6 @@ async fn main() {
 
     let reader = SeededReader::new(seed, args.size);
 
-    // delete all existing objects
-    println!("Deleting existing objects...");
-    let objects = sdk
-        .object_events(None, Some(100))
-        .await
-        .expect("failed to list objects");
-    for obj in objects {
-        sdk.delete_object(&obj.id).await;
-    }
-    sdk.prune_slabs().await.expect("pruning failed");
-
     // upload the data to the network
     println!("Uploading random data...");
     let mut upload_options = UploadOptions::default();

--- a/sia_storage/examples/benchmark.rs
+++ b/sia_storage/examples/benchmark.rs
@@ -14,6 +14,14 @@ struct Args {
     /// Size of the data to upload and download in bytes (default: 120 MiB)
     #[arg(short, long, default_value_t = 120 * 1024 * 1024)]
     size: usize,
+
+    /// Maximum number of concurrent shard uploads.
+    #[arg(long)]
+    upload_max_inflight: Option<usize>,
+
+    /// Maximum number of concurrent chunk downloads.
+    #[arg(long)]
+    download_max_inflight: Option<usize>,
 }
 
 const APP_META: AppMetadata = AppMetadata {
@@ -219,9 +227,13 @@ async fn main() {
 
     // upload the data to the network
     println!("Uploading random data...");
+    let mut upload_options = UploadOptions::default();
+    if let Some(n) = args.upload_max_inflight {
+        upload_options.max_inflight = n;
+    }
     let start = Instant::now();
     let obj = sdk
-        .upload(Object::default(), reader, UploadOptions::default())
+        .upload(Object::default(), reader, upload_options)
         .await
         .expect("failed to upload object");
     let upload_duration = start.elapsed();
@@ -232,10 +244,14 @@ async fn main() {
 
     // download the object back from the network
     println!("Downloading object...");
+    let mut download_options = DownloadOptions::default();
+    if let Some(n) = args.download_max_inflight {
+        download_options.max_inflight = n;
+    }
     let start = Instant::now();
     let mut verifier = SeededVerifier::new(seed, args.size);
     let mut reader = sdk
-        .download(&obj, DownloadOptions::default())
+        .download(&obj, download_options)
         .expect("failed to start download");
     copy(&mut reader, &mut verifier)
         .await

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -150,9 +150,9 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             .map(|(i, task)| {
                 if i < min_shards {
                     let guard = client.reserve_inflight_download(&task.sector.host_key);
-                    return (task, guard);
+                    (task, guard)
                 } else {
-                    return (task, None);
+                    (task, None)
                 }
             })
             .collect();

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -72,17 +72,11 @@ struct SectorTask {
 }
 
 struct AwaitingRecovery {
-    /// Top `min_shards` sectors, each with their inflight slot already
-    /// reserved by [`SlabRecovery::new`]. The guards must be held until the
-    /// per-sector read tasks are spawned, then move into those tasks for
-    /// the duration of the RPC. Reserving synchronously at construction
-    /// time means concurrent `SlabRecovery::new` calls (e.g. the batch
-    /// queued by `Download::new`) see each other's load and disperse
-    /// across hosts instead of all picking the same fastest ones.
-    initial: Vec<(SectorTask, Option<InflightGuard>)>,
-    /// Remaining sectors, unreserved. Used on failure or after the 500ms
-    /// race timeout; reservation happens at spawn time on this path.
-    remaining: VecDeque<SectorTask>,
+    /// The sectors to download for this slab, paired with their inflight guards
+    /// if they were reserved by `SlabRecovery::new`. Guards are held for the
+    /// duration of the RPC in `SlabRecovery::recover_shard` to ensure the
+    /// reservation is released on completion or error.
+    sectors: Vec<(SectorTask, Option<InflightGuard>)>,
 }
 
 struct ShardsRecovered {
@@ -150,16 +144,19 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         // into the spawned read tasks via `recover_shards` and drop with
         // them; failure/timeout retries reserve on demand from `remaining`.
         let min_shards = slab.slab.min_shards as usize;
-        let mut iter = sectors.into_iter();
-        let initial: Vec<(SectorTask, Option<InflightGuard>)> = iter
-            .by_ref()
-            .take(min_shards)
-            .map(|task| {
-                let guard = client.reserve_inflight_download(&task.sector.host_key);
-                (task, guard)
+        let sectors = sectors
+            .into_iter()
+            .enumerate()
+            .map(|(i, task)| {
+                if i < min_shards {
+                    let guard = client.reserve_inflight_download(&task.sector.host_key);
+                    return (task, guard);
+                } else {
+                    return (task, None);
+                }
             })
             .collect();
-        let remaining: VecDeque<SectorTask> = iter.collect();
+
         Ok(Self {
             client,
             account_key,
@@ -168,7 +165,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             encryption_key: slab.slab.encryption_key,
             offset: slab.slab.offset as usize,
             length: slab.slab.length as usize,
-            state: AwaitingRecovery { initial, remaining },
+            state: AwaitingRecovery { sectors },
         })
     }
 
@@ -219,9 +216,8 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         shard_downloaded: Option<ShardProgressCallback>,
     ) -> Result<SlabRecovery<ShardsRecovered, T>, DownloadError> {
         let mut shard_tasks = JoinSet::new();
-        let total_sectors = self.state.initial.len() + self.state.remaining.len();
-        let mut shards = vec![None; total_sectors];
-        let mut sectors = self.state.remaining;
+        let mut shards = vec![None; self.state.sectors.len()];
+        let mut sectors = VecDeque::from(self.state.sectors);
         let min_shards = self.min_shards;
         let client = self.client;
         let account_key = self.account_key;
@@ -237,7 +233,10 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         // Spawn the initial batch using the inflight slots reserved by
         // `SlabRecovery::new`. Each guard moves into its corresponding
         // task and stays alive for the duration of the RPC.
-        for (task, inflight) in self.state.initial {
+        for i in 0..self.min_shards {
+            let (task, inflight) = sectors
+                .pop_front()
+                .ok_or(DownloadError::NotEnoughShards(i, self.min_shards))?;
             join_set_spawn!(
                 &mut shard_tasks,
                 Self::recover_shard(
@@ -282,7 +281,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                         Err(_) => {
                             if recovered_shards as usize + shard_tasks.len() + sectors.len() < min_shards as usize {
                                 return Err(DownloadError::NotEnoughShards(recovered_shards, min_shards));
-                            } else if let Some(task) = sectors.pop_front() {
+                            } else if let Some((task, _)) = sectors.pop_front() {
                                 let inflight = client.reserve_inflight_download(&task.sector.host_key);
                                 join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, inflight, self.slab_index, shard_offset, shard_length));
                             }
@@ -290,7 +289,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                     }
                 },
                 _ = sleep(Duration::from_millis(500)), if !sectors.is_empty() => {
-                    let task = sectors.pop_front().expect("sectors should not be empty");
+                    let (task, _) = sectors.pop_front().expect("sectors should not be empty");
                     let inflight = client.reserve_inflight_download(&task.sector.host_key);
                     join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, inflight, self.slab_index, shard_offset, shard_length));
                 },

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -6,7 +6,7 @@ use std::task::{Poll, ready};
 
 use crate::encryption::{Chacha20Cipher, EncryptionKey, encrypt_recovered_shards};
 use crate::erasure_coding::{self, ErasureCoder};
-use crate::hosts::{Hosts, RPCError};
+use crate::hosts::{Hosts, InflightGuard, RPCError};
 use crate::rhp4::{Client, Transport};
 use crate::time::{Duration, Elapsed, Instant, sleep};
 use crate::{AppKey, DownloadOptions, Object, Sector, ShardProgress, ShardProgressCallback, Slab};
@@ -72,7 +72,17 @@ struct SectorTask {
 }
 
 struct AwaitingRecovery {
-    sectors: Vec<SectorTask>,
+    /// Top `min_shards` sectors, each with their inflight slot already
+    /// reserved by [`SlabRecovery::new`]. The guards must be held until the
+    /// per-sector read tasks are spawned, then move into those tasks for
+    /// the duration of the RPC. Reserving synchronously at construction
+    /// time means concurrent `SlabRecovery::new` calls (e.g. the batch
+    /// queued by `Download::new`) see each other's load and disperse
+    /// across hosts instead of all picking the same fastest ones.
+    initial: Vec<(SectorTask, Option<InflightGuard>)>,
+    /// Remaining sectors, unreserved. Used on failure or after the 500ms
+    /// race timeout; reservation happens at spawn time on this path.
+    remaining: VecDeque<SectorTask>,
 }
 
 struct ShardsRecovered {
@@ -131,6 +141,25 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             })
             .collect::<Vec<_>>();
         client.prioritize(&mut sectors, |task| &task.sector.host_key);
+
+        // Reserve inflight slots for the top `min_shards` hosts now, while
+        // we still hold the synchronous call frame. `Download::new` queues
+        // many `SlabRecovery::new` calls back-to-back; without this, all of
+        // them would prioritize against the same all-zero inflight
+        // snapshot and pile onto the same fastest hosts. The guards travel
+        // into the spawned read tasks via `recover_shards` and drop with
+        // them; failure/timeout retries reserve on demand from `remaining`.
+        let min_shards = slab.slab.min_shards as usize;
+        let mut iter = sectors.into_iter();
+        let initial: Vec<(SectorTask, Option<InflightGuard>)> = iter
+            .by_ref()
+            .take(min_shards)
+            .map(|task| {
+                let guard = client.reserve_inflight_download(&task.sector.host_key);
+                (task, guard)
+            })
+            .collect();
+        let remaining: VecDeque<SectorTask> = iter.collect();
         Ok(Self {
             client,
             account_key,
@@ -139,7 +168,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             encryption_key: slab.slab.encryption_key,
             offset: slab.slab.offset as usize,
             length: slab.slab.length as usize,
-            state: AwaitingRecovery { sectors },
+            state: AwaitingRecovery { initial, remaining },
         })
     }
 
@@ -147,10 +176,16 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         client: Hosts<T>,
         account_key: Arc<AppKey>,
         task: SectorTask,
+        inflight: Option<InflightGuard>,
         slab_index: usize,
         sector_offset: usize,
         sector_length: usize,
     ) -> Result<(usize, Vec<u8>, ShardProgress), DownloadError> {
+        // Hold the inflight reservation for the duration of the RPC. The
+        // guard was created by the caller before spawning so the load is
+        // visible to concurrent `prioritize` calls, then dropped here on
+        // either success or error.
+        let _inflight = inflight;
         let start = Instant::now();
         let data = client
             .read_sector(
@@ -184,8 +219,9 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         shard_downloaded: Option<ShardProgressCallback>,
     ) -> Result<SlabRecovery<ShardsRecovered, T>, DownloadError> {
         let mut shard_tasks = JoinSet::new();
-        let mut shards = vec![None; self.state.sectors.len()];
-        let mut sectors = VecDeque::from(self.state.sectors);
+        let total_sectors = self.state.initial.len() + self.state.remaining.len();
+        let mut shards = vec![None; total_sectors];
+        let mut sectors = self.state.remaining;
         let min_shards = self.min_shards;
         let client = self.client;
         let account_key = self.account_key;
@@ -198,16 +234,17 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         let shard_offset = start;
         let shard_length = end - start;
 
-        for i in 0..self.min_shards {
-            let task = sectors
-                .pop_front()
-                .ok_or(DownloadError::NotEnoughShards(i, self.min_shards))?;
+        // Spawn the initial batch using the inflight slots reserved by
+        // `SlabRecovery::new`. Each guard moves into its corresponding
+        // task and stays alive for the duration of the RPC.
+        for (task, inflight) in self.state.initial {
             join_set_spawn!(
                 &mut shard_tasks,
                 Self::recover_shard(
                     client.clone(),
                     account_key.clone(),
                     task,
+                    inflight,
                     self.slab_index,
                     shard_offset,
                     shard_length,
@@ -246,14 +283,16 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                             if recovered_shards as usize + shard_tasks.len() + sectors.len() < min_shards as usize {
                                 return Err(DownloadError::NotEnoughShards(recovered_shards, min_shards));
                             } else if let Some(task) = sectors.pop_front() {
-                                join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, self.slab_index, shard_offset, shard_length));
+                                let inflight = client.reserve_inflight_download(&task.sector.host_key);
+                                join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, inflight, self.slab_index, shard_offset, shard_length));
                             }
                         }
                     }
                 },
                 _ = sleep(Duration::from_millis(500)), if !sectors.is_empty() => {
                     let task = sectors.pop_front().expect("sectors should not be empty");
-                    join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, self.slab_index, shard_offset, shard_length));
+                    let inflight = client.reserve_inflight_download(&task.sector.host_key);
+                    join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, inflight, self.slab_index, shard_offset, shard_length));
                 },
             }
         }
@@ -447,11 +486,18 @@ impl Download {
             let hosts = self.hosts.clone();
             let account_key = self.account_key.clone();
             let shard_progress_callback = self.shard_downloaded.clone();
+            // Build the SlabRecovery synchronously so prioritization and
+            // top-K inflight reservations land before this method returns.
+            // `Download::new` queues `max_inflight` chunks back-to-back;
+            // each successive `spawn_next` must see the previous chunk's
+            // reservations to disperse picks across hosts.
+            let len = chunk_slab.slab.length as usize;
+            let recovery = SlabRecovery::new(hosts, account_key, chunk_slab);
             self.queue
                 .push_back(AbortOnDropHandle::new(maybe_spawn!(async move {
-                    let len = chunk_slab.slab.length as usize;
+                    let recovery = recovery?;
                     let mut buf = Vec::with_capacity(len);
-                    SlabRecovery::new(hosts, account_key, chunk_slab)?
+                    recovery
                         .recover_shards(shard_progress_callback)
                         .await?
                         .decode()?

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -229,7 +229,7 @@ impl Ord for HostScore {
         // Lower failure_rate is better (so invert here for max-comparison).
         match other.failure_rate.cmp(&self.failure_rate) {
             std::cmp::Ordering::Equal => match (self.throughput, other.throughput) {
-                (None, None) => std::cmp::Ordering::Equal,
+                (None, None) => other.inflight.cmp(&self.inflight),
                 // discovery: unsampled outranks sampled
                 (None, Some(_)) => std::cmp::Ordering::Greater,
                 (Some(_), None) => std::cmp::Ordering::Less,

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -1,16 +1,15 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 use chrono::Utc;
 use log::debug;
-use priority_queue::PriorityQueue;
 use serde::{Deserialize, Serialize};
 use sia_core::rhp4::HostPrices;
 use sia_core::signing::{PrivateKey, PublicKey};
 use sia_core::types::Hash256;
 use sia_core::types::v2::NetAddress;
-use std::sync::Mutex;
 use thiserror::Error;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
@@ -43,8 +42,6 @@ struct RPCAverage(Option<f64>); // exponential moving average of throughput in b
 
 impl RPCAverage {
     const ALPHA: f64 = 0.2;
-    // Default throughput in bytes/sec if no samples; equivalent to 1 Gbps.
-    const DEFAULT_BYTES_PER_SEC: u64 = 125_000_000;
 
     fn add_sample(&mut self, bytes_per_sec: u64) {
         match self.0 {
@@ -57,17 +54,19 @@ impl RPCAverage {
         }
     }
 
-    fn avg(&self) -> u64 {
-        match self.0 {
-            Some(avg) => avg as u64,
-            None => Self::DEFAULT_BYTES_PER_SEC,
-        }
+    /// Returns the current average in bytes/sec, or `None` if no samples have
+    /// been recorded yet. Callers decide how to treat unsampled hosts.
+    fn avg(&self) -> Option<f64> {
+        self.0
     }
 }
 
 impl Display for RPCAverage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.avg(), f)
+        match self.avg() {
+            Some(v) => Display::fmt(&v, f),
+            None => f.write_str("unsampled"),
+        }
     }
 }
 
@@ -78,18 +77,6 @@ impl PartialEq for RPCAverage {
 }
 
 impl Eq for RPCAverage {}
-
-impl Ord for RPCAverage {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.avg().cmp(&other.avg())
-    }
-}
-
-impl PartialOrd for RPCAverage {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
 
 #[derive(Debug, Default, Clone)]
 struct FailureRate(Option<f64>); // exponential moving average of failure rate
@@ -144,7 +131,7 @@ impl Ord for FailureRate {
     }
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone)]
 struct HostMetric {
     rpc_write_avg: RPCAverage,
     rpc_read_avg: RPCAverage,
@@ -173,6 +160,17 @@ impl HostMetric {
     fn add_failure(&mut self) {
         self.failure_rate.add_sample(false);
     }
+
+    /// Combined read + write throughput average. `None` only when neither side
+    /// has been sampled. Used by [`HostScore`] for the discovery preference
+    /// (unsampled outranks sampled).
+    fn combined_throughput(&self) -> Option<f64> {
+        match (self.rpc_write_avg.avg(), self.rpc_read_avg.avg()) {
+            (None, None) => None,
+            (Some(w), Some(r)) => Some((w + r) / 2.0),
+            (Some(v), None) | (None, Some(v)) => Some(v),
+        }
+    }
 }
 
 // Computes throughput in bytes/sec, returning None when elapsed is zero so that
@@ -185,30 +183,67 @@ fn bytes_per_sec(bytes: u64, elapsed: Duration) -> Option<u64> {
     Some((bytes as f64 / elapsed.as_secs_f64()) as u64)
 }
 
-impl Ord for HostMetric {
+/// Score for picking the next upload host. Higher is better.
+///
+/// Sort order:
+/// 1. Lower `failure_rate` wins.
+/// 2. Unsampled hosts (no throughput data) outrank sampled ones — this is
+///    the "discovery" preference so every available host eventually gets
+///    tried at least once.
+/// 3. Among sampled hosts, higher `throughput / (inflight + 1)` wins —
+///    the expected per-shard throughput if you added one more shard. That
+///    penalizes already-busy hosts proportionally to load, so a saturated
+///    fast host can lose to an idle slower one, while a genuinely much
+///    faster host still wins even when serving a few shards.
+#[derive(Debug, Clone, Copy)]
+struct HostScore {
+    failure_rate: i64,
+    throughput: Option<f64>,
+    inflight: usize,
+}
+
+impl HostScore {
+    fn new(metric: &HostMetric, inflight: usize) -> Self {
+        Self {
+            failure_rate: metric.failure_rate.rate(),
+            throughput: metric.combined_throughput(),
+            inflight,
+        }
+    }
+
+    fn weighted_throughput(&self) -> Option<f64> {
+        self.throughput.map(|t| t / (self.inflight as f64 + 1.0))
+    }
+}
+
+impl PartialEq for HostScore {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for HostScore {}
+
+impl Ord for HostScore {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Lower failure_rate is better (so invert here for max-comparison).
         match other.failure_rate.cmp(&self.failure_rate) {
-            // lower failure rate is higher priority
-            std::cmp::Ordering::Equal => {
-                // use average of read and write throughput as tiebreaker
-                let avg_self = self
-                    .rpc_write_avg
-                    .avg()
-                    .saturating_add(self.rpc_read_avg.avg())
-                    / 2;
-                let avg_other = other
-                    .rpc_write_avg
-                    .avg()
-                    .saturating_add(other.rpc_read_avg.avg())
-                    / 2;
-                avg_self.cmp(&avg_other) // higher average throughput is higher priority
-            }
+            std::cmp::Ordering::Equal => match (self.throughput, other.throughput) {
+                (None, None) => std::cmp::Ordering::Equal,
+                // discovery: unsampled outranks sampled
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (Some(_), Some(_)) => self
+                    .weighted_throughput()
+                    .unwrap()
+                    .total_cmp(&other.weighted_throughput().unwrap()),
+            },
             ord => ord,
         }
     }
 }
 
-impl PartialOrd for HostMetric {
+impl PartialOrd for HostScore {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -218,18 +253,27 @@ impl PartialOrd for HostMetric {
 struct HostInfo {
     addresses: Vec<NetAddress>,
     good_for_upload: bool,
+    /// Number of upload RPCs currently in flight to this host. Updated by
+    /// an [`InflightGuard`] in `Hosts::write_sector`; read by the host
+    /// scorer in `next_upload_host`.
+    inflight_uploads: Arc<AtomicUsize>,
+    /// Number of download RPCs currently in flight to this host. Updated
+    /// by an [`InflightGuard`] in `Hosts::read_sector`; read by
+    /// `prioritize` so concurrent slab downloads disperse across hosts
+    /// instead of all piling onto the same top-N.
+    inflight_downloads: Arc<AtomicUsize>,
 }
 
 #[derive(Debug)]
 struct HostList {
     hosts: RwLock<HashMap<PublicKey, HostInfo>>,
-    preferred_hosts: RwLock<PriorityQueue<PublicKey, HostMetric>>,
+    metrics: RwLock<HashMap<PublicKey, HostMetric>>,
 }
 
 impl HostList {
     fn new() -> Self {
         Self {
-            preferred_hosts: RwLock::new(PriorityQueue::new()),
+            metrics: RwLock::new(HashMap::new()),
             hosts: RwLock::new(HashMap::new()),
         }
     }
@@ -239,42 +283,67 @@ impl HostList {
         hosts.get(host_key).map(|h| h.addresses.clone())
     }
 
-    /// Sorts a list of hosts according to their priority in the client's
-    /// preferred hosts queue. The function `f` is used to extract the
-    /// public key from each item.
-    fn prioritize<H, F>(&self, hosts: &mut [H], f: F)
+    /// Sorts a list of items by their host's download score (descending).
+    /// Score is `throughput / (inflight_downloads + 1)`, lower failure_rate
+    /// wins first, and unsampled hosts get discovery priority. Used by the
+    /// download path so concurrent slab downloads spread initial picks
+    /// across less-busy hosts.
+    fn prioritize<H, F>(&self, items: &mut [H], f: F)
     where
         F: Fn(&H) -> &PublicKey,
     {
-        let preferred_hosts = self.preferred_hosts.read().unwrap();
-        hosts.sort_by(|a, b| {
-            preferred_hosts
-                .get_priority(f(b))
-                .cmp(&preferred_hosts.get_priority(f(a)))
-        });
+        let metrics = self.metrics.read().unwrap();
+        let host_info = self.hosts.read().unwrap();
+        let score_for = |k: &PublicKey| -> Option<HostScore> {
+            let metric = metrics.get(k)?;
+            let inflight = host_info
+                .get(k)
+                .map(|h| h.inflight_downloads.load(Ordering::Relaxed))
+                .unwrap_or(0);
+            Some(HostScore::new(metric, inflight))
+        };
+        // Use `sort_by_cached_key` so each item's score is computed exactly
+        // once. The inflight counter is an atomic that other tasks mutate
+        // concurrently — recomputing during the sort would let the same
+        // host's score change between comparisons, violating total order
+        // and crashing the sort.
+        items.sort_by_cached_key(|b| std::cmp::Reverse(score_for(f(b))));
     }
 
     /// Adds new hosts to the list if they don't already exist.
     ///
     /// If `clear` is true, existing hosts not in the new list are removed, but
-    /// their metrics are retained in case they reappear later.
+    /// their metrics and inflight counters are retained in case they reappear later.
     fn update(&self, new_hosts: Vec<Host>, clear: bool) {
         let mut hosts = self.hosts.write().unwrap();
-        if clear {
-            hosts.clear();
-        }
-        let mut priority = self.preferred_hosts.write().unwrap();
+        // Preserve inflight counters across `clear=true` updates so guards
+        // currently outstanding still decrement the right counter.
+        let old = if clear {
+            std::mem::take(&mut *hosts)
+        } else {
+            HashMap::new()
+        };
+        let mut metrics = self.metrics.write().unwrap();
         for host in new_hosts {
+            let existing = hosts
+                .get(&host.public_key)
+                .or_else(|| old.get(&host.public_key));
+            let inflight_uploads = existing
+                .map(|h| h.inflight_uploads.clone())
+                .unwrap_or_else(|| Arc::new(AtomicUsize::new(0)));
+            let inflight_downloads = existing
+                .map(|h| h.inflight_downloads.clone())
+                .unwrap_or_else(|| Arc::new(AtomicUsize::new(0)));
             hosts.insert(
                 host.public_key,
                 HostInfo {
                     addresses: host.addresses,
                     good_for_upload: host.good_for_upload,
+                    inflight_uploads,
+                    inflight_downloads,
                 },
             );
-            if !priority.contains(&host.public_key) {
-                priority.push(host.public_key, HostMetric::default());
-            }
+            metrics.entry(host.public_key).or_default();
         }
     }
 
@@ -288,58 +357,105 @@ impl HostList {
             .count()
     }
 
-    /// Creates a queue of hosts that are good to upload to for sequential
-    /// access sorted by priority.
-    fn upload_queue(&self) -> HostQueue {
-        let mut available_hosts = self
+    /// Returns the upload host with the best score for handling another
+    /// shard, excluding any in `exclude`. The score is
+    /// `throughput / (inflight + 1)` and lower `failure_rate` wins first.
+    /// Returns `None` if no eligible host is available.
+    fn next_upload_host(&self, exclude: &HashSet<PublicKey>) -> Option<PublicKey> {
+        let hosts = self.hosts.read().unwrap();
+        let metrics = self.metrics.read().unwrap();
+        let mut best: Option<(PublicKey, HostScore)> = None;
+        for (hk, info) in hosts.iter() {
+            if !info.good_for_upload || exclude.contains(hk) {
+                continue;
+            }
+            let Some(metric) = metrics.get(hk) else {
+                continue;
+            };
+            let inflight = info.inflight_uploads.load(Ordering::Relaxed);
+            let score = HostScore::new(metric, inflight);
+            match &best {
+                None => best = Some((*hk, score)),
+                Some((_, current)) if score > *current => best = Some((*hk, score)),
+                _ => {}
+            }
+        }
+        best.map(|(hk, _)| hk)
+    }
+
+    /// Begins tracking an in-flight upload to the host. Returns a guard that
+    /// increments the host's `inflight_uploads` counter immediately and
+    /// decrements it on drop. Returns `None` if the host is unknown.
+    fn track_inflight_upload(&self, host_key: &PublicKey) -> Option<InflightGuard> {
+        let counter = self
             .hosts
             .read()
             .unwrap()
-            .iter()
-            .filter_map(|(hk, h)| h.good_for_upload.then_some(*hk))
-            .collect::<Vec<_>>();
-
-        self.prioritize(&mut available_hosts, |hk| hk);
-        HostQueue::new(available_hosts)
+            .get(host_key)?
+            .inflight_uploads
+            .clone();
+        Some(InflightGuard::new(counter))
     }
 
-    /// Adds a failure for the given host, updating its metrics and priority.
+    /// Download analogue of [`Self::track_inflight_upload`].
+    fn track_inflight_download(&self, host_key: &PublicKey) -> Option<InflightGuard> {
+        let counter = self
+            .hosts
+            .read()
+            .unwrap()
+            .get(host_key)?
+            .inflight_downloads
+            .clone();
+        Some(InflightGuard::new(counter))
+    }
+
+    /// Mutates the per-host metric in place. Used by the sample/failure
+    /// recording helpers below.
+    fn with_metric<F>(&self, host_key: &PublicKey, f: F)
+    where
+        F: FnOnce(&mut HostMetric),
+    {
+        if let Some(metric) = self.metrics.write().unwrap().get_mut(host_key) {
+            f(metric);
+        }
+    }
+
+    /// Adds a failure for the given host, updating its metrics.
     fn add_failure(&self, host_key: PublicKey) {
-        self.preferred_hosts
-            .write()
-            .unwrap()
-            .change_priority_by(&host_key, |metric| {
-                metric.add_failure();
-            });
+        self.with_metric(&host_key, |m| m.add_failure());
     }
 
-    /// Adds a read sample for the given host, updating its metrics and priority.
+    /// Adds a read sample for the given host, updating its metrics.
     fn add_read_sample(&self, host_key: PublicKey, bytes: u64, elapsed: Duration) {
-        self.preferred_hosts
-            .write()
-            .unwrap()
-            .change_priority_by(&host_key, |metric| {
-                metric.add_read_sample(bytes, elapsed);
-            });
+        self.with_metric(&host_key, |m| m.add_read_sample(bytes, elapsed));
     }
 
-    /// Adds a write sample for the given host, updating its metrics and priority.
+    /// Adds a write sample for the given host, updating its metrics.
     fn add_write_sample(&self, host_key: PublicKey, bytes: u64, elapsed: Duration) {
-        self.preferred_hosts
-            .write()
-            .unwrap()
-            .change_priority_by(&host_key, |metric| {
-                metric.add_write_sample(bytes, elapsed);
-            });
+        self.with_metric(&host_key, |m| m.add_write_sample(bytes, elapsed));
     }
 
     fn add_settings_sample(&self, host_key: PublicKey, elapsed: Duration) {
-        self.preferred_hosts
-            .write()
-            .unwrap()
-            .change_priority_by(&host_key, |metric| {
-                metric.add_settings_sample(elapsed);
-            });
+        self.with_metric(&host_key, |m| m.add_settings_sample(elapsed));
+    }
+}
+
+/// RAII guard that increments an `AtomicUsize` on construction and
+/// decrements it on drop. Used to track per-host inflight uploads so the
+/// host scorer reflects current load and is balanced even on early returns
+/// or async cancellations.
+struct InflightGuard(Arc<AtomicUsize>);
+
+impl InflightGuard {
+    fn new(counter: Arc<AtomicUsize>) -> Self {
+        counter.fetch_add(1, Ordering::Relaxed);
+        Self(counter)
+    }
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
@@ -442,10 +558,13 @@ impl<T: Transport> Hosts<T> {
         self.hosts.available_for_upload()
     }
 
-    /// Creates a queue of hosts that are good to upload to for sequential
-    /// access sorted by priority.
-    pub fn upload_queue(&self) -> HostQueue {
-        self.hosts.upload_queue()
+    /// Picks the best host for the next shard upload, excluding any in
+    /// `exclude`. The scorer favors the host with the highest
+    /// `throughput / (inflight + 1)` — i.e. best expected per-shard
+    /// throughput if you added one more shard. Returns `None` if no
+    /// eligible host is available.
+    pub fn next_upload_host(&self, exclude: &HashSet<PublicKey>) -> Option<PublicKey> {
+        self.hosts.next_upload_host(exclude)
     }
 
     /// Adds a failure for the given host, updating its metrics and priority.
@@ -536,6 +655,7 @@ impl<T: Transport> Hosts<T> {
         write_timeout: Duration,
     ) -> Result<Hash256, RPCError> {
         let host = self.host_endpoint(host_key)?;
+        let _inflight = self.hosts.track_inflight_upload(&host_key);
         timeout(write_timeout, async {
             let (prices, _) = Self::fetch_prices(
                 self.transport.clone(),
@@ -570,6 +690,7 @@ impl<T: Transport> Hosts<T> {
     ) -> Result<bytes::Bytes, RPCError> {
         let host = self.host_endpoint(host_key)?;
         let bytes = length as u64;
+        let _inflight = self.hosts.track_inflight_download(&host_key);
         timeout(read_timeout, async {
             let (prices, _) = Self::fetch_prices(
                 self.transport.clone(),
@@ -611,74 +732,6 @@ pub enum QueueError {
     /// The host has been retried too many times.
     #[error("host retry limit exceeded")]
     MaxRetriesExceeded,
-}
-
-/// Maximum number of times a single host may be re-queued via
-/// [`HostQueue::retry`] before it is dropped.
-const MAX_RETRIES: usize = 3;
-
-#[derive(Debug)]
-struct HostQueueInner {
-    hosts: VecDeque<PublicKey>,
-    attempts: HashMap<PublicKey, usize>,
-}
-
-/// A thread-safe queue of host public keys.
-#[derive(Debug, Clone)]
-pub(crate) struct HostQueue {
-    inner: Arc<Mutex<HostQueueInner>>,
-}
-
-impl Iterator for HostQueue {
-    type Item = PublicKey;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.pop_front().ok()
-    }
-}
-
-impl HostQueue {
-    pub(crate) fn new(hosts: Vec<PublicKey>) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(HostQueueInner {
-                hosts: VecDeque::from(hosts),
-                attempts: HashMap::new(),
-            })),
-        }
-    }
-
-    pub fn pop_front(&self) -> Result<PublicKey, QueueError> {
-        let mut inner = self.inner.lock().map_err(|_| QueueError::MutexError)?;
-        inner.hosts.pop_front().ok_or(QueueError::NoMoreHosts)
-    }
-
-    pub fn pop_n(&self, n: usize) -> Result<Vec<PublicKey>, QueueError> {
-        let mut inner = self.inner.lock().map_err(|_| QueueError::MutexError)?;
-        if inner.hosts.len() < n {
-            return Err(QueueError::NoMoreHosts);
-        }
-        let mut result = Vec::with_capacity(n);
-        for _ in 0..n {
-            let host_key = inner.hosts.pop_front().ok_or(QueueError::NoMoreHosts)?;
-            result.push(host_key);
-        }
-        Ok(result)
-    }
-
-    pub fn retry(&self, host: PublicKey) -> Result<(), QueueError> {
-        let mut inner = self.inner.lock().map_err(|_| QueueError::MutexError)?;
-        let attempts = inner.attempts.get(&host).copied().unwrap_or(0);
-        if attempts >= MAX_RETRIES {
-            return Err(QueueError::MaxRetriesExceeded);
-        }
-        inner.hosts.push_back(host);
-        inner
-            .attempts
-            .entry(host)
-            .and_modify(|e| *e += 1)
-            .or_insert(1);
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -733,36 +786,30 @@ mod test {
         let mut avg = RPCAverage::default();
         assert_eq!(
             avg.avg(),
-            125000000,
-            "default average should be 1 Gbps before any samples"
+            None,
+            "unsampled average should be None (no 1 Gbps default)"
         );
 
         avg.add_sample(100);
-        assert_eq!(avg.avg(), 100, "initial average should be first sample");
+        assert_eq!(avg.avg(), Some(100.0), "initial average should be first sample");
 
         avg.add_sample(200);
         assert!(
-            avg.avg() > 100,
+            avg.avg() > Some(100.0),
             "average should increase after higher sample"
         );
 
         avg.add_sample(50);
         assert!(
-            avg.avg() < 200,
+            avg.avg() < Some(200.0),
             "average should decrease after lower sample"
-        );
-
-        let mut avg2 = RPCAverage::default();
-        avg2.add_sample(150);
-        assert_eq!(
-            avg.cmp(&avg2),
-            std::cmp::Ordering::Less,
-            "lower average should be lesser"
         );
     }
 
     #[sia_core_derive::cross_target_test]
     fn test_host_metric_ordering() {
+        // Sorting a list of HostMetric by HostScore (inflight=0) should
+        // descend by failure_rate then by throughput.
         let mut hosts = vec![
             HostMetric::default(),
             HostMetric::default(),
@@ -777,8 +824,8 @@ mod test {
         for _ in 0..5 {
             hosts[1].failure_rate.add_sample(true);
         }
-        hosts.sort();
-
+        // Sort by HostScore ascending; reverse to get desc.
+        hosts.sort_by(|a, b| HostScore::new(a, 0).cmp(&HostScore::new(b, 0)));
         let rates = hosts
             .into_iter()
             .rev()
@@ -797,13 +844,12 @@ mod test {
         hosts[0].rpc_write_avg.add_sample(100);
         hosts[1].rpc_write_avg.add_sample(1000);
         hosts[2].rpc_write_avg.add_sample(500);
-        hosts.sort();
-
+        hosts.sort_by(|a, b| HostScore::new(a, 0).cmp(&HostScore::new(b, 0)));
         let rates = hosts
             .into_iter()
             .rev()
-            .map(|h| h.rpc_write_avg)
-            .collect::<Vec<RPCAverage>>();
+            .map(|h| h.rpc_write_avg.avg())
+            .collect::<Vec<Option<f64>>>();
         assert!(
             rates.is_sorted_by(|a, b| a >= b),
             "hosts should be sorted by rpc write avg desc"
@@ -811,46 +857,51 @@ mod test {
     }
 
     #[sia_core_derive::cross_target_test]
-    fn test_host_priority_queue() {
-        let mut pq = PriorityQueue::<PublicKey, HostMetric>::new();
-        let mut hosts = vec![];
-        for _ in 0..5 {
-            let pk = random_pubkey();
-            pq.push(pk, HostMetric::default());
-            hosts.push(pk);
-        }
+    fn test_host_ranking() {
+        // End-to-end host ranking via HostScore at the metric layer.
+        // All-unsampled, all-equal: HostScore::new with inflight=0 is the
+        // pure-quality ranking and ties for hosts with no samples.
+        let unsampled_a = HostScore::new(&HostMetric::default(), 0);
+        let unsampled_b = HostScore::new(&HostMetric::default(), 0);
+        assert_eq!(unsampled_a.cmp(&unsampled_b), std::cmp::Ordering::Equal);
 
-        // initially, the order is the same as insertion
-        assert_eq!(pq.peek().unwrap().0, &hosts[0]);
+        // Sample one host: unsampled now outranks it (discovery preference).
+        let sampled_slow = {
+            let mut m = HostMetric::default();
+            m.add_write_sample(100, Duration::from_secs(1));
+            m
+        };
+        let sampled_slow_score = HostScore::new(&sampled_slow, 0);
+        assert!(
+            unsampled_a > sampled_slow_score,
+            "unsampled should outrank sampled (discovery)",
+        );
 
-        // fourth host gets a sample with throughput below the 1Gbps default,
-        // dropping its priority below the other hosts
-        pq.change_priority_by(&hosts[3], |metric| {
-            metric.add_write_sample(100, Duration::from_secs(1));
-        });
-        assert_ne!(pq.peek().unwrap().0, &hosts[3]);
+        // Among sampled, faster wins.
+        let sampled_fast = {
+            let mut m = HostMetric::default();
+            m.add_read_sample(1000, Duration::from_secs(1));
+            m
+        };
+        let sampled_fast_score = HostScore::new(&sampled_fast, 0);
+        assert!(sampled_fast_score > sampled_slow_score);
 
-        // add a faster sample to second host, should have higher priority than fourth
-        pq.change_priority_by(&hosts[1], |metric| {
-            metric.add_read_sample(200, Duration::from_secs(1));
-        });
-        assert!(pq.get_priority(&hosts[1]).unwrap() > pq.get_priority(&hosts[3]).unwrap());
-
-        // add a failure to the second host, should lower its priority below fourth
-        pq.change_priority_by(&hosts[1], |metric| {
-            metric.add_failure();
-        });
-        assert!(pq.get_priority(&hosts[1]).unwrap() < pq.get_priority(&hosts[3]).unwrap());
+        // Failure trumps throughput.
+        let failing_fast = {
+            let mut m = sampled_fast.clone();
+            m.add_failure();
+            m
+        };
+        let failing_fast_score = HostScore::new(&failing_fast, 0);
+        assert!(failing_fast_score < sampled_slow_score);
     }
 
     #[sia_core_derive::cross_target_test]
-    fn test_upload_queue() {
+    fn test_next_upload_host() {
         let hosts_manager = Hosts::new(Client::new());
-
         let hk1 = random_pubkey();
         let hk2 = random_pubkey();
         let hk3 = random_pubkey();
-
         hosts_manager.update(
             vec![
                 Host {
@@ -859,7 +910,108 @@ mod test {
                     country_code: String::new(),
                     latitude: 0.0,
                     longitude: 0.0,
-                    good_for_upload: false,
+                    good_for_upload: true,
+                },
+                Host {
+                    public_key: hk2,
+                    addresses: vec![],
+                    country_code: String::new(),
+                    latitude: 0.0,
+                    longitude: 0.0,
+                    good_for_upload: false, // not upload-eligible
+                },
+                Host {
+                    public_key: hk3,
+                    addresses: vec![],
+                    country_code: String::new(),
+                    latitude: 0.0,
+                    longitude: 0.0,
+                    good_for_upload: true,
+                },
+            ],
+            true,
+        );
+
+        // With no samples and no inflight, both hk1 and hk3 are eligible
+        // and have equal score; result is deterministic-enough — we just
+        // assert it returns one of them, and that hk2 (not good_for_upload)
+        // is never picked.
+        let mut exclude = HashSet::new();
+        let first = hosts_manager.next_upload_host(&exclude).unwrap();
+        assert!(first == hk1 || first == hk3);
+        assert_ne!(first, hk2);
+
+        // Excluding the first picks the other upload-eligible host.
+        exclude.insert(first);
+        let second = hosts_manager.next_upload_host(&exclude).unwrap();
+        assert!(second == hk1 || second == hk3);
+        assert_ne!(second, first);
+        assert_ne!(second, hk2);
+
+        // Excluding both leaves nothing.
+        exclude.insert(second);
+        assert!(hosts_manager.next_upload_host(&exclude).is_none());
+    }
+
+    #[sia_core_derive::cross_target_test]
+    fn test_host_score_orders_by_weighted_throughput() {
+        // Same metric but different inflight: the less-loaded host wins.
+        let metric = {
+            let mut m = HostMetric::default();
+            m.add_write_sample(1_000_000, Duration::from_secs(1));
+            m
+        };
+        let busy = HostScore::new(&metric, 4);
+        let idle = HostScore::new(&metric, 0);
+        assert!(idle > busy, "less-loaded host should outrank busy host");
+
+        // A 10x faster host beats an idle slow host even when it has some load.
+        let fast_metric = {
+            let mut m = HostMetric::default();
+            m.add_write_sample(10_000_000, Duration::from_secs(1));
+            m
+        };
+        let fast_busy = HostScore::new(&fast_metric, 4);
+        let slow_idle = HostScore::new(&metric, 0);
+        assert!(
+            fast_busy > slow_idle,
+            "fast-but-busy should beat slow-and-idle when fast is >Nx faster",
+        );
+
+        // Failure rate trumps throughput.
+        let failing = {
+            let mut m = fast_metric.clone();
+            for _ in 0..5 {
+                m.add_failure();
+            }
+            m
+        };
+        let failing_score = HostScore::new(&failing, 0);
+        let healthy_score = HostScore::new(&metric, 0);
+        assert!(
+            healthy_score > failing_score,
+            "healthy host should outrank a failing fast host",
+        );
+    }
+
+    #[sia_core_derive::cross_target_test]
+    fn test_prioritize_uses_download_inflight() {
+        // Two hosts with identical throughput samples; bumping one host's
+        // download inflight counter should push it down in the sorted
+        // order. Mirrors the upload-side `next_upload_host` behavior so
+        // concurrent slab downloads spread across less-busy hosts.
+        let hosts_manager = Hosts::new(Client::new());
+        let hk1 = random_pubkey();
+        let hk2 = random_pubkey();
+        hosts_manager.update(
+            vec![
+                Host {
+                    public_key: hk1,
+                    addresses: vec![],
+                    country_code: String::new(),
+                    latitude: 0.0,
+                    longitude: 0.0,
+                    good_for_upload: true,
                 },
                 Host {
                     public_key: hk2,
@@ -869,74 +1021,42 @@ mod test {
                     longitude: 0.0,
                     good_for_upload: true,
                 },
-                Host {
-                    public_key: hk3,
-                    addresses: vec![],
-                    country_code: String::new(),
-                    latitude: 0.0,
-                    longitude: 0.0,
-                    good_for_upload: false,
-                },
             ],
             true,
         );
+        // Sample both with the same throughput so the inflight counter is
+        // the only differentiator.
+        hosts_manager
+            .hosts
+            .add_read_sample(hk1, 1_000_000, Duration::from_secs(1));
+        hosts_manager
+            .hosts
+            .add_read_sample(hk2, 1_000_000, Duration::from_secs(1));
 
-        let queue = hosts_manager.upload_queue();
-        let first = queue.pop_front().unwrap();
-        assert_eq!(first, hk2);
-        assert!(
-            queue.pop_front().is_err(),
-            "queue should only have one host"
+        // With both idle, sort order is arbitrary among ties — assert the
+        // ranking switches when we add inflight to one of them.
+        let mut items = vec![hk1, hk2];
+        hosts_manager.hosts.prioritize(&mut items, |k| k);
+        let initial_first = items[0];
+        let initial_second = items[1];
+
+        // Bump inflight on whichever host happened to be first by holding
+        // three live guards on it.
+        let _guards: Vec<_> = (0..3)
+            .map(|_| {
+                hosts_manager
+                    .hosts
+                    .track_inflight_download(&initial_first)
+                    .unwrap()
+            })
+            .collect();
+
+        let mut items = vec![hk1, hk2];
+        hosts_manager.hosts.prioritize(&mut items, |k| k);
+        assert_eq!(
+            items[0], initial_second,
+            "host with higher download inflight should sort second",
         );
-    }
-
-    #[sia_core_derive::cross_target_test]
-    fn test_host_queue_pop_n() {
-        let hosts: Vec<_> = (0..5).map(|_| random_pubkey()).collect();
-        let queue = HostQueue::new(hosts.clone());
-
-        // pop 3 hosts
-        let popped = queue.pop_n(3).expect("should pop 3 hosts");
-        assert_eq!(popped.len(), 3);
-        assert_eq!(popped[0], hosts[0]);
-        assert_eq!(popped[1], hosts[1]);
-        assert_eq!(popped[2], hosts[2]);
-
-        // pop remaining 2
-        let popped = queue.pop_n(2).expect("should pop 2 hosts");
-        assert_eq!(popped.len(), 2);
-        assert_eq!(popped[0], hosts[3]);
-        assert_eq!(popped[1], hosts[4]);
-
-        // queue should be empty
-        assert!(matches!(queue.pop_front(), Err(QueueError::NoMoreHosts)));
-    }
-
-    #[sia_core_derive::cross_target_test]
-    fn test_host_queue_pop_n_not_enough_hosts() {
-        let hosts: Vec<_> = (0..3).map(|_| random_pubkey()).collect();
-        let queue = HostQueue::new(hosts.clone());
-
-        // try to pop more than available
-        let result = queue.pop_n(5);
-        assert!(matches!(result, Err(QueueError::NoMoreHosts)));
-
-        // queue should be unchanged - can still pop all 3
-        let popped = queue.pop_n(3).expect("should pop 3");
-        assert_eq!(popped.len(), 3);
-    }
-
-    #[sia_core_derive::cross_target_test]
-    fn test_host_queue_pop_n_zero() {
-        let hosts: Vec<_> = (0..3).map(|_| random_pubkey()).collect();
-        let queue = HostQueue::new(hosts);
-
-        // pop 0 hosts should succeed with empty vec
-        let popped = queue.pop_n(0).expect("should succeed");
-        assert!(popped.is_empty());
-
-        // queue should be unchanged - can still pop 3
-        let popped = queue.pop_n(3).expect("should pop 3");
-        assert_eq!(popped.len(), 3);
+        assert_eq!(items[1], initial_first);
     }
 }

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -357,14 +357,18 @@ impl HostList {
             .count()
     }
 
-    /// Returns the upload host with the best score for handling another
-    /// shard, excluding any in `exclude`. The score is
-    /// `throughput / (inflight + 1)` and lower `failure_rate` wins first.
-    /// Returns `None` if no eligible host is available.
-    fn next_upload_host(&self, exclude: &HashSet<PublicKey>) -> Option<PublicKey> {
+    /// Picks the best upload host for another shard and reserves an
+    /// inflight slot on it. The reservation increments the winner's
+    /// `inflight_uploads` counter as part of the same call, so subsequent
+    /// pickers see the new load — the race window shrinks from "until the
+    /// RPC starts" to the scan in this function (microseconds).
+    ///
+    /// Score is `throughput / (inflight + 1)`; lower `failure_rate` wins
+    /// first. Returns `None` if no eligible host is available.
+    fn next_upload_host(&self, exclude: &HashSet<PublicKey>) -> Option<(PublicKey, InflightGuard)> {
         let hosts = self.hosts.read().unwrap();
         let metrics = self.metrics.read().unwrap();
-        let mut best: Option<(PublicKey, HostScore)> = None;
+        let mut best: Option<(PublicKey, Arc<AtomicUsize>, HostScore)> = None;
         for (hk, info) in hosts.iter() {
             if !info.good_for_upload || exclude.contains(hk) {
                 continue;
@@ -375,29 +379,19 @@ impl HostList {
             let inflight = info.inflight_uploads.load(Ordering::Relaxed);
             let score = HostScore::new(metric, inflight);
             match &best {
-                None => best = Some((*hk, score)),
-                Some((_, current)) if score > *current => best = Some((*hk, score)),
+                None => best = Some((*hk, info.inflight_uploads.clone(), score)),
+                Some((_, _, current)) if score > *current => {
+                    best = Some((*hk, info.inflight_uploads.clone(), score))
+                }
                 _ => {}
             }
         }
-        best.map(|(hk, _)| hk)
+        best.map(|(hk, counter, _)| (hk, InflightGuard::new(counter)))
     }
 
-    /// Begins tracking an in-flight upload to the host. Returns a guard that
-    /// increments the host's `inflight_uploads` counter immediately and
-    /// decrements it on drop. Returns `None` if the host is unknown.
-    fn track_inflight_upload(&self, host_key: &PublicKey) -> Option<InflightGuard> {
-        let counter = self
-            .hosts
-            .read()
-            .unwrap()
-            .get(host_key)?
-            .inflight_uploads
-            .clone();
-        Some(InflightGuard::new(counter))
-    }
-
-    /// Download analogue of [`Self::track_inflight_upload`].
+    /// Begins tracking an in-flight download from the host. Returns a guard
+    /// that increments the host's `inflight_downloads` counter immediately
+    /// and decrements it on drop. Returns `None` if the host is unknown.
     fn track_inflight_download(&self, host_key: &PublicKey) -> Option<InflightGuard> {
         let counter = self
             .hosts
@@ -444,9 +438,13 @@ impl HostList {
 /// decrements it on drop. Used to track per-host inflight uploads so the
 /// host scorer reflects current load and is balanced even on early returns
 /// or async cancellations.
-struct InflightGuard(Arc<AtomicUsize>);
+pub(crate) struct InflightGuard(Arc<AtomicUsize>);
 
 impl InflightGuard {
+    /// Increments `counter` and returns a guard that decrements it on
+    /// drop. The increment is part of the selection path so concurrent
+    /// pickers see the load on their next scan rather than only after
+    /// the RPC starts.
     fn new(counter: Arc<AtomicUsize>) -> Self {
         counter.fetch_add(1, Ordering::Relaxed);
         Self(counter)
@@ -558,13 +556,31 @@ impl<T: Transport> Hosts<T> {
         self.hosts.available_for_upload()
     }
 
-    /// Picks the best host for the next shard upload, excluding any in
-    /// `exclude`. The scorer favors the host with the highest
-    /// `throughput / (inflight + 1)` — i.e. best expected per-shard
-    /// throughput if you added one more shard. Returns `None` if no
-    /// eligible host is available.
-    pub fn next_upload_host(&self, exclude: &HashSet<PublicKey>) -> Option<PublicKey> {
+    /// Atomically picks the best upload host for another shard and reserves
+    /// an inflight slot on it. The returned [`InflightGuard`] must be kept
+    /// alive for the duration of the upload — drop it to roll the
+    /// reservation back on failure. Selection and reservation happen under
+    /// the same lock so concurrent pickers can't all observe the same low
+    /// inflight count and pile onto the same host.
+    ///
+    /// The scorer favors the host with the highest
+    /// `throughput / (inflight + 1)` — best expected per-shard throughput
+    /// if you added one more shard. Returns `None` if no eligible host is
+    /// available.
+    pub fn next_upload_host(
+        &self,
+        exclude: &HashSet<PublicKey>,
+    ) -> Option<(PublicKey, InflightGuard)> {
         self.hosts.next_upload_host(exclude)
+    }
+
+    /// Reserves an inflight slot for a download from the given host. The
+    /// returned guard increments `inflight_downloads` immediately so
+    /// concurrent `prioritize` calls see the load, and decrements on drop.
+    /// Callers should create the guard before spawning the download task
+    /// and hold it for the duration of the RPC.
+    pub fn reserve_inflight_download(&self, host_key: &PublicKey) -> Option<InflightGuard> {
+        self.hosts.track_inflight_download(host_key)
     }
 
     /// Adds a failure for the given host, updating its metrics and priority.
@@ -647,6 +663,10 @@ impl<T: Transport> Hosts<T> {
         }
     }
 
+    /// Performs an upload RPC to the given host. The caller is responsible
+    /// for holding the [`InflightGuard`] returned by
+    /// [`Self::next_upload_host`] for the duration of this call so the
+    /// host scorer reflects the load.
     pub async fn write_sector(
         &self,
         host_key: PublicKey,
@@ -655,7 +675,6 @@ impl<T: Transport> Hosts<T> {
         write_timeout: Duration,
     ) -> Result<Hash256, RPCError> {
         let host = self.host_endpoint(host_key)?;
-        let _inflight = self.hosts.track_inflight_upload(&host_key);
         timeout(write_timeout, async {
             let (prices, _) = Self::fetch_prices(
                 self.transport.clone(),
@@ -679,6 +698,10 @@ impl<T: Transport> Hosts<T> {
         .await?
     }
 
+    /// Performs a download RPC from the given host. The caller is
+    /// responsible for holding the [`InflightGuard`] returned by
+    /// [`Self::reserve_inflight_download`] for the duration of this call so
+    /// the host scorer reflects the load.
     pub async fn read_sector(
         &self,
         host_key: PublicKey,
@@ -690,7 +713,6 @@ impl<T: Transport> Hosts<T> {
     ) -> Result<bytes::Bytes, RPCError> {
         let host = self.host_endpoint(host_key)?;
         let bytes = length as u64;
-        let _inflight = self.hosts.track_inflight_download(&host_key);
         timeout(read_timeout, async {
             let (prices, _) = Self::fetch_prices(
                 self.transport.clone(),
@@ -937,13 +959,13 @@ mod test {
         // assert it returns one of them, and that hk2 (not good_for_upload)
         // is never picked.
         let mut exclude = HashSet::new();
-        let first = hosts_manager.next_upload_host(&exclude).unwrap();
+        let (first, first_guard) = hosts_manager.next_upload_host(&exclude).unwrap();
         assert!(first == hk1 || first == hk3);
         assert_ne!(first, hk2);
 
         // Excluding the first picks the other upload-eligible host.
         exclude.insert(first);
-        let second = hosts_manager.next_upload_host(&exclude).unwrap();
+        let (second, second_guard) = hosts_manager.next_upload_host(&exclude).unwrap();
         assert!(second == hk1 || second == hk3);
         assert_ne!(second, first);
         assert_ne!(second, hk2);
@@ -951,6 +973,10 @@ mod test {
         // Excluding both leaves nothing.
         exclude.insert(second);
         assert!(hosts_manager.next_upload_host(&exclude).is_none());
+
+        // Drop the guards explicitly so the counters balance.
+        drop(first_guard);
+        drop(second_guard);
     }
 
     #[sia_core_derive::cross_target_test]

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
@@ -357,40 +357,15 @@ impl HostList {
             .count()
     }
 
-    /// Picks the best upload host for another shard and reserves an
-    /// inflight slot on it. The reservation increments the winner's
-    /// `inflight_uploads` counter as part of the same call, so subsequent
-    /// pickers see the new load — the race window shrinks from "until the
-    /// RPC starts" to the scan in this function (microseconds).
-    ///
-    /// `is_excluded` is called for each candidate; returning `true` skips
-    /// it. Score is `throughput / (inflight + 1)`; lower `failure_rate`
-    /// wins first. Returns `None` if no eligible host is available.
-    fn next_upload_host<F>(&self, mut is_excluded: F) -> Option<(PublicKey, InflightGuard)>
-    where
-        F: FnMut(&PublicKey) -> bool,
-    {
-        let hosts = self.hosts.read().unwrap();
-        let metrics = self.metrics.read().unwrap();
-        let mut best: Option<(PublicKey, Arc<AtomicUsize>, HostScore)> = None;
-        for (hk, info) in hosts.iter() {
-            if !info.good_for_upload || is_excluded(hk) {
-                continue;
-            }
-            let Some(metric) = metrics.get(hk) else {
-                continue;
-            };
-            let inflight = info.inflight_uploads.load(Ordering::Relaxed);
-            let score = HostScore::new(metric, inflight);
-            match &best {
-                None => best = Some((*hk, info.inflight_uploads.clone(), score)),
-                Some((_, _, current)) if score > *current => {
-                    best = Some((*hk, info.inflight_uploads.clone(), score))
-                }
-                _ => {}
-            }
-        }
-        best.map(|(hk, counter, _)| (hk, InflightGuard::new(counter)))
+    /// Snapshots the currently upload-eligible host keys. Used by
+    /// [`HostQueue::new`] to seed the per-slab pool.
+    fn upload_eligible_hosts(&self) -> Vec<PublicKey> {
+        self.hosts
+            .read()
+            .unwrap()
+            .iter()
+            .filter_map(|(k, info)| info.good_for_upload.then_some(*k))
+            .collect()
     }
 
     /// Begins tracking an in-flight download from the host. Returns a guard
@@ -438,66 +413,82 @@ impl HostList {
     }
 }
 
-/// Maximum number of times a single host may be picked across all shards
-/// in a slab. A host with a transient failure should get a few more
-/// chances within the slab rather than being permanently sidelined on the
-/// first error.
-const MAX_HOST_RETRIES: usize = 3;
+/// Maximum number of attempts per host within a single slab — initial
+/// pick plus retries. A host with a transient failure should get a few
+/// more chances within the slab rather than being permanently sidelined
+/// on the first error.
+const MAX_RETRIES: usize = 3;
 
-/// Per-slab host accounting. Tracks two things:
-/// - `claimed`: hosts currently in flight, or holding a successful sector
-///   on this slab. Excluded from picks so no two shards in the slab can
-///   both succeed on the same host (slab uniqueness; the indexer rejects
-///   duplicate hosts in a slab).
-/// - `attempts`: per-host pick count. A host that hits [`MAX_HOST_RETRIES`]
-///   is permanently off-limits for the slab.
+/// Per-slab pool of upload hosts. Snapshots upload-eligible hosts at
+/// construction and hands them out one at a time. Failed hosts can be
+/// returned via [`HostQueue::retry`] for re-pick, capped at
+/// [`MAX_RETRIES`] attempts per host across the slab.
 ///
-/// Lifecycle for a host:
-/// - `pick` → attempt count +1, added to claimed.
-/// - Write succeeds → stays in claimed forever. Attempt count irrelevant.
-/// - Write fails → `release_failed` removes from claimed; attempts stays
-///   incremented. Another shard (or a retry within the same shard) can
-///   re-pick the host while its attempts < `MAX_HOST_RETRIES`.
-pub(crate) struct UsedHosts {
+/// `available` is a snapshot, not a live view of [`HostList`]: hosts
+/// removed via [`Hosts::update`] after construction stay in the pool but
+/// are filtered at pick time when they no longer exist in `HostList`.
+/// Slabs live for seconds, so snapshot staleness doesn't materially
+/// affect placement.
+pub(crate) struct HostQueue {
     hosts: Arc<HostList>,
-    claimed: HashSet<PublicKey>,
+    available: Vec<PublicKey>,
     attempts: HashMap<PublicKey, usize>,
 }
 
-impl UsedHosts {
-    fn new(hosts: Arc<HostList>) -> Self {
+impl HostQueue {
+    fn new(hosts: Arc<HostList>, available: Vec<PublicKey>) -> Self {
         Self {
             hosts,
-            claimed: HashSet::new(),
+            available,
             attempts: HashMap::new(),
         }
     }
 
-    /// Atomically picks the best upload host for another shard in this slab
-    /// and reserves an inflight slot on it. Skips hosts currently held in
-    /// `claimed` or whose attempt count has reached [`MAX_HOST_RETRIES`].
-    /// The returned [`InflightGuard`] must be held for the duration of the
-    /// upload RPC so concurrent pickers see the load.
+    /// Picks the best host from the pool and atomically reserves an
+    /// inflight slot. Scoring matches [`HostScore`]: lower `failure_rate`
+    /// wins, then unsampled hosts outrank sampled (discovery), then
+    /// `throughput / (inflight + 1)` among sampled. The winner is removed
+    /// from `available`; the returned [`InflightGuard`] must be held for
+    /// the duration of the upload RPC so concurrent pickers see the load.
     pub(crate) fn pick(&mut self) -> Option<(PublicKey, InflightGuard)> {
-        let Self {
-            hosts,
-            claimed,
-            attempts,
-        } = self;
-        let (host, guard) = hosts.next_upload_host(|hk| {
-            claimed.contains(hk) || attempts.get(hk).is_some_and(|n| *n >= MAX_HOST_RETRIES)
-        })?;
-        *attempts.entry(host).or_insert(0) += 1;
-        claimed.insert(host);
-        Some((host, guard))
+        let host_info = self.hosts.hosts.read().unwrap();
+        let metrics = self.hosts.metrics.read().unwrap();
+        let mut best: Option<(usize, HostScore, Arc<AtomicUsize>)> = None;
+        for (i, hk) in self.available.iter().enumerate() {
+            let Some(info) = host_info.get(hk) else {
+                continue;
+            };
+            let Some(metric) = metrics.get(hk) else {
+                continue;
+            };
+            let inflight = info.inflight_uploads.load(Ordering::Relaxed);
+            let score = HostScore::new(metric, inflight);
+            match &best {
+                None => best = Some((i, score, info.inflight_uploads.clone())),
+                Some((_, current, _)) if score > *current => {
+                    best = Some((i, score, info.inflight_uploads.clone()))
+                }
+                _ => {}
+            }
+        }
+        let (i, _, counter) = best?;
+        drop(host_info);
+        drop(metrics);
+        let host = self.available.swap_remove(i);
+        Some((host, InflightGuard::new(counter)))
     }
 
-    /// Releases a host whose write failed. Removes it from `claimed` so it
-    /// can be re-picked while its attempt count is still under
-    /// [`MAX_HOST_RETRIES`]. The attempt count itself is kept so the cap
-    /// continues to apply.
-    pub(crate) fn release_failed(&mut self, host: &PublicKey) {
-        self.claimed.remove(host);
+    /// Returns a failed host to the pool so it can be re-picked. Returns
+    /// `true` when the host went back into `available`, `false` when its
+    /// per-slab attempt budget is exhausted.
+    pub(crate) fn retry(&mut self, host: PublicKey) -> bool {
+        let attempts = self.attempts.entry(host).or_default();
+        *attempts += 1;
+        if *attempts >= MAX_RETRIES {
+            return false;
+        }
+        self.available.push(host);
+        true
     }
 }
 
@@ -623,12 +614,13 @@ impl<T: Transport> Hosts<T> {
         self.hosts.available_for_upload()
     }
 
-    /// Creates a per-slab `UsedHosts` accumulator. It enforces slab
-    /// uniqueness (no two shards in a slab can land on the same host) and
-    /// caps how many times a single host can be re-picked across the
-    /// slab's shards. Each upload slab should construct its own.
-    pub fn slab_host_picker(&self) -> UsedHosts {
-        UsedHosts::new(self.hosts.clone())
+    /// Creates a per-slab [`HostQueue`] seeded with the currently
+    /// upload-eligible hosts. The queue enforces slab uniqueness (each
+    /// host can be picked at most once until retried) and caps re-picks
+    /// per host via [`MAX_RETRIES`]. Each upload slab should construct
+    /// its own.
+    pub fn slab_host_picker(&self) -> HostQueue {
+        HostQueue::new(self.hosts.clone(), self.hosts.upload_eligible_hosts())
     }
 
     /// Reserves an inflight slot for a download from the given host. The
@@ -980,7 +972,7 @@ mod test {
     }
 
     #[sia_core_derive::cross_target_test]
-    fn test_used_hosts_pick() {
+    fn test_host_queue_pick() {
         let hosts_manager = Hosts::new(Client::new());
         let hk1 = random_pubkey();
         let hk2 = random_pubkey();
@@ -1018,20 +1010,20 @@ mod test {
         // With no samples and no inflight, both hk1 and hk3 are eligible
         // and have equal score; result is deterministic-enough — we just
         // assert it returns one of them, and that hk2 (not good_for_upload)
-        // is never picked.
-        let mut used = hosts_manager.slab_host_picker();
-        let (first, first_guard) = used.pick().unwrap();
+        // is never in the pool.
+        let mut queue = hosts_manager.slab_host_picker();
+        let (first, first_guard) = queue.pick().unwrap();
         assert!(first == hk1 || first == hk3);
         assert_ne!(first, hk2);
 
-        // Second pick excludes the first via the `claimed` set.
-        let (second, second_guard) = used.pick().unwrap();
+        // Second pick consumes the other eligible host.
+        let (second, second_guard) = queue.pick().unwrap();
         assert!(second == hk1 || second == hk3);
         assert_ne!(second, first);
         assert_ne!(second, hk2);
 
-        // Both eligible hosts now claimed — no more picks available.
-        assert!(used.pick().is_none());
+        // Pool empty — no more picks available.
+        assert!(queue.pick().is_none());
 
         // Drop the guards explicitly so the counters balance.
         drop(first_guard);
@@ -1039,9 +1031,9 @@ mod test {
     }
 
     #[sia_core_derive::cross_target_test]
-    fn test_used_hosts_retry_cap() {
-        // release_failed lets a host be re-picked, but MAX_HOST_RETRIES caps
-        // total picks per host across the slab.
+    fn test_host_queue_retry_cap() {
+        // `retry` lets a host be re-picked, but MAX_RETRIES caps the total
+        // attempts per host across the slab.
         let hosts_manager = Hosts::new(Client::new());
         let hk = random_pubkey();
         hosts_manager.update(
@@ -1056,14 +1048,16 @@ mod test {
             true,
         );
 
-        let mut used = hosts_manager.slab_host_picker();
-        for _ in 0..MAX_HOST_RETRIES {
-            let (picked, guard) = used.pick().unwrap();
+        let mut queue = hosts_manager.slab_host_picker();
+        for i in 0..MAX_RETRIES {
+            let (picked, guard) = queue.pick().unwrap();
             assert_eq!(picked, hk);
-            used.release_failed(&picked);
             drop(guard);
+            let pushed = queue.retry(picked);
+            let expected = i < MAX_RETRIES - 1;
+            assert_eq!(pushed, expected, "retry #{i} returned wrong value");
         }
-        assert!(used.pick().is_none(), "should respect retry cap");
+        assert!(queue.pick().is_none(), "should respect retry cap");
     }
 
     #[sia_core_derive::cross_target_test]

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -363,14 +363,18 @@ impl HostList {
     /// pickers see the new load — the race window shrinks from "until the
     /// RPC starts" to the scan in this function (microseconds).
     ///
-    /// Score is `throughput / (inflight + 1)`; lower `failure_rate` wins
-    /// first. Returns `None` if no eligible host is available.
-    fn next_upload_host(&self, exclude: &HashSet<PublicKey>) -> Option<(PublicKey, InflightGuard)> {
+    /// `is_excluded` is called for each candidate; returning `true` skips
+    /// it. Score is `throughput / (inflight + 1)`; lower `failure_rate`
+    /// wins first. Returns `None` if no eligible host is available.
+    fn next_upload_host<F>(&self, mut is_excluded: F) -> Option<(PublicKey, InflightGuard)>
+    where
+        F: FnMut(&PublicKey) -> bool,
+    {
         let hosts = self.hosts.read().unwrap();
         let metrics = self.metrics.read().unwrap();
         let mut best: Option<(PublicKey, Arc<AtomicUsize>, HostScore)> = None;
         for (hk, info) in hosts.iter() {
-            if !info.good_for_upload || exclude.contains(hk) {
+            if !info.good_for_upload || is_excluded(hk) {
                 continue;
             }
             let Some(metric) = metrics.get(hk) else {
@@ -431,6 +435,69 @@ impl HostList {
 
     fn add_settings_sample(&self, host_key: PublicKey, elapsed: Duration) {
         self.with_metric(&host_key, |m| m.add_settings_sample(elapsed));
+    }
+}
+
+/// Maximum number of times a single host may be picked across all shards
+/// in a slab. A host with a transient failure should get a few more
+/// chances within the slab rather than being permanently sidelined on the
+/// first error.
+const MAX_HOST_RETRIES: usize = 3;
+
+/// Per-slab host accounting. Tracks two things:
+/// - `claimed`: hosts currently in flight, or holding a successful sector
+///   on this slab. Excluded from picks so no two shards in the slab can
+///   both succeed on the same host (slab uniqueness; the indexer rejects
+///   duplicate hosts in a slab).
+/// - `attempts`: per-host pick count. A host that hits [`MAX_HOST_RETRIES`]
+///   is permanently off-limits for the slab.
+///
+/// Lifecycle for a host:
+/// - `pick` → attempt count +1, added to claimed.
+/// - Write succeeds → stays in claimed forever. Attempt count irrelevant.
+/// - Write fails → `release_failed` removes from claimed; attempts stays
+///   incremented. Another shard (or a retry within the same shard) can
+///   re-pick the host while its attempts < `MAX_HOST_RETRIES`.
+pub(crate) struct UsedHosts {
+    hosts: Arc<HostList>,
+    claimed: HashSet<PublicKey>,
+    attempts: HashMap<PublicKey, usize>,
+}
+
+impl UsedHosts {
+    fn new(hosts: Arc<HostList>) -> Self {
+        Self {
+            hosts,
+            claimed: HashSet::new(),
+            attempts: HashMap::new(),
+        }
+    }
+
+    /// Atomically picks the best upload host for another shard in this slab
+    /// and reserves an inflight slot on it. Skips hosts currently held in
+    /// `claimed` or whose attempt count has reached [`MAX_HOST_RETRIES`].
+    /// The returned [`InflightGuard`] must be held for the duration of the
+    /// upload RPC so concurrent pickers see the load.
+    pub(crate) fn pick(&mut self) -> Option<(PublicKey, InflightGuard)> {
+        let Self {
+            hosts,
+            claimed,
+            attempts,
+        } = self;
+        let (host, guard) = hosts.next_upload_host(|hk| {
+            claimed.contains(hk) || attempts.get(hk).is_some_and(|n| *n >= MAX_HOST_RETRIES)
+        })?;
+        *attempts.entry(host).or_insert(0) += 1;
+        claimed.insert(host);
+        Some((host, guard))
+    }
+
+    /// Releases a host whose write failed. Removes it from `claimed` so it
+    /// can be re-picked while its attempt count is still under
+    /// [`MAX_HOST_RETRIES`]. The attempt count itself is kept so the cap
+    /// continues to apply.
+    pub(crate) fn release_failed(&mut self, host: &PublicKey) {
+        self.claimed.remove(host);
     }
 }
 
@@ -556,22 +623,12 @@ impl<T: Transport> Hosts<T> {
         self.hosts.available_for_upload()
     }
 
-    /// Atomically picks the best upload host for another shard and reserves
-    /// an inflight slot on it. The returned [`InflightGuard`] must be kept
-    /// alive for the duration of the upload — drop it to roll the
-    /// reservation back on failure. Selection and reservation happen under
-    /// the same lock so concurrent pickers can't all observe the same low
-    /// inflight count and pile onto the same host.
-    ///
-    /// The scorer favors the host with the highest
-    /// `throughput / (inflight + 1)` — best expected per-shard throughput
-    /// if you added one more shard. Returns `None` if no eligible host is
-    /// available.
-    pub fn next_upload_host(
-        &self,
-        exclude: &HashSet<PublicKey>,
-    ) -> Option<(PublicKey, InflightGuard)> {
-        self.hosts.next_upload_host(exclude)
+    /// Creates a per-slab `UsedHosts` accumulator. It enforces slab
+    /// uniqueness (no two shards in a slab can land on the same host) and
+    /// caps how many times a single host can be re-picked across the
+    /// slab's shards. Each upload slab should construct its own.
+    pub fn slab_host_picker(&self) -> UsedHosts {
+        UsedHosts::new(self.hosts.clone())
     }
 
     /// Reserves an inflight slot for a download from the given host. The
@@ -813,7 +870,11 @@ mod test {
         );
 
         avg.add_sample(100);
-        assert_eq!(avg.avg(), Some(100.0), "initial average should be first sample");
+        assert_eq!(
+            avg.avg(),
+            Some(100.0),
+            "initial average should be first sample"
+        );
 
         avg.add_sample(200);
         assert!(
@@ -919,7 +980,7 @@ mod test {
     }
 
     #[sia_core_derive::cross_target_test]
-    fn test_next_upload_host() {
+    fn test_used_hosts_pick() {
         let hosts_manager = Hosts::new(Client::new());
         let hk1 = random_pubkey();
         let hk2 = random_pubkey();
@@ -958,25 +1019,51 @@ mod test {
         // and have equal score; result is deterministic-enough — we just
         // assert it returns one of them, and that hk2 (not good_for_upload)
         // is never picked.
-        let mut exclude = HashSet::new();
-        let (first, first_guard) = hosts_manager.next_upload_host(&exclude).unwrap();
+        let mut used = hosts_manager.slab_host_picker();
+        let (first, first_guard) = used.pick().unwrap();
         assert!(first == hk1 || first == hk3);
         assert_ne!(first, hk2);
 
-        // Excluding the first picks the other upload-eligible host.
-        exclude.insert(first);
-        let (second, second_guard) = hosts_manager.next_upload_host(&exclude).unwrap();
+        // Second pick excludes the first via the `claimed` set.
+        let (second, second_guard) = used.pick().unwrap();
         assert!(second == hk1 || second == hk3);
         assert_ne!(second, first);
         assert_ne!(second, hk2);
 
-        // Excluding both leaves nothing.
-        exclude.insert(second);
-        assert!(hosts_manager.next_upload_host(&exclude).is_none());
+        // Both eligible hosts now claimed — no more picks available.
+        assert!(used.pick().is_none());
 
         // Drop the guards explicitly so the counters balance.
         drop(first_guard);
         drop(second_guard);
+    }
+
+    #[sia_core_derive::cross_target_test]
+    fn test_used_hosts_retry_cap() {
+        // release_failed lets a host be re-picked, but MAX_HOST_RETRIES caps
+        // total picks per host across the slab.
+        let hosts_manager = Hosts::new(Client::new());
+        let hk = random_pubkey();
+        hosts_manager.update(
+            vec![Host {
+                public_key: hk,
+                addresses: vec![],
+                country_code: String::new(),
+                latitude: 0.0,
+                longitude: 0.0,
+                good_for_upload: true,
+            }],
+            true,
+        );
+
+        let mut used = hosts_manager.slab_host_picker();
+        for _ in 0..MAX_HOST_RETRIES {
+            let (picked, guard) = used.pick().unwrap();
+            assert_eq!(picked, hk);
+            used.release_failed(&picked);
+            drop(guard);
+        }
+        assert!(used.pick().is_none(), "should respect retry cap");
     }
 
     #[sia_core_derive::cross_target_test]

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -253,9 +253,10 @@ impl PartialOrd for HostScore {
 struct HostInfo {
     addresses: Vec<NetAddress>,
     good_for_upload: bool,
-    /// Number of upload RPCs currently in flight to this host. Updated by
-    /// an [`InflightGuard`] in `Hosts::write_sector`; read by the host
-    /// scorer in `next_upload_host`.
+    /// Number of upload RPCs currently in flight to this host. The guard
+    /// is created by [`HostQueue::pick`] (incrementing this counter as
+    /// part of the selection path) and dropped when the spawned upload
+    /// task exits. Read by the scorer inside [`HostQueue::pick`].
     inflight_uploads: Arc<AtomicUsize>,
     /// Number of download RPCs currently in flight to this host. Updated
     /// by an [`InflightGuard`] in `Hosts::read_sector`; read by
@@ -413,85 +414,6 @@ impl HostList {
     }
 }
 
-/// Maximum number of attempts per host within a single slab — initial
-/// pick plus retries. A host with a transient failure should get a few
-/// more chances within the slab rather than being permanently sidelined
-/// on the first error.
-const MAX_RETRIES: usize = 3;
-
-/// Per-slab pool of upload hosts. Snapshots upload-eligible hosts at
-/// construction and hands them out one at a time. Failed hosts can be
-/// returned via [`HostQueue::retry`] for re-pick, capped at
-/// [`MAX_RETRIES`] attempts per host across the slab.
-///
-/// `available` is a snapshot, not a live view of [`HostList`]: hosts
-/// removed via [`Hosts::update`] after construction stay in the pool but
-/// are filtered at pick time when they no longer exist in `HostList`.
-/// Slabs live for seconds, so snapshot staleness doesn't materially
-/// affect placement.
-pub(crate) struct HostQueue {
-    hosts: Arc<HostList>,
-    available: Vec<PublicKey>,
-    attempts: HashMap<PublicKey, usize>,
-}
-
-impl HostQueue {
-    fn new(hosts: Arc<HostList>, available: Vec<PublicKey>) -> Self {
-        Self {
-            hosts,
-            available,
-            attempts: HashMap::new(),
-        }
-    }
-
-    /// Picks the best host from the pool and atomically reserves an
-    /// inflight slot. Scoring matches [`HostScore`]: lower `failure_rate`
-    /// wins, then unsampled hosts outrank sampled (discovery), then
-    /// `throughput / (inflight + 1)` among sampled. The winner is removed
-    /// from `available`; the returned [`InflightGuard`] must be held for
-    /// the duration of the upload RPC so concurrent pickers see the load.
-    pub(crate) fn pick(&mut self) -> Option<(PublicKey, InflightGuard)> {
-        let host_info = self.hosts.hosts.read().unwrap();
-        let metrics = self.hosts.metrics.read().unwrap();
-        let mut best: Option<(usize, HostScore, Arc<AtomicUsize>)> = None;
-        for (i, hk) in self.available.iter().enumerate() {
-            let Some(info) = host_info.get(hk) else {
-                continue;
-            };
-            let Some(metric) = metrics.get(hk) else {
-                continue;
-            };
-            let inflight = info.inflight_uploads.load(Ordering::Relaxed);
-            let score = HostScore::new(metric, inflight);
-            match &best {
-                None => best = Some((i, score, info.inflight_uploads.clone())),
-                Some((_, current, _)) if score > *current => {
-                    best = Some((i, score, info.inflight_uploads.clone()))
-                }
-                _ => {}
-            }
-        }
-        let (i, _, counter) = best?;
-        drop(host_info);
-        drop(metrics);
-        let host = self.available.swap_remove(i);
-        Some((host, InflightGuard::new(counter)))
-    }
-
-    /// Returns a failed host to the pool so it can be re-picked. Returns
-    /// `true` when the host went back into `available`, `false` when its
-    /// per-slab attempt budget is exhausted.
-    pub(crate) fn retry(&mut self, host: PublicKey) -> bool {
-        let attempts = self.attempts.entry(host).or_default();
-        *attempts += 1;
-        if *attempts >= MAX_RETRIES {
-            return false;
-        }
-        self.available.push(host);
-        true
-    }
-}
-
 /// RAII guard that increments an `AtomicUsize` on construction and
 /// decrements it on drop. Used to track per-host inflight uploads so the
 /// host scorer reflects current load and is balanced even on early returns
@@ -619,7 +541,7 @@ impl<T: Transport> Hosts<T> {
     /// host can be picked at most once until retried) and caps re-picks
     /// per host via [`MAX_RETRIES`]. Each upload slab should construct
     /// its own.
-    pub fn slab_host_picker(&self) -> HostQueue {
+    pub fn upload_queue(&self) -> HostQueue {
         HostQueue::new(self.hosts.clone(), self.hosts.upload_eligible_hosts())
     }
 
@@ -713,9 +635,8 @@ impl<T: Transport> Hosts<T> {
     }
 
     /// Performs an upload RPC to the given host. The caller is responsible
-    /// for holding the [`InflightGuard`] returned by
-    /// [`Self::next_upload_host`] for the duration of this call so the
-    /// host scorer reflects the load.
+    /// for holding the [`InflightGuard`] returned by [`HostQueue::pick`]
+    /// for the duration of this call so the host scorer reflects the load.
     pub async fn write_sector(
         &self,
         host_key: PublicKey,
@@ -803,6 +724,85 @@ pub enum QueueError {
     /// The host has been retried too many times.
     #[error("host retry limit exceeded")]
     MaxRetriesExceeded,
+}
+
+/// Maximum number of attempts per host within a single slab — initial
+/// pick plus retries. A host with a transient failure should get a few
+/// more chances within the slab rather than being permanently sidelined
+/// on the first error.
+const MAX_RETRIES: usize = 3;
+
+/// Per-slab pool of upload hosts. Snapshots upload-eligible hosts at
+/// construction and hands them out one at a time. Failed hosts can be
+/// returned via [`HostQueue::retry`] for re-pick, capped at
+/// [`MAX_RETRIES`] attempts per host across the slab.
+///
+/// `available` is a snapshot, not a live view of [`HostList`]: hosts
+/// removed via [`Hosts::update`] after construction stay in the pool but
+/// are filtered at pick time when they no longer exist in `HostList`.
+/// Slabs live for seconds, so snapshot staleness doesn't materially
+/// affect placement.
+pub(crate) struct HostQueue {
+    hosts: Arc<HostList>,
+    available: Vec<PublicKey>,
+    attempts: HashMap<PublicKey, usize>,
+}
+
+impl HostQueue {
+    fn new(hosts: Arc<HostList>, available: Vec<PublicKey>) -> Self {
+        Self {
+            hosts,
+            available,
+            attempts: HashMap::new(),
+        }
+    }
+
+    /// Picks the best host from the pool and atomically reserves an
+    /// inflight slot. Scoring matches [`HostScore`]: lower `failure_rate`
+    /// wins, then unsampled hosts outrank sampled (discovery), then
+    /// `throughput / (inflight + 1)` among sampled. The winner is removed
+    /// from `available`; the returned [`InflightGuard`] must be held for
+    /// the duration of the upload RPC so concurrent pickers see the load.
+    pub(crate) fn pick(&mut self) -> Option<(PublicKey, InflightGuard)> {
+        let host_info = self.hosts.hosts.read().unwrap();
+        let metrics = self.hosts.metrics.read().unwrap();
+        let mut best: Option<(usize, HostScore, Arc<AtomicUsize>)> = None;
+        for (i, hk) in self.available.iter().enumerate() {
+            let Some(info) = host_info.get(hk) else {
+                continue;
+            };
+            let Some(metric) = metrics.get(hk) else {
+                continue;
+            };
+            let inflight = info.inflight_uploads.load(Ordering::Relaxed);
+            let score = HostScore::new(metric, inflight);
+            match &best {
+                None => best = Some((i, score, info.inflight_uploads.clone())),
+                Some((_, current, _)) if score > *current => {
+                    best = Some((i, score, info.inflight_uploads.clone()))
+                }
+                _ => {}
+            }
+        }
+        let (i, _, counter) = best?;
+        drop(host_info);
+        drop(metrics);
+        let host = self.available.swap_remove(i);
+        Some((host, InflightGuard::new(counter)))
+    }
+
+    /// Returns a failed host to the pool so it can be re-picked. Returns
+    /// `true` when the host went back into `available`, `false` when its
+    /// per-slab attempt budget is exhausted.
+    pub(crate) fn retry(&mut self, host: PublicKey) -> bool {
+        let attempts = self.attempts.entry(host).or_default();
+        *attempts += 1;
+        if *attempts >= MAX_RETRIES {
+            return false;
+        }
+        self.available.push(host);
+        true
+    }
 }
 
 #[cfg(test)]
@@ -1011,7 +1011,7 @@ mod test {
         // and have equal score; result is deterministic-enough — we just
         // assert it returns one of them, and that hk2 (not good_for_upload)
         // is never in the pool.
-        let mut queue = hosts_manager.slab_host_picker();
+        let mut queue = hosts_manager.upload_queue();
         let (first, first_guard) = queue.pick().unwrap();
         assert!(first == hk1 || first == hk3);
         assert_ne!(first, hk2);
@@ -1048,7 +1048,7 @@ mod test {
             true,
         );
 
-        let mut queue = hosts_manager.slab_host_picker();
+        let mut queue = hosts_manager.upload_queue();
         for i in 0..MAX_RETRIES {
             let (picked, guard) = queue.pick().unwrap();
             assert_eq!(picked, hk);

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -334,7 +334,7 @@ impl DownloadOptions {
 impl Default for DownloadOptions {
     fn default() -> Self {
         Self {
-            max_inflight: 80, // ~20 MiB in memory
+            max_inflight: 270, // ~20 MiB in memory
             offset: 0,
             length: None,
             shard_downloaded: None,
@@ -462,7 +462,7 @@ impl Default for UploadOptions {
         Self {
             data_shards: 10,
             parity_shards: 20,
-            max_inflight: 15,
+            max_inflight: 90,
             shard_uploaded: None,
         }
     }

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -334,7 +334,7 @@ impl DownloadOptions {
 impl Default for DownloadOptions {
     fn default() -> Self {
         Self {
-            max_inflight: 270, // ~20 MiB in memory
+            max_inflight: 80, // ~20 MiB in memory
             offset: 0,
             length: None,
             shard_downloaded: None,
@@ -462,7 +462,7 @@ impl Default for UploadOptions {
         Self {
             data_shards: 10,
             parity_shards: 20,
-            max_inflight: 90,
+            max_inflight: 15,
             shard_uploaded: None,
         }
     }

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -1,10 +1,10 @@
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::io;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::encryption::{EncryptionKey, encrypt_shard};
 use crate::erasure_coding::{self, ErasureCoder, ReadSlab, SlabReader};
-use crate::hosts::{HostQueue, QueueError, RPCError};
+use crate::hosts::{QueueError, RPCError};
 use crate::rhp4::Client;
 use crate::task::AbortOnDropHandle;
 use crate::time::{Duration, Elapsed, Instant, sleep};
@@ -23,11 +23,12 @@ use tokio::task::JoinSet;
 struct ShardUpload {
     semaphore: Arc<Semaphore>,
     client: Hosts<Client>,
-    hosts: HostQueue,
     account_key: Arc<AppKey>,
     data: Bytes,
     slab_index: usize,
     shard_index: usize,
+    // Tracks hosts already used by any shard in this slab.
+    used_hosts: Arc<Mutex<HashSet<PublicKey>>>,
 }
 
 struct SectorUploadResult {
@@ -47,7 +48,6 @@ impl ShardUpload {
         permit: OwnedSemaphorePermit,
     ) {
         let client = self.client.clone();
-        let hosts = self.hosts.clone();
         let account_key = self.account_key.clone();
         let data = self.data.clone();
         let slab_index = self.slab_index;
@@ -61,7 +61,6 @@ impl ShardUpload {
                         "slab {slab_index} shard {shard_index} upload to host {host_key} failed after {:?} {e}",
                         now.elapsed()
                     );
-                    let _ = hosts.retry(host_key);
                 })?;
             let elapsed = now.elapsed();
             debug!(
@@ -76,10 +75,22 @@ impl ShardUpload {
         });
     }
 
-    async fn upload_shard(self, host_key: PublicKey) -> Result<SectorUploadResult, UploadError> {
+    /// Atomically pick the next-best host for this shard and reserve it
+    /// against the slab's `slab_used` set so no other shard in the slab
+    /// picks the same host. Returns `None` only when no eligible host
+    /// remains.
+    fn pick_next_host(&self) -> Option<PublicKey> {
+        let mut used = self.used_hosts.lock().unwrap();
+        let next = self.client.next_upload_host(&used)?;
+        used.insert(next);
+        Some(next)
+    }
+
+    async fn upload_shard(self) -> Result<SectorUploadResult, UploadError> {
         let permit = self.semaphore.clone().acquire_owned().await?;
+        let initial = self.pick_next_host().ok_or(QueueError::NoMoreHosts)?;
         let mut tasks = JoinSet::new();
-        self.spawn_write(&mut tasks, host_key, UPLOAD_TIMEOUT, permit);
+        self.spawn_write(&mut tasks, initial, UPLOAD_TIMEOUT, permit);
         loop {
             let active = tasks.len();
             tokio::select! {
@@ -87,32 +98,37 @@ impl ShardUpload {
                 Some(res) = tasks.join_next() => {
                     match res? {
                         Ok(result) => {
-                            if result.sector.host_key != host_key {
+                            if result.sector.host_key != initial {
                                 debug!(
                                     "slab {} shard {} penalizing original host {}",
-                                    self.slab_index, self.shard_index, host_key
+                                    self.slab_index, self.shard_index, initial
                                 );
-                                self.client.add_failure(host_key)
+                                self.client.add_failure(initial)
                             }
                             return Ok(result);
                         }
                         Err(_) => {
+                            // write_sector already incremented failure_rate
+                            // on its error path, dropping the host's score.
+                            // Pick the next best host not already used by
+                            // any shard in this slab.
                             if tasks.is_empty() {
-                                let host_key = self.hosts.pop_front()?;
+                                let next = self.pick_next_host()
+                                    .ok_or(QueueError::NoMoreHosts)?;
                                 let permit = self.semaphore.clone().acquire_owned().await?;
-                                self.spawn_write(&mut tasks, host_key, UPLOAD_TIMEOUT, permit);
+                                self.spawn_write(&mut tasks, next, UPLOAD_TIMEOUT, permit);
                             }
                         }
                     }
                 },
                 _ = sleep(Duration::from_secs(active.max(1) as u64)) => {
                     if let Ok(racer) = self.semaphore.clone().try_acquire_owned()
-                        && let Ok(host_key) = self.hosts.pop_front() {
+                        && let Some(next) = self.pick_next_host() {
                             debug!(
-                                "slab {} shard {} racing slow host",
+                                "slab {} shard {} racing slow host with {next}",
                                 self.slab_index, self.shard_index
                             );
-                            self.spawn_write(&mut tasks, host_key, UPLOAD_TIMEOUT, racer);
+                            self.spawn_write(&mut tasks, next, UPLOAD_TIMEOUT, racer);
                         }
                 }
             }
@@ -262,20 +278,28 @@ impl Upload {
                 Ok::<_, UploadError>(shards)
             })?;
 
-            let hosts = client.upload_queue();
-            let initial_hosts = hosts.pop_n(total_shards)?;
+            // No pre-assignment of hosts: each shard picks its host
+            // just-in-time via `Hosts::next_upload_host`, which scores by
+            // `throughput / (inflight + 1)`. This disperses load across
+            // hosts naturally — multiple slabs running in parallel won't
+            // all pile onto the same top-N hosts, because by the time
+            // slab N+1's shards pick, slab N's chosen hosts have higher
+            // inflight and lower score.
+            //
+            // `used_hosts` enforces that every shard within this slab lands
+            // on a distinct host (the indexer rejects duplicate sectors
+            // because they break redundancy). Every host any shard picks
+            // — initial, retry, or racer — is added to the set.
+            let used_hosts: Arc<Mutex<HashSet<PublicKey>>> =
+                Arc::new(Mutex::new(HashSet::with_capacity(total_shards)));
             let owned_slab_key = Arc::new(slab_key.clone());
             let mut shard_tasks: JoinSet<Result<SectorUploadResult, UploadError>> = JoinSet::new();
-            for (shard_index, (mut shard, initial_host)) in shards
-                .into_iter()
-                .zip(initial_hosts.into_iter())
-                .enumerate()
-            {
+            for (shard_index, mut shard) in shards.into_iter().enumerate() {
                 let owned_slab_key = owned_slab_key.clone();
                 let shard_client = client.clone();
-                let shard_hosts = hosts.clone();
                 let shard_account_key = app_key.clone();
                 let shard_sema_inner = shard_sema.clone();
+                let used_hosts = used_hosts.clone();
                 join_set_spawn!(shard_tasks, async move {
                     let shard = maybe_spawn_blocking!({
                         encrypt_shard(&owned_slab_key, shard_index as u8, 0, &mut shard);
@@ -284,13 +308,13 @@ impl Upload {
                     let shard_upload = ShardUpload {
                         semaphore: shard_sema_inner,
                         client: shard_client,
-                        hosts: shard_hosts,
                         account_key: shard_account_key,
                         data: Bytes::from(shard),
                         slab_index,
                         shard_index,
+                        used_hosts,
                     };
-                    shard_upload.upload_shard(initial_host).await
+                    shard_upload.upload_shard().await
                 });
             }
 

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io;
 use std::sync::{Arc, Mutex};
 
@@ -20,6 +20,62 @@ use tokio::io::{AsyncRead, BufReader};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinSet;
 
+/// Maximum number of times a single host may be picked across all shards
+/// in a slab. Mirrors the cap from the old `HostQueue::retry` behavior so
+/// a host with a transient failure can still get a few more chances within
+/// the same slab, rather than being permanently sidelined on the first error.
+const MAX_HOST_RETRIES: usize = 3;
+
+/// Per-slab host accounting. Tracks two things:
+/// - `claimed`: hosts currently in flight, or holding a successful sector
+///   on this slab. Excluded from picks so no two shards in the slab can
+///   both succeed on the same host (slab uniqueness; the indexer rejects
+///   duplicate hosts in a slab).
+/// - `attempts`: per-host pick count. A host that hits [`MAX_HOST_RETRIES`]
+///   is permanently off-limits for the slab.
+///
+/// Lifecycle for a host:
+/// - `pick` → attempt count +1, added to claimed.
+/// - Write succeeds → stays in claimed forever. Attempt count irrelevant.
+/// - Write fails → `release_failed` removes from claimed; attempts stays
+///   incremented. Another shard (or a retry within the same shard) can
+///   re-pick the host while its attempts < `MAX_HOST_RETRIES`.
+#[derive(Default)]
+struct UsedHosts {
+    claimed: HashSet<PublicKey>,
+    attempts: HashMap<PublicKey, usize>,
+}
+
+impl UsedHosts {
+    /// Pick the best host that's neither currently claimed nor has
+    /// exhausted its retry budget. Marks the result as claimed and bumps
+    /// its attempt counter.
+    fn pick(&mut self, client: &Hosts<Client>) -> Option<PublicKey> {
+        let exclude: HashSet<PublicKey> = self
+            .claimed
+            .iter()
+            .copied()
+            .chain(
+                self.attempts
+                    .iter()
+                    .filter_map(|(k, n)| (*n >= MAX_HOST_RETRIES).then_some(*k)),
+            )
+            .collect();
+        let host = client.next_upload_host(&exclude)?;
+        *self.attempts.entry(host).or_insert(0) += 1;
+        self.claimed.insert(host);
+        Some(host)
+    }
+
+    /// Release a host whose write failed. Removes it from `claimed` so it
+    /// can be re-picked (by this shard or another) while its attempt count
+    /// is still under [`MAX_HOST_RETRIES`]. The attempt count itself is
+    /// kept so the cap continues to apply.
+    fn release_failed(&mut self, host: &PublicKey) {
+        self.claimed.remove(host);
+    }
+}
+
 struct ShardUpload {
     semaphore: Arc<Semaphore>,
     client: Hosts<Client>,
@@ -27,8 +83,8 @@ struct ShardUpload {
     data: Bytes,
     slab_index: usize,
     shard_index: usize,
-    // Tracks hosts already used by any shard in this slab.
-    used_hosts: Arc<Mutex<HashSet<PublicKey>>>,
+    /// Per-slab host accounting shared across all shards.
+    used_hosts: Arc<Mutex<UsedHosts>>,
 }
 
 struct SectorUploadResult {
@@ -42,7 +98,7 @@ const UPLOAD_TIMEOUT: Duration = Duration::from_secs(90);
 impl ShardUpload {
     fn spawn_write(
         &self,
-        tasks: &mut JoinSet<Result<SectorUploadResult, UploadError>>,
+        tasks: &mut JoinSet<(PublicKey, Result<SectorUploadResult, UploadError>)>,
         host_key: PublicKey,
         write_timeout: Duration,
         permit: OwnedSemaphorePermit,
@@ -55,35 +111,39 @@ impl ShardUpload {
         join_set_spawn!(tasks, async move {
             let _permit = permit;
             let now = Instant::now();
-            let root = client.write_sector(host_key, &account_key.0, data, write_timeout).await
-                .inspect_err(|e| {
+            let result: Result<SectorUploadResult, UploadError> = match client
+                .write_sector(host_key, &account_key.0, data, write_timeout)
+                .await
+            {
+                Ok(root) => {
+                    let elapsed = now.elapsed();
+                    debug!(
+                        "slab {slab_index} shard {shard_index} uploaded to {host_key} in {:?}",
+                        elapsed
+                    );
+                    Ok(SectorUploadResult {
+                        sector: Sector { root, host_key },
+                        shard_index,
+                        elapsed,
+                    })
+                }
+                Err(e) => {
                     debug!(
                         "slab {slab_index} shard {shard_index} upload to host {host_key} failed after {:?} {e}",
                         now.elapsed()
                     );
-                })?;
-            let elapsed = now.elapsed();
-            debug!(
-                "slab {slab_index} shard {shard_index} uploaded to {host_key} in {:?}",
-                elapsed
-            );
-            Ok(SectorUploadResult {
-                sector: Sector { root, host_key },
-                shard_index,
-                elapsed,
-            })
+                    Err(UploadError::from(e))
+                }
+            };
+            (host_key, result)
         });
     }
 
-    /// Atomically pick the next-best host for this shard and reserve it
-    /// against the slab's `slab_used` set so no other shard in the slab
-    /// picks the same host. Returns `None` only when no eligible host
-    /// remains.
+    /// Atomically pick the next-best host for this shard, respecting the
+    /// slab's host accounting: skip hosts currently in flight, holding a
+    /// successful sector, or that have exhausted their retry budget.
     fn pick_next_host(&self) -> Option<PublicKey> {
-        let mut used = self.used_hosts.lock().unwrap();
-        let next = self.client.next_upload_host(&used)?;
-        used.insert(next);
-        Some(next)
+        self.used_hosts.lock().unwrap().pick(&self.client)
     }
 
     async fn upload_shard(self) -> Result<SectorUploadResult, UploadError> {
@@ -96,7 +156,8 @@ impl ShardUpload {
             tokio::select! {
                 biased;
                 Some(res) = tasks.join_next() => {
-                    match res? {
+                    let (host_key, write_result) = res?;
+                    match write_result {
                         Ok(result) => {
                             if result.sector.host_key != initial {
                                 debug!(
@@ -108,10 +169,11 @@ impl ShardUpload {
                             return Ok(result);
                         }
                         Err(_) => {
-                            // write_sector already incremented failure_rate
-                            // on its error path, dropping the host's score.
-                            // Pick the next best host not already used by
-                            // any shard in this slab.
+                            // write_sector already updated the host's
+                            // failure_rate on the error path. Release it
+                            // from `claimed` so it can be re-picked within
+                            // its retry budget.
+                            self.used_hosts.lock().unwrap().release_failed(&host_key);
                             if tasks.is_empty() {
                                 let next = self.pick_next_host()
                                     .ok_or(QueueError::NoMoreHosts)?;
@@ -286,14 +348,19 @@ impl Upload {
             // slab N+1's shards pick, slab N's chosen hosts have higher
             // inflight and lower score.
             //
-            // `used_hosts` enforces that every shard within this slab lands
-            // on a distinct host (the indexer rejects duplicate sectors
-            // because they break redundancy). Every host any shard picks
-            // — initial, retry, or racer — is added to the set.
-            let used_hosts: Arc<Mutex<HashSet<PublicKey>>> =
-                Arc::new(Mutex::new(HashSet::with_capacity(total_shards)));
+            // `used_hosts` enforces slab uniqueness — every shard within
+            // this slab must land on a distinct host (the indexer rejects
+            // duplicate sectors because they break redundancy) — while
+            // also allowing failed hosts to be re-picked up to
+            // `MAX_HOST_RETRIES` times across the slab.
+            let used_hosts: Arc<Mutex<UsedHosts>> =
+                Arc::new(Mutex::new(UsedHosts::default()));
             let owned_slab_key = Arc::new(slab_key.clone());
-            let mut shard_tasks: JoinSet<Result<SectorUploadResult, UploadError>> = JoinSet::new();
+            // ShardUpload::upload_shard returns Result<SectorUploadResult, UploadError>
+            // (one settled result per shard — not the per-attempt tuple
+            // that spawn_write uses inside upload_shard).
+            let mut shard_tasks: JoinSet<Result<SectorUploadResult, UploadError>> =
+                JoinSet::new();
             for (shard_index, mut shard) in shards.into_iter().enumerate() {
                 let owned_slab_key = owned_slab_key.clone();
                 let shard_client = client.clone();

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -23,12 +23,11 @@ use tokio::task::JoinSet;
 struct ShardUpload {
     semaphore: Arc<Semaphore>,
     client: Hosts<Client>,
+    hosts: Arc<Mutex<HostQueue>>,
     account_key: Arc<AppKey>,
     data: Bytes,
     slab_index: usize,
     shard_index: usize,
-    /// Per-slab host pool shared across all shards.
-    queue: Arc<Mutex<HostQueue>>,
 }
 
 struct SectorUploadResult {
@@ -42,13 +41,14 @@ const UPLOAD_TIMEOUT: Duration = Duration::from_secs(90);
 impl ShardUpload {
     fn spawn_write(
         &self,
-        tasks: &mut JoinSet<(PublicKey, Result<SectorUploadResult, UploadError>)>,
+        tasks: &mut JoinSet<Result<SectorUploadResult, UploadError>>,
         host_key: PublicKey,
         inflight: InflightGuard,
         write_timeout: Duration,
         permit: OwnedSemaphorePermit,
     ) {
         let client = self.client.clone();
+        let hosts = self.hosts.clone();
         let account_key = self.account_key.clone();
         let data = self.data.clone();
         let slab_index = self.slab_index;
@@ -60,31 +60,24 @@ impl ShardUpload {
             // either after success or failure.
             let _inflight = inflight;
             let now = Instant::now();
-            let result: Result<SectorUploadResult, UploadError> = match client
-                .write_sector(host_key, &account_key.0, data, write_timeout)
-                .await
-            {
-                Ok(root) => {
-                    let elapsed = now.elapsed();
-                    debug!(
-                        "slab {slab_index} shard {shard_index} uploaded to {host_key} in {:?}",
-                        elapsed
-                    );
-                    Ok(SectorUploadResult {
-                        sector: Sector { root, host_key },
-                        shard_index,
-                        elapsed,
-                    })
-                }
-                Err(e) => {
+            let root = client.write_sector(host_key, &account_key.0, data, write_timeout).await
+                .inspect_err(|e| {
                     debug!(
                         "slab {slab_index} shard {shard_index} upload to host {host_key} failed after {:?} {e}",
                         now.elapsed()
                     );
-                    Err(UploadError::from(e))
-                }
-            };
-            (host_key, result)
+                    hosts.lock().unwrap().retry(host_key);
+                })?;
+            let elapsed = now.elapsed();
+            debug!(
+                "slab {slab_index} shard {shard_index} uploaded to {host_key} in {:?}",
+                elapsed
+            );
+            Ok(SectorUploadResult {
+                sector: Sector { root, host_key },
+                shard_index,
+                elapsed,
+            })
         });
     }
 
@@ -93,7 +86,7 @@ impl ShardUpload {
     /// travel with the spawned write task so the reservation lives until
     /// the RPC finishes.
     fn pick_next_host(&self) -> Option<(PublicKey, InflightGuard)> {
-        self.queue.lock().unwrap().pick()
+        self.hosts.lock().unwrap().pick()
     }
 
     async fn upload_shard(self) -> Result<SectorUploadResult, UploadError> {
@@ -106,8 +99,7 @@ impl ShardUpload {
             tokio::select! {
                 biased;
                 Some(res) = tasks.join_next() => {
-                    let (host_key, write_result) = res?;
-                    match write_result {
+                    match res? {
                         Ok(result) => {
                             if result.sector.host_key != initial {
                                 debug!(
@@ -119,13 +111,6 @@ impl ShardUpload {
                             return Ok(result);
                         }
                         Err(_) => {
-                            // write_sector already updated the host's
-                            // failure_rate on the error path. Return it to
-                            // the pool so another shard (or this one) can
-                            // re-pick it within its retry budget. The
-                            // InflightGuard for the failed task dropped
-                            // when the task body exited.
-                            self.queue.lock().unwrap().retry(host_key);
                             if tasks.is_empty() {
                                 let (next, guard) = self.pick_next_host()
                                     .ok_or(QueueError::NoMoreHosts)?;
@@ -305,18 +290,15 @@ impl Upload {
             // rejects duplicate sectors because they break redundancy) —
             // while allowing failed hosts to be re-picked up to the slab's
             // retry cap.
-            let queue: Arc<Mutex<HostQueue>> = Arc::new(Mutex::new(client.slab_host_picker()));
+            let hosts: Arc<Mutex<HostQueue>> = Arc::new(Mutex::new(client.upload_queue()));
             let owned_slab_key = Arc::new(slab_key.clone());
-            // ShardUpload::upload_shard returns Result<SectorUploadResult, UploadError>
-            // (one settled result per shard — not the per-attempt tuple
-            // that spawn_write uses inside upload_shard).
             let mut shard_tasks: JoinSet<Result<SectorUploadResult, UploadError>> = JoinSet::new();
             for (shard_index, mut shard) in shards.into_iter().enumerate() {
                 let owned_slab_key = owned_slab_key.clone();
                 let shard_client = client.clone();
                 let shard_account_key = app_key.clone();
                 let shard_sema_inner = shard_sema.clone();
-                let queue = queue.clone();
+                let hosts = hosts.clone();
                 join_set_spawn!(shard_tasks, async move {
                     let shard = maybe_spawn_blocking!({
                         encrypt_shard(&owned_slab_key, shard_index as u8, 0, &mut shard);
@@ -329,7 +311,7 @@ impl Upload {
                         data: Bytes::from(shard),
                         slab_index,
                         shard_index,
-                        queue,
+                        hosts,
                     };
                     shard_upload.upload_shard().await
                 });

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::encryption::{EncryptionKey, encrypt_shard};
 use crate::erasure_coding::{self, ErasureCoder, ReadSlab, SlabReader};
-use crate::hosts::{QueueError, RPCError};
+use crate::hosts::{InflightGuard, QueueError, RPCError};
 use crate::rhp4::Client;
 use crate::task::AbortOnDropHandle;
 use crate::time::{Duration, Elapsed, Instant, sleep};
@@ -48,9 +48,11 @@ struct UsedHosts {
 
 impl UsedHosts {
     /// Pick the best host that's neither currently claimed nor has
-    /// exhausted its retry budget. Marks the result as claimed and bumps
-    /// its attempt counter.
-    fn pick(&mut self, client: &Hosts<Client>) -> Option<PublicKey> {
+    /// exhausted its retry budget. Marks the result as claimed, bumps its
+    /// attempt counter, and atomically reserves an inflight slot — the
+    /// returned [`InflightGuard`] must be held for the duration of the
+    /// upload RPC so concurrent pickers see the load.
+    fn pick(&mut self, client: &Hosts<Client>) -> Option<(PublicKey, InflightGuard)> {
         let exclude: HashSet<PublicKey> = self
             .claimed
             .iter()
@@ -61,10 +63,10 @@ impl UsedHosts {
                     .filter_map(|(k, n)| (*n >= MAX_HOST_RETRIES).then_some(*k)),
             )
             .collect();
-        let host = client.next_upload_host(&exclude)?;
+        let (host, guard) = client.next_upload_host(&exclude)?;
         *self.attempts.entry(host).or_insert(0) += 1;
         self.claimed.insert(host);
-        Some(host)
+        Some((host, guard))
     }
 
     /// Release a host whose write failed. Removes it from `claimed` so it
@@ -100,6 +102,7 @@ impl ShardUpload {
         &self,
         tasks: &mut JoinSet<(PublicKey, Result<SectorUploadResult, UploadError>)>,
         host_key: PublicKey,
+        inflight: InflightGuard,
         write_timeout: Duration,
         permit: OwnedSemaphorePermit,
     ) {
@@ -110,6 +113,10 @@ impl ShardUpload {
         let shard_index = self.shard_index;
         join_set_spawn!(tasks, async move {
             let _permit = permit;
+            // Hold the inflight guard for the duration of the RPC so the
+            // host's load is visible to concurrent pickers; dropped here
+            // either after success or failure.
+            let _inflight = inflight;
             let now = Instant::now();
             let result: Result<SectorUploadResult, UploadError> = match client
                 .write_sector(host_key, &account_key.0, data, write_timeout)
@@ -139,18 +146,21 @@ impl ShardUpload {
         });
     }
 
-    /// Atomically pick the next-best host for this shard, respecting the
-    /// slab's host accounting: skip hosts currently in flight, holding a
-    /// successful sector, or that have exhausted their retry budget.
-    fn pick_next_host(&self) -> Option<PublicKey> {
+    /// Atomically pick the next-best host for this shard and reserve an
+    /// inflight slot on it. Respects the slab's host accounting: skips
+    /// hosts currently in flight, holding a successful sector, or that
+    /// have exhausted their retry budget. The returned guard must travel
+    /// with the spawned write task so the reservation lives until the RPC
+    /// finishes.
+    fn pick_next_host(&self) -> Option<(PublicKey, InflightGuard)> {
         self.used_hosts.lock().unwrap().pick(&self.client)
     }
 
     async fn upload_shard(self) -> Result<SectorUploadResult, UploadError> {
         let permit = self.semaphore.clone().acquire_owned().await?;
-        let initial = self.pick_next_host().ok_or(QueueError::NoMoreHosts)?;
+        let (initial, initial_guard) = self.pick_next_host().ok_or(QueueError::NoMoreHosts)?;
         let mut tasks = JoinSet::new();
-        self.spawn_write(&mut tasks, initial, UPLOAD_TIMEOUT, permit);
+        self.spawn_write(&mut tasks, initial, initial_guard, UPLOAD_TIMEOUT, permit);
         loop {
             let active = tasks.len();
             tokio::select! {
@@ -172,25 +182,27 @@ impl ShardUpload {
                             // write_sector already updated the host's
                             // failure_rate on the error path. Release it
                             // from `claimed` so it can be re-picked within
-                            // its retry budget.
+                            // its retry budget. The InflightGuard for the
+                            // failed task has already dropped when the
+                            // task body exited.
                             self.used_hosts.lock().unwrap().release_failed(&host_key);
                             if tasks.is_empty() {
-                                let next = self.pick_next_host()
+                                let (next, guard) = self.pick_next_host()
                                     .ok_or(QueueError::NoMoreHosts)?;
                                 let permit = self.semaphore.clone().acquire_owned().await?;
-                                self.spawn_write(&mut tasks, next, UPLOAD_TIMEOUT, permit);
+                                self.spawn_write(&mut tasks, next, guard, UPLOAD_TIMEOUT, permit);
                             }
                         }
                     }
                 },
                 _ = sleep(Duration::from_secs(active.max(1) as u64)) => {
                     if let Ok(racer) = self.semaphore.clone().try_acquire_owned()
-                        && let Some(next) = self.pick_next_host() {
+                        && let Some((next, guard)) = self.pick_next_host() {
                             debug!(
                                 "slab {} shard {} racing slow host with {next}",
                                 self.slab_index, self.shard_index
                             );
-                            self.spawn_write(&mut tasks, next, UPLOAD_TIMEOUT, racer);
+                            self.spawn_write(&mut tasks, next, guard, UPLOAD_TIMEOUT, racer);
                         }
                 }
             }

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::encryption::{EncryptionKey, encrypt_shard};
 use crate::erasure_coding::{self, ErasureCoder, ReadSlab, SlabReader};
-use crate::hosts::{InflightGuard, QueueError, RPCError, UsedHosts};
+use crate::hosts::{HostQueue, InflightGuard, QueueError, RPCError};
 use crate::rhp4::Client;
 use crate::task::AbortOnDropHandle;
 use crate::time::{Duration, Elapsed, Instant, sleep};
@@ -27,8 +27,8 @@ struct ShardUpload {
     data: Bytes,
     slab_index: usize,
     shard_index: usize,
-    /// Per-slab host accounting shared across all shards.
-    used_hosts: Arc<Mutex<UsedHosts>>,
+    /// Per-slab host pool shared across all shards.
+    queue: Arc<Mutex<HostQueue>>,
 }
 
 struct SectorUploadResult {
@@ -88,14 +88,12 @@ impl ShardUpload {
         });
     }
 
-    /// Atomically pick the next-best host for this shard and reserve an
-    /// inflight slot on it. Respects the slab's host accounting: skips
-    /// hosts currently in flight, holding a successful sector, or that
-    /// have exhausted their retry budget. The returned guard must travel
-    /// with the spawned write task so the reservation lives until the RPC
-    /// finishes.
+    /// Atomically pick the next-best host for this shard from the slab's
+    /// pool and reserve an inflight slot on it. The returned guard must
+    /// travel with the spawned write task so the reservation lives until
+    /// the RPC finishes.
     fn pick_next_host(&self) -> Option<(PublicKey, InflightGuard)> {
-        self.used_hosts.lock().unwrap().pick()
+        self.queue.lock().unwrap().pick()
     }
 
     async fn upload_shard(self) -> Result<SectorUploadResult, UploadError> {
@@ -122,12 +120,12 @@ impl ShardUpload {
                         }
                         Err(_) => {
                             // write_sector already updated the host's
-                            // failure_rate on the error path. Release it
-                            // from `claimed` so it can be re-picked within
-                            // its retry budget. The InflightGuard for the
-                            // failed task has already dropped when the
-                            // task body exited.
-                            self.used_hosts.lock().unwrap().release_failed(&host_key);
+                            // failure_rate on the error path. Return it to
+                            // the pool so another shard (or this one) can
+                            // re-pick it within its retry budget. The
+                            // InflightGuard for the failed task dropped
+                            // when the task body exited.
+                            self.queue.lock().unwrap().retry(host_key);
                             if tasks.is_empty() {
                                 let (next, guard) = self.pick_next_host()
                                     .ok_or(QueueError::NoMoreHosts)?;
@@ -295,19 +293,19 @@ impl Upload {
             })?;
 
             // No pre-assignment of hosts: each shard picks its host
-            // just-in-time via the slab's `UsedHosts`, which scores by
+            // just-in-time via the slab's `HostQueue`, which scores by
             // `throughput / (inflight + 1)`. This disperses load across
             // hosts naturally — multiple slabs running in parallel won't
             // all pile onto the same top-N hosts, because by the time
             // slab N+1's shards pick, slab N's chosen hosts have higher
             // inflight and lower score.
             //
-            // `UsedHosts` also enforces slab uniqueness — every shard
+            // `HostQueue` also enforces slab uniqueness — every shard
             // within this slab must land on a distinct host (the indexer
             // rejects duplicate sectors because they break redundancy) —
             // while allowing failed hosts to be re-picked up to the slab's
             // retry cap.
-            let used_hosts: Arc<Mutex<UsedHosts>> = Arc::new(Mutex::new(client.slab_host_picker()));
+            let queue: Arc<Mutex<HostQueue>> = Arc::new(Mutex::new(client.slab_host_picker()));
             let owned_slab_key = Arc::new(slab_key.clone());
             // ShardUpload::upload_shard returns Result<SectorUploadResult, UploadError>
             // (one settled result per shard — not the per-attempt tuple
@@ -318,7 +316,7 @@ impl Upload {
                 let shard_client = client.clone();
                 let shard_account_key = app_key.clone();
                 let shard_sema_inner = shard_sema.clone();
-                let used_hosts = used_hosts.clone();
+                let queue = queue.clone();
                 join_set_spawn!(shard_tasks, async move {
                     let shard = maybe_spawn_blocking!({
                         encrypt_shard(&owned_slab_key, shard_index as u8, 0, &mut shard);
@@ -331,7 +329,7 @@ impl Upload {
                         data: Bytes::from(shard),
                         slab_index,
                         shard_index,
-                        used_hosts,
+                        queue,
                     };
                     shard_upload.upload_shard().await
                 });

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -365,14 +365,12 @@ impl Upload {
             // duplicate sectors because they break redundancy) — while
             // also allowing failed hosts to be re-picked up to
             // `MAX_HOST_RETRIES` times across the slab.
-            let used_hosts: Arc<Mutex<UsedHosts>> =
-                Arc::new(Mutex::new(UsedHosts::default()));
+            let used_hosts: Arc<Mutex<UsedHosts>> = Arc::new(Mutex::new(UsedHosts::default()));
             let owned_slab_key = Arc::new(slab_key.clone());
             // ShardUpload::upload_shard returns Result<SectorUploadResult, UploadError>
             // (one settled result per shard — not the per-attempt tuple
             // that spawn_write uses inside upload_shard).
-            let mut shard_tasks: JoinSet<Result<SectorUploadResult, UploadError>> =
-                JoinSet::new();
+            let mut shard_tasks: JoinSet<Result<SectorUploadResult, UploadError>> = JoinSet::new();
             for (shard_index, mut shard) in shards.into_iter().enumerate() {
                 let owned_slab_key = owned_slab_key.clone();
                 let shard_client = client.clone();

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -1,10 +1,10 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::io;
 use std::sync::{Arc, Mutex};
 
 use crate::encryption::{EncryptionKey, encrypt_shard};
 use crate::erasure_coding::{self, ErasureCoder, ReadSlab, SlabReader};
-use crate::hosts::{InflightGuard, QueueError, RPCError};
+use crate::hosts::{InflightGuard, QueueError, RPCError, UsedHosts};
 use crate::rhp4::Client;
 use crate::task::AbortOnDropHandle;
 use crate::time::{Duration, Elapsed, Instant, sleep};
@@ -19,64 +19,6 @@ use thiserror::Error;
 use tokio::io::{AsyncRead, BufReader};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinSet;
-
-/// Maximum number of times a single host may be picked across all shards
-/// in a slab. Mirrors the cap from the old `HostQueue::retry` behavior so
-/// a host with a transient failure can still get a few more chances within
-/// the same slab, rather than being permanently sidelined on the first error.
-const MAX_HOST_RETRIES: usize = 3;
-
-/// Per-slab host accounting. Tracks two things:
-/// - `claimed`: hosts currently in flight, or holding a successful sector
-///   on this slab. Excluded from picks so no two shards in the slab can
-///   both succeed on the same host (slab uniqueness; the indexer rejects
-///   duplicate hosts in a slab).
-/// - `attempts`: per-host pick count. A host that hits [`MAX_HOST_RETRIES`]
-///   is permanently off-limits for the slab.
-///
-/// Lifecycle for a host:
-/// - `pick` → attempt count +1, added to claimed.
-/// - Write succeeds → stays in claimed forever. Attempt count irrelevant.
-/// - Write fails → `release_failed` removes from claimed; attempts stays
-///   incremented. Another shard (or a retry within the same shard) can
-///   re-pick the host while its attempts < `MAX_HOST_RETRIES`.
-#[derive(Default)]
-struct UsedHosts {
-    claimed: HashSet<PublicKey>,
-    attempts: HashMap<PublicKey, usize>,
-}
-
-impl UsedHosts {
-    /// Pick the best host that's neither currently claimed nor has
-    /// exhausted its retry budget. Marks the result as claimed, bumps its
-    /// attempt counter, and atomically reserves an inflight slot — the
-    /// returned [`InflightGuard`] must be held for the duration of the
-    /// upload RPC so concurrent pickers see the load.
-    fn pick(&mut self, client: &Hosts<Client>) -> Option<(PublicKey, InflightGuard)> {
-        let exclude: HashSet<PublicKey> = self
-            .claimed
-            .iter()
-            .copied()
-            .chain(
-                self.attempts
-                    .iter()
-                    .filter_map(|(k, n)| (*n >= MAX_HOST_RETRIES).then_some(*k)),
-            )
-            .collect();
-        let (host, guard) = client.next_upload_host(&exclude)?;
-        *self.attempts.entry(host).or_insert(0) += 1;
-        self.claimed.insert(host);
-        Some((host, guard))
-    }
-
-    /// Release a host whose write failed. Removes it from `claimed` so it
-    /// can be re-picked (by this shard or another) while its attempt count
-    /// is still under [`MAX_HOST_RETRIES`]. The attempt count itself is
-    /// kept so the cap continues to apply.
-    fn release_failed(&mut self, host: &PublicKey) {
-        self.claimed.remove(host);
-    }
-}
 
 struct ShardUpload {
     semaphore: Arc<Semaphore>,
@@ -153,7 +95,7 @@ impl ShardUpload {
     /// with the spawned write task so the reservation lives until the RPC
     /// finishes.
     fn pick_next_host(&self) -> Option<(PublicKey, InflightGuard)> {
-        self.used_hosts.lock().unwrap().pick(&self.client)
+        self.used_hosts.lock().unwrap().pick()
     }
 
     async fn upload_shard(self) -> Result<SectorUploadResult, UploadError> {
@@ -353,19 +295,19 @@ impl Upload {
             })?;
 
             // No pre-assignment of hosts: each shard picks its host
-            // just-in-time via `Hosts::next_upload_host`, which scores by
+            // just-in-time via the slab's `UsedHosts`, which scores by
             // `throughput / (inflight + 1)`. This disperses load across
             // hosts naturally — multiple slabs running in parallel won't
             // all pile onto the same top-N hosts, because by the time
             // slab N+1's shards pick, slab N's chosen hosts have higher
             // inflight and lower score.
             //
-            // `used_hosts` enforces slab uniqueness — every shard within
-            // this slab must land on a distinct host (the indexer rejects
-            // duplicate sectors because they break redundancy) — while
-            // also allowing failed hosts to be re-picked up to
-            // `MAX_HOST_RETRIES` times across the slab.
-            let used_hosts: Arc<Mutex<UsedHosts>> = Arc::new(Mutex::new(UsedHosts::default()));
+            // `UsedHosts` also enforces slab uniqueness — every shard
+            // within this slab must land on a distinct host (the indexer
+            // rejects duplicate sectors because they break redundancy) —
+            // while allowing failed hosts to be re-picked up to the slab's
+            // retry cap.
+            let used_hosts: Arc<Mutex<UsedHosts>> = Arc::new(Mutex::new(client.slab_host_picker()));
             let owned_slab_key = Arc::new(slab_key.clone());
             // ShardUpload::upload_shard returns Result<SectorUploadResult, UploadError>
             // (one settled result per shard — not the per-attempt tuple


### PR DESCRIPTION
This is something I have been playing around with today trying to make the upload code faster. Based off the new reed Solomon branch of Nate's open PR.

I noticed that even with the tracking of metrics once you increase `max_inflight` to a cover a few slabs most slab uploads just end up using the same hosts.

This PR updates this by taking into account the number of inflight uploads/downloads when hading out hosts and also by effectively sharing the queue.

I ran this with `90` inflight uploads and `270` inflight downloads using the benchmark with a size of 10GB.

On master 
```
Object uploaded ID: 26e2274050b45e321ab373354580dc5650521a433e9033adf09e8d0d1bb5190b    Size: 10.00 GiB Encoded: 30.00 GiB      Elapsed: 117.601010741s Throughput: 730.43 Mbps Encoded Throughput: 2.19 Gbps
Object downloaded ID: 26e2274050b45e321ab373354580dc5650521a433e9033adf09e8d0d1bb5190b  Size: 10.00 GiB Encoded: 30.00 GiB      Elapsed: 271.715108489s TTFB: 448.027559ms      Throughput: 316.14 Mbps Max Write Latency: 2.12669455s
```

and on this branch
```
Object uploaded ID: 4cc6edbc9542a73f80a14203cfc0c3d70fad0dec5b09d9104a364c72a4bb2fa1    Size: 10.00 GiB Encoded: 30.00 GiB      Elapsed: 64.510601574s  Throughput: 1.33 Gbps   Encoded Throughput: 3.99 Gbps
Object downloaded ID: 4cc6edbc9542a73f80a14203cfc0c3d70fad0dec5b09d9104a364c72a4bb2fa1  Size: 10.00 GiB Encoded: 30.00 GiB      Elapsed: 292.43711083s  TTFB: 92.600987ms       Throughput: 293.74 Mbps Max Write Latency: 1.44317758s
```

The impact seems to be higher for uploads which could be for multiple reasons such as being able to freely pick the host during upload while being restricted to 30 on download or just hosts having a worse uplink than down.

It does seem to improve upload speeds though.

If anyone wants to try it themselves run
```
cargo run --release --example benchmark -p sia_storage -- --size 10737418240
```

the `tmp` commit already updates the `max_inflight` defaults.

NOTE: This isn't cleaned up or anything yet but I wanted to push it before the weekend for other people to get a chance to check it out and try it themselves if they want.