### PR TITLE
Track sia_storage_wasm and sia_storage_napi in knope versioned files

### DIFF
--- a/.changeset/bump_sia_core_to_0_3_1.md
+++ b/.changeset/bump_sia_core_to_0_3_1.md
@@ -1,0 +1,6 @@
+---
+sia_storage_wasm: patch
+sia_storage_napi: patch
+---
+
+# Update `sia_core` to `0.3.1`.

--- a/knope.toml
+++ b/knope.toml
@@ -7,6 +7,7 @@ versioned_files = [
     { path = "sia_storage/Cargo.toml", dependency = "sia_core" },
     { path = "sia_storage_ffi/Cargo.toml", dependency = "sia_core" },
     { path = "sia_storage_napi/Cargo.toml", dependency = "sia_core" },
+    { path = "sia_storage_wasm/Cargo.toml", dependency = "sia_core" },
     { path = "Cargo.lock", dependency = "sia_core" }
 ]
 changelog = "sia_core/CHANGELOG.md"

--- a/sia_storage_napi/Cargo.toml
+++ b/sia_storage_napi/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4", features = ["serde"] }
 napi = { version = "3.8.5", features = ["async", "napi8", "chrono_date", "web_stream"] }
 napi-derive = { version = "3.5.4", features = ["type-def"] }
 rand = "0.10.0"
-sia_core = { version = "0.3.0", path = "../sia_core" }
+sia_core = { version = "0.3.1", path = "../sia_core" }
 sia_storage = { version = "0.8.0", path = "../sia_storage" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.0", features = ["rt-multi-thread", "sync"] }

--- a/sia_storage_wasm/Cargo.toml
+++ b/sia_storage_wasm/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 sia_storage = { version = "0.8.0", path = "../sia_storage" }
-sia_core = { version = "0.3.0", path = "../sia_core" }
+sia_core = { version = "0.3.1", path = "../sia_core" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"


### PR DESCRIPTION
Adds sia_storage_wasm to sia_core's versioned_files entry and sia_storage to sia_core_derive's, then bumps the stale sia_core = "0.3.0" pins in sia_storage_wasm and sia_storage_napi up to the current 0.3.1 release.