### PR TITLE
Overprovision downloaded shards

### DIFF
--- a/.changeset/changed_downloadoptionsmax_inflight_from_u8_to_u32.md
+++ b/.changeset/changed_downloadoptionsmax_inflight_from_u8_to_u32.md
@@ -1,0 +1,6 @@
+---
+sia_storage_ffi: major
+sia_storage_napi: major
+---
+
+# Changed DownloadOptions::max_inflight from u8 to u32.

--- a/.changeset/overprovision_downloads.md
+++ b/.changeset/overprovision_downloads.md
@@ -1,0 +1,8 @@
+---
+sia_storage: minor
+sia_storage_ffi: minor
+sia_storage_wasm: minor
+sia_storage_napi: minor
+---
+
+# Overprovision shard downloads to reduce tail latency from slow hosts

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -230,10 +230,9 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         let shard_offset = start;
         let shard_length = end - start;
 
-        // Spawn the initial batch using the inflight slots reserved by
-        // `SlabRecovery::new`. Each guard moves into its corresponding
-        // task and stays alive for the duration of the RPC.
-        for i in 0..self.min_shards {
+        // overprovision the recovery to reduce tail latency from slow hosts
+        let spawn_shards = self.min_shards * 3 / 2;
+        for i in 0..spawn_shards {
             let (task, inflight) = sectors
                 .pop_front()
                 .ok_or(DownloadError::NotEnoughShards(i, self.min_shards))?;

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -31,7 +31,7 @@ pub enum DownloadError {
 
     /// Not enough shards were successfully downloaded to recover the data.
     #[error("not enough shards: {0}/{1}")]
-    NotEnoughShards(u8, u8),
+    NotEnoughShards(usize, usize),
 
     /// The requested range is out of bounds.
     #[error("invalid range: {0}-{1}")]
@@ -98,7 +98,7 @@ struct SlabRecovery<State, T: Transport> {
     account_key: Arc<AppKey>,
 
     slab_index: usize,
-    min_shards: u8,
+    min_shards: usize,
     encryption_key: EncryptionKey,
     offset: usize,
     length: usize,
@@ -161,7 +161,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             client,
             account_key,
             slab_index: slab.index,
-            min_shards: slab.slab.min_shards,
+            min_shards,
             encryption_key: slab.slab.encryption_key,
             offset: slab.slab.offset as usize,
             length: slab.slab.length as usize,
@@ -218,24 +218,25 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         let mut shard_tasks = JoinSet::new();
         let mut shards = vec![None; self.state.sectors.len()];
         let mut sectors = VecDeque::from(self.state.sectors);
-        let min_shards = self.min_shards;
+
         let client = self.client;
         let account_key = self.account_key;
         let encryption_key = self.encryption_key;
 
         // compute the sector aligned region to download
-        let chunk_size = SEGMENT_SIZE * self.min_shards as usize;
+        let min_shards = self.min_shards;
+        let chunk_size = SEGMENT_SIZE * min_shards;
         let start = (self.offset / chunk_size) * SEGMENT_SIZE;
         let end = (self.offset + self.length).div_ceil(chunk_size) * SEGMENT_SIZE;
         let shard_offset = start;
         let shard_length = end - start;
 
         // overprovision the recovery to reduce tail latency from slow hosts
-        let spawn_shards = self.min_shards * 3 / 2;
+        let spawn_shards = (min_shards * 3 / 2).min(sectors.len());
         for i in 0..spawn_shards {
             let (task, inflight) = sectors
                 .pop_front()
-                .ok_or(DownloadError::NotEnoughShards(i, self.min_shards))?;
+                .ok_or(DownloadError::NotEnoughShards(i, min_shards))?;
             join_set_spawn!(
                 &mut shard_tasks,
                 Self::recover_shard(
@@ -249,8 +250,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                 )
             );
         }
-        let mut recovered_shards: u8 = 0;
-
+        let mut recovered_shards: usize = 0;
         loop {
             tokio::select! {
                 Some(res) = shard_tasks.join_next() => {
@@ -278,7 +278,7 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                             }
                         },
                         Err(_) => {
-                            if recovered_shards as usize + shard_tasks.len() + sectors.len() < min_shards as usize {
+                            if recovered_shards + shard_tasks.len() + sectors.len() < min_shards {
                                 return Err(DownloadError::NotEnoughShards(recovered_shards, min_shards));
                             } else if let Some((task, _)) = sectors.pop_front() {
                                 let inflight = client.reserve_inflight_download(&task.sector.host_key);
@@ -299,8 +299,8 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
 
 impl<T: Transport> SlabRecovery<ShardsRecovered, T> {
     fn decode(self) -> Result<SlabRecovery<SlabDecoded, T>, DownloadError> {
-        let parity_shards = self.state.shards.len() - self.min_shards as usize;
-        let rs = ErasureCoder::new(self.min_shards as usize, parity_shards)?;
+        let parity_shards = self.state.shards.len() - self.min_shards;
+        let rs = ErasureCoder::new(self.min_shards, parity_shards)?;
         let mut shards = self.state.shards;
         // decrypt the downloaded shards in place and recover the data shards
         encrypt_recovered_shards(
@@ -312,7 +312,7 @@ impl<T: Transport> SlabRecovery<ShardsRecovered, T> {
         rs.reconstruct_data_shards(&mut shards)?;
         let data_shards = shards
             .into_iter()
-            .take(self.min_shards as usize)
+            .take(self.min_shards)
             .map(|s| Bytes::from(s.unwrap())) // safe: data shards were just reconstructed
             .collect();
         Ok(SlabRecovery {

--- a/sia_storage/src/lib.rs
+++ b/sia_storage/src/lib.rs
@@ -334,7 +334,7 @@ impl DownloadOptions {
 impl Default for DownloadOptions {
     fn default() -> Self {
         Self {
-            max_inflight: 80, // ~20 MiB in memory
+            max_inflight: 256, // ~64 MiB in memory
             offset: 0,
             length: None,
             shard_downloaded: None,

--- a/sia_storage_ffi/src/lib.rs
+++ b/sia_storage_ffi/src/lib.rs
@@ -784,7 +784,7 @@ impl From<UploadOptions> for sia_storage::UploadOptions {
 #[derive(uniffi::Record)]
 pub struct DownloadOptions {
     #[uniffi(default = None)]
-    pub max_inflight: Option<u8>,
+    pub max_inflight: Option<u32>,
     #[uniffi(default = None)]
     pub offset: Option<u64>,
     #[uniffi(default = None)]

--- a/sia_storage_napi/src/lib.rs
+++ b/sia_storage_napi/src/lib.rs
@@ -399,7 +399,7 @@ impl FromNapiValue for SendableUploadOptions {
 /// Download options.
 #[napi(object, object_to_js = false)]
 pub struct DownloadOptions {
-    pub max_inflight: Option<u8>,
+    pub max_inflight: Option<u32>,
     pub offset: Option<BigInt>,
     pub length: Option<BigInt>,
     #[napi(ts_type = "(progress: ShardProgress) => void")]


### PR DESCRIPTION
Improves download speed by over provisioning shards to reduce tail latency.

cargo run --release --example benchmark run --upload-max-inflight=90 --size=10737418240

**base + 80 download max inflight (~20MiB memory):**
```sh
download [00:02:42] [========>-------------------------------] 2.18 GiB/10.00 GiB (115.20 Mbps, 13m)  
```

**over provision + 80 download max inflight (~20MiB memory):**
```sh
download [00:03:00] [========================================] 10.00 GiB/10.00 GiB (475.01 Mbps, 0s)
Download
  Size:          10.00 GiB
  Elapsed:       180.835475325s
  TTFB:          625.012051ms
  Throughput:    475.01 Mbps
  Max latency:   935.118759ms
```

**over provision + 256 download max inflight (~64MiB memory):**
```sh
download [00:02:04] [========================================] 10.00 GiB/10.00 GiB (690.91 Mbps, 0s)
Download
  Size:          10.00 GiB
  Elapsed:       124.328142278s
  TTFB:          708.144178ms
  Throughput:    690.91 Mbps
  Max latency:   1.032089603s
```