### PR TITLE
Make racing adaptive

### DIFF
--- a/.changeset/made_racing_adaptive_so_that_racers_will_not_steal_slots_from_higher_priority_work.md
+++ b/.changeset/made_racing_adaptive_so_that_racers_will_not_steal_slots_from_higher_priority_work.md
@@ -1,0 +1,10 @@
+---
+sia_storage_ffi: patch
+sia_storage_wasm: patch
+sia_storage_napi: patch
+sia_storage: patch
+---
+
+# Made racing adaptive so that racers will not steal slots from higher priority work
+
+For uploads, racing will only start when every shard has an attempt in flight. For downloads, racing will only start when the chunk is near the read head. The race timeout is derived from the p95 of recently completed RPCs instead of a fixed interval so only hosts well outside the normal latency spread get raced.

--- a/sia_storage/examples/benchmark.rs
+++ b/sia_storage/examples/benchmark.rs
@@ -522,7 +522,17 @@ async fn run_benchmark(
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn Error>> {
-    env_logger::init();
+    // Write RUST_LOG output to a timestamped file instead of the terminal
+    // so it doesn't interleave with the progress bars.
+    let log_path = format!(
+        "benchmark-{}.log",
+        chrono::Local::now().format("%Y%m%dT%H%M%S")
+    );
+    let log_file = std::fs::File::create(&log_path)?;
+    env_logger::Builder::from_default_env()
+        .target(env_logger::Target::Pipe(Box::new(log_file)))
+        .init();
+    eprintln!("logging to {log_path}");
     let cli = Cli::parse();
     match cli.command {
         Command::Login { indexer, new } => login(&cli.profile, &indexer, new).await,

--- a/sia_storage/src/download.rs
+++ b/sia_storage/src/download.rs
@@ -12,9 +12,11 @@ use crate::time::{Duration, Elapsed, Instant, sleep};
 use crate::{AppKey, DownloadOptions, Object, Sector, ShardProgress, ShardProgressCallback, Slab};
 use bytes::{Buf, Bytes};
 use chacha20::cipher::StreamCipher;
+use log::debug;
 use sia_core::rhp4::SEGMENT_SIZE;
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::watch;
 use tokio::task::JoinSet;
 use tokio_util::task::AbortOnDropHandle;
 
@@ -71,12 +73,25 @@ struct SectorTask {
     shard_index: usize,
 }
 
+/// A chunk may only race slow hosts while it is within `n` chunks of the read head.
+/// Racing further ahead steals capacity from chunks the reader needs first.
+const RACE_WINDOW: usize = 3;
+
+const RACE_FACTOR: f64 = 1.5;
+
 struct AwaitingRecovery {
     /// The sectors to download for this slab, paired with their inflight guards
     /// if they were reserved by `SlabRecovery::new`. Guards are held for the
     /// duration of the RPC in `SlabRecovery::recover_shard` to ensure the
     /// reservation is released on completion or error.
     sectors: Vec<(SectorTask, Option<InflightGuard>)>,
+    /// This chunk's position in download order. Compared against `popped`
+    /// to decide whether the chunk is close enough to the read head to race.
+    seq: usize,
+    /// Counts the chunks handed to the reader so far. `recover_shards`
+    /// subscribes to it; holding a sender keeps the channel open so the
+    /// `changed` arm cannot fail.
+    popped: watch::Sender<usize>,
 }
 
 struct ShardsRecovered {
@@ -111,6 +126,8 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         client: Hosts<T>,
         account_key: Arc<AppKey>,
         slab: ChunkSlab,
+        seq: usize,
+        popped: watch::Sender<usize>,
     ) -> Result<Self, DownloadError> {
         if slab.slab.min_shards == 0 {
             return Err(DownloadError::InvalidSlab(
@@ -165,7 +182,11 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             encryption_key: slab.slab.encryption_key,
             offset: slab.slab.offset as usize,
             length: slab.slab.length as usize,
-            state: AwaitingRecovery { sectors },
+            state: AwaitingRecovery {
+                sectors,
+                seq,
+                popped,
+            },
         })
     }
 
@@ -196,6 +217,10 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             )
             .await?;
         let elapsed = start.elapsed();
+        debug!(
+            "slab {} shard {} recovered from {} in {:?}",
+            slab_index, task.shard_index, task.sector.host_key, elapsed
+        );
         // Bytes -> Vec<u8> is zero-copy when the Bytes is uniquely owned
         // (true here — no other refs to the response yet).
         Ok((
@@ -218,6 +243,8 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         let mut shard_tasks = JoinSet::new();
         let mut shards = vec![None; self.state.sectors.len()];
         let mut sectors = VecDeque::from(self.state.sectors);
+        let seq = self.state.seq;
+        let mut popped_rx = self.state.popped.subscribe();
 
         let client = self.client;
         let account_key = self.account_key;
@@ -230,6 +257,9 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
         let end = (self.offset + self.length).div_ceil(chunk_size) * SEGMENT_SIZE;
         let shard_offset = start;
         let shard_length = end - start;
+        let race_timeout = client
+            .read_estimate(shard_length as u32)
+            .mul_f64(RACE_FACTOR);
 
         // overprovision the recovery to reduce tail latency from slow hosts
         let spawn_shards = (min_shards * 3 / 2).min(sectors.len());
@@ -251,9 +281,13 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
             );
         }
         let mut recovered_shards: usize = 0;
+        let mut eligible = seq < popped_rx.borrow_and_update().saturating_add(RACE_WINDOW);
+        let mut last_event = Instant::now();
+
         loop {
             tokio::select! {
                 Some(res) = shard_tasks.join_next() => {
+                    last_event = Instant::now();
                     match res? {
                         Ok((index, data, progress)) => {
                             shards[index] = Some(data);
@@ -287,10 +321,17 @@ impl<T: Transport> SlabRecovery<AwaitingRecovery, T> {
                         }
                     }
                 },
-                _ = sleep(Duration::from_millis(500)), if !sectors.is_empty() => {
+                // Fires once racing will not steal work from more important chunks and the race timeout has elapsed
+                _ = sleep((last_event + race_timeout).saturating_duration_since(Instant::now())), if eligible && !sectors.is_empty() => {
+                    let elapsed = last_event.elapsed();
+                    last_event = Instant::now();
                     let (task, _) = sectors.pop_front().expect("sectors should not be empty");
                     let inflight = client.reserve_inflight_download(&task.sector.host_key);
+                    debug!("chunk {seq} racing slow host with {} after {:?}", task.sector.host_key, elapsed);
                     join_set_spawn!(&mut shard_tasks, Self::recover_shard(client.clone(), account_key.clone(), task, inflight, self.slab_index, shard_offset, shard_length));
+                },
+                _ = popped_rx.wait_for(|popped| seq < popped.saturating_add(RACE_WINDOW)), if !eligible => {
+                    eligible = true;
                 },
             }
         }
@@ -426,6 +467,11 @@ pub struct Download {
     buf: Bytes,
     queue: VecDeque<AbortOnDropHandle<Result<Vec<u8>, DownloadError>>>,
     chunk_iter: ChunkIter,
+    /// Sequence number assigned to the next spawned chunk.
+    next_seq: usize,
+    /// Number of chunks handed to the reader so far. Chunk tasks watch this
+    /// to decide whether they are within [`RACE_WINDOW`] of the read head.
+    popped: watch::Sender<usize>,
     // sticky error
     //
     // note: in Go we would store the error and return it, but that would
@@ -464,6 +510,7 @@ impl AsyncRead for Download {
                 }
             };
             self.queue.pop_front();
+            self.popped.send_modify(|p| *p += 1);
             self.spawn_next();
             self.cipher.apply_keystream(&mut result); // decrypt
             self.buf = Bytes::from(result);
@@ -499,7 +546,10 @@ impl Download {
             // each successive `spawn_next` must see the previous chunk's
             // reservations to disperse picks across hosts.
             let len = chunk_slab.slab.length as usize;
-            let recovery = SlabRecovery::new(hosts, account_key, chunk_slab);
+            let seq = self.next_seq;
+            self.next_seq += 1;
+            let recovery =
+                SlabRecovery::new(hosts, account_key, chunk_slab, seq, self.popped.clone());
             self.queue
                 .push_back(AbortOnDropHandle::new(maybe_spawn!(async move {
                     let recovery = recovery?;
@@ -534,6 +584,7 @@ impl Download {
         let Some(chunk_handle) = self.queue.pop_front() else {
             return Ok(Vec::new()); // EOF
         };
+        self.popped.send_modify(|p| *p += 1);
         let mut result = match chunk_handle.await {
             Ok(Ok(data)) => data,
             Ok(Err(e)) => {
@@ -574,6 +625,8 @@ impl Download {
             buf: Bytes::new(),
             queue: VecDeque::with_capacity(options.max_inflight),
             chunk_iter,
+            next_seq: 0,
+            popped: watch::channel(0).0,
             errored: false,
             shard_downloaded: options.shard_downloaded,
         };
@@ -715,16 +768,22 @@ mod test {
             slab.length = length as u32;
 
             let mut recovered_data = Vec::with_capacity(length);
-            SlabRecovery::new(hosts.clone(), app_key.clone(), ChunkSlab { slab, index: 0 })
-                .unwrap()
-                .recover_shards(None)
-                .await
-                .unwrap()
-                .decode()
-                .unwrap()
-                .write(&mut recovered_data)
-                .await
-                .unwrap();
+            SlabRecovery::new(
+                hosts.clone(),
+                app_key.clone(),
+                ChunkSlab { slab, index: 0 },
+                0,
+                watch::channel(0).0,
+            )
+            .unwrap()
+            .recover_shards(None)
+            .await
+            .unwrap()
+            .decode()
+            .unwrap()
+            .write(&mut recovered_data)
+            .await
+            .unwrap();
             assert_eq!(
                 &data[offset..offset + length],
                 &recovered_data[..],
@@ -829,5 +888,140 @@ mod test {
                 "slab {slab_idx} had no progress callbacks"
             );
         }
+    }
+
+    /// Uploads one slab to 60 hosts, then seeds fast read samples for the
+    /// first 15 sector hosts so they deterministically win `prioritize`
+    /// (the rest only have write samples from the upload) and the read median
+    /// sits at its floor, and finally makes those 15 hosts slow. Racers
+    /// (when allowed) come from the remaining fast hosts.
+    async fn racing_setup(slow_delay: Duration) -> (Hosts<Client>, Arc<AppKey>, Slab) {
+        let upload_options = UploadOptions::default();
+        let optimal_data_size = upload_options.data_shards as usize * SECTOR_SIZE;
+
+        let transport = Client::new();
+        let hosts = Hosts::new(transport.clone());
+        hosts.update(
+            (0..60)
+                .map(|_| Host {
+                    public_key: PrivateKey::from_seed(&rand::random()).public_key(),
+                    addresses: vec![NetAddress {
+                        protocol: sia_core::types::v2::Protocol::QUIC,
+                        address: "localhost:1234".to_string(),
+                    }],
+                    country_code: "US".to_string(),
+                    latitude: 0.0,
+                    longitude: 0.0,
+                    good_for_upload: true,
+                })
+                .collect(),
+            true,
+        );
+        let mut data = BytesMut::zeroed(optimal_data_size);
+        rand::rng().fill_bytes(&mut data);
+        let data = data.freeze();
+        let app_key = Arc::new(AppKey::import(rand::random()));
+
+        let slabs = upload_slabs(
+            hosts.clone(),
+            app_key.clone(),
+            Cursor::new(data),
+            upload_options,
+        )
+        .await
+        .unwrap();
+        let slab = slabs[0].clone();
+
+        let slow_set: Vec<_> = slab.sectors.iter().take(15).map(|s| s.host_key).collect();
+        for host_key in &slow_set {
+            hosts.record_read_sample(*host_key, 1 << 18, Duration::from_micros(1));
+        }
+        transport.set_slow_hosts(slow_set, slow_delay);
+        (hosts, app_key, slab)
+    }
+
+    fn racing_chunk(slab: &Slab) -> ChunkSlab {
+        let mut chunk = slab.clone();
+        chunk.offset = 0;
+        chunk.length = 1 << 18;
+        ChunkSlab {
+            slab: chunk,
+            index: 0,
+        }
+    }
+
+    #[sia_core_derive::cross_target_test]
+    async fn test_download_race_gated_outside_window() {
+        let (hosts, app_key, slab) = racing_setup(Duration::from_millis(1500)).await;
+        let start = Instant::now();
+        SlabRecovery::new(
+            hosts.clone(),
+            app_key.clone(),
+            racing_chunk(&slab),
+            RACE_WINDOW, // first chunk outside the window
+            watch::channel(0).0,
+        )
+        .unwrap()
+        .recover_shards(None)
+        .await
+        .unwrap();
+        assert!(
+            start.elapsed() >= Duration::from_millis(1200),
+            "chunk outside the window must not race: {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[sia_core_derive::cross_target_test]
+    async fn test_download_race_within_window() {
+        let (hosts, app_key, slab) = racing_setup(Duration::from_millis(1500)).await;
+        let start = Instant::now();
+        SlabRecovery::new(
+            hosts.clone(),
+            app_key.clone(),
+            racing_chunk(&slab),
+            0,
+            watch::channel(0).0,
+        )
+        .unwrap()
+        .recover_shards(None)
+        .await
+        .unwrap();
+        assert!(
+            start.elapsed() < Duration::from_millis(1200),
+            "chunk at the read head should race slow hosts: {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[sia_core_derive::cross_target_test]
+    async fn test_download_race_triggered_by_window() {
+        let (hosts, app_key, slab) = racing_setup(Duration::from_millis(1500)).await;
+        let popped_tx = watch::channel(0).0;
+        // the reader pops a chunk 200ms in, bringing this chunk into the
+        // window; racing should begin immediately rather than waiting
+        // another race-timeout interval
+        let tx = popped_tx.clone();
+        maybe_spawn!(async move {
+            sleep(Duration::from_millis(200)).await;
+            tx.send_modify(|p| *p += 1);
+        });
+        let start = Instant::now();
+        SlabRecovery::new(
+            hosts.clone(),
+            app_key.clone(),
+            racing_chunk(&slab),
+            RACE_WINDOW,
+            popped_tx,
+        )
+        .unwrap()
+        .recover_shards(None)
+        .await
+        .unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(190) && elapsed < Duration::from_millis(1200),
+            "racing should begin once the chunk enters the window: {elapsed:?}"
+        );
     }
 }

--- a/sia_storage/src/hosts.rs
+++ b/sia_storage/src/hosts.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
 use chrono::Utc;
 use log::debug;
 use serde::{Deserialize, Serialize};
-use sia_core::rhp4::HostPrices;
+use sia_core::rhp4::{HostPrices, SECTOR_SIZE};
 use sia_core::signing::{PrivateKey, PublicKey};
 use sia_core::types::Hash256;
 use sia_core::types::v2::NetAddress;
@@ -14,8 +14,11 @@ use thiserror::Error;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
+use crate::hosts::metrics::{HostMetric, HostScore, RPCAverage, Transfer};
 use crate::rhp4::{HostEndpoint, Transport};
 use crate::time::{Duration, Elapsed, Instant, timeout};
+
+mod metrics;
 
 /// Represents a host in the Sia network. The
 /// addresses can be used to connect to the host.
@@ -35,218 +38,6 @@ pub struct Host {
     pub longitude: f64,
     /// Whether the host is currently suitable for uploading data.
     pub good_for_upload: bool,
-}
-
-#[derive(Debug, Default, Clone)]
-struct RPCAverage(Option<f64>); // exponential moving average of throughput in bytes/sec
-
-impl RPCAverage {
-    const ALPHA: f64 = 0.2;
-
-    fn add_sample(&mut self, bytes_per_sec: u64) {
-        match self.0 {
-            Some(avg) => {
-                self.0 = Some(Self::ALPHA * (bytes_per_sec as f64) + (1.0 - Self::ALPHA) * avg);
-            }
-            None => {
-                self.0 = Some(bytes_per_sec as f64);
-            }
-        }
-    }
-
-    /// Returns the current average in bytes/sec, or `None` if no samples have
-    /// been recorded yet. Callers decide how to treat unsampled hosts.
-    fn avg(&self) -> Option<f64> {
-        self.0
-    }
-}
-
-impl Display for RPCAverage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.avg() {
-            Some(v) => Display::fmt(&v, f),
-            None => f.write_str("unsampled"),
-        }
-    }
-}
-
-impl PartialEq for RPCAverage {
-    fn eq(&self, other: &Self) -> bool {
-        self.avg() == other.avg()
-    }
-}
-
-impl Eq for RPCAverage {}
-
-#[derive(Debug, Default, Clone)]
-struct FailureRate(Option<f64>); // exponential moving average of failure rate
-
-impl FailureRate {
-    const ALPHA: f64 = 0.2;
-
-    fn add_sample(&mut self, success: bool) {
-        let sample = if success { 0.0 } else { 1.0 };
-        match self.0 {
-            Some(rate) => {
-                self.0 = Some(Self::ALPHA * sample + (1.0 - Self::ALPHA) * rate);
-            }
-            None => {
-                self.0 = Some(sample);
-            }
-        }
-    }
-
-    // Computes the failure rate as an integer percentage (0-100)
-    fn rate(&self) -> i64 {
-        match self.0 {
-            Some(rate) => (rate * 100.0).round() as i64,
-            None => 0, // presume no failures if no samples
-        }
-    }
-}
-
-impl Display for FailureRate {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}%", self.rate())
-    }
-}
-
-impl PartialEq for FailureRate {
-    fn eq(&self, other: &Self) -> bool {
-        self.rate() == other.rate()
-    }
-}
-
-impl Eq for FailureRate {}
-
-impl PartialOrd for FailureRate {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for FailureRate {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.rate().cmp(&other.rate())
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-struct HostMetric {
-    rpc_write_avg: RPCAverage,
-    rpc_read_avg: RPCAverage,
-    failure_rate: FailureRate,
-}
-
-impl HostMetric {
-    fn add_write_sample(&mut self, bytes: u64, elapsed: Duration) {
-        if let Some(bps) = bytes_per_sec(bytes, elapsed) {
-            self.rpc_write_avg.add_sample(bps);
-        }
-        self.failure_rate.add_sample(true);
-    }
-
-    fn add_read_sample(&mut self, bytes: u64, elapsed: Duration) {
-        if let Some(bps) = bytes_per_sec(bytes, elapsed) {
-            self.rpc_read_avg.add_sample(bps);
-        }
-        self.failure_rate.add_sample(true);
-    }
-
-    fn add_settings_sample(&mut self, elapsed: Duration) {
-        self.add_read_sample(270, elapsed); // serialized settings response is ~270 bytes
-    }
-
-    fn add_failure(&mut self) {
-        self.failure_rate.add_sample(false);
-    }
-
-    /// Combined read + write throughput average. `None` only when neither side
-    /// has been sampled. Used by [`HostScore`] for the discovery preference
-    /// (unsampled outranks sampled).
-    fn combined_throughput(&self) -> Option<f64> {
-        match (self.rpc_write_avg.avg(), self.rpc_read_avg.avg()) {
-            (None, None) => None,
-            (Some(w), Some(r)) => Some((w + r) / 2.0),
-            (Some(v), None) | (None, Some(v)) => Some(v),
-        }
-    }
-}
-
-// Computes throughput in bytes/sec, returning None when elapsed is zero so that
-// the sample is skipped instead of producing an invalid/infinite throughput
-// value that would skew the moving average.
-fn bytes_per_sec(bytes: u64, elapsed: Duration) -> Option<u64> {
-    if elapsed.is_zero() {
-        return None;
-    }
-    Some((bytes as f64 / elapsed.as_secs_f64()) as u64)
-}
-
-/// Score for picking the next upload host. Higher is better.
-///
-/// Sort order:
-/// 1. Lower `failure_rate` wins.
-/// 2. Unsampled hosts (no throughput data) outrank sampled ones — this is
-///    the "discovery" preference so every available host eventually gets
-///    tried at least once.
-/// 3. Among sampled hosts, higher `throughput / (inflight + 1)` wins —
-///    the expected per-shard throughput if you added one more shard. That
-///    penalizes already-busy hosts proportionally to load, so a saturated
-///    fast host can lose to an idle slower one, while a genuinely much
-///    faster host still wins even when serving a few shards.
-#[derive(Debug, Clone, Copy)]
-struct HostScore {
-    failure_rate: i64,
-    throughput: Option<f64>,
-    inflight: usize,
-}
-
-impl HostScore {
-    fn new(metric: &HostMetric, inflight: usize) -> Self {
-        Self {
-            failure_rate: metric.failure_rate.rate(),
-            throughput: metric.combined_throughput(),
-            inflight,
-        }
-    }
-
-    fn weighted_throughput(&self) -> Option<f64> {
-        self.throughput.map(|t| t / (self.inflight as f64 + 1.0))
-    }
-}
-
-impl PartialEq for HostScore {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == std::cmp::Ordering::Equal
-    }
-}
-
-impl Eq for HostScore {}
-
-impl Ord for HostScore {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // Lower failure_rate is better (so invert here for max-comparison).
-        match other.failure_rate.cmp(&self.failure_rate) {
-            std::cmp::Ordering::Equal => match (self.throughput, other.throughput) {
-                (None, None) => other.inflight.cmp(&self.inflight),
-                // discovery: unsampled outranks sampled
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (Some(_), Some(_)) => self
-                    .weighted_throughput()
-                    .unwrap()
-                    .total_cmp(&other.weighted_throughput().unwrap()),
-            },
-            ord => ord,
-        }
-    }
-}
-
-impl PartialOrd for HostScore {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 #[derive(Debug)]
@@ -400,17 +191,13 @@ impl HostList {
     }
 
     /// Adds a read sample for the given host, updating its metrics.
-    fn add_read_sample(&self, host_key: PublicKey, bytes: u64, elapsed: Duration) {
-        self.with_metric(&host_key, |m| m.add_read_sample(bytes, elapsed));
+    fn add_read_sample(&self, host_key: PublicKey, transfer: Transfer) {
+        self.with_metric(&host_key, |m| m.add_read_sample(transfer));
     }
 
     /// Adds a write sample for the given host, updating its metrics.
-    fn add_write_sample(&self, host_key: PublicKey, bytes: u64, elapsed: Duration) {
-        self.with_metric(&host_key, |m| m.add_write_sample(bytes, elapsed));
-    }
-
-    fn add_settings_sample(&self, host_key: PublicKey, elapsed: Duration) {
-        self.with_metric(&host_key, |m| m.add_settings_sample(elapsed));
+    fn add_write_sample(&self, host_key: PublicKey, transfer: Transfer) {
+        self.with_metric(&host_key, |m| m.add_write_sample(transfer));
     }
 }
 
@@ -492,6 +279,9 @@ pub(crate) struct Hosts<T: Transport> {
     transport: T,
     price_cache: Arc<HostCache<HostPrices>>,
     hosts: Arc<HostList>,
+
+    global_write_avg: Arc<RwLock<RPCAverage>>,
+    global_read_avg: Arc<RwLock<RPCAverage>>,
 }
 
 impl<T: Transport> Hosts<T> {
@@ -500,6 +290,9 @@ impl<T: Transport> Hosts<T> {
             transport,
             hosts: Arc::new(HostList::new()),
             price_cache: Arc::new(HostCache::new()),
+
+            global_write_avg: Arc::new(RwLock::new(RPCAverage::default())),
+            global_read_avg: Arc::new(RwLock::new(RPCAverage::default())),
         }
     }
 
@@ -557,6 +350,56 @@ impl<T: Transport> Hosts<T> {
     /// Adds a failure for the given host, updating its metrics and priority.
     pub fn add_failure(&self, host_key: PublicKey) {
         self.hosts.add_failure(host_key);
+    }
+
+    /// Records a successful write for the host's metrics and the global
+    /// write throughput EMA. Zero-size or zero-duration transfers are
+    /// skipped rather than recorded as infinite throughput.
+    pub fn record_write_sample(&self, host_key: PublicKey, size: u32, elapsed: Duration) {
+        let Some(transfer) = Transfer::try_new(size, elapsed) else {
+            return;
+        };
+        self.hosts.add_write_sample(host_key, transfer);
+        self.global_write_avg
+            .write()
+            .unwrap()
+            .add_sample(transfer.rate());
+    }
+
+    /// Read equivalent of [`Self::record_write_sample`].
+    pub fn record_read_sample(&self, host_key: PublicKey, size: u32, elapsed: Duration) {
+        let Some(transfer) = Transfer::try_new(size, elapsed) else {
+            return;
+        };
+        self.hosts.add_read_sample(host_key, transfer);
+        self.global_read_avg
+            .write()
+            .unwrap()
+            .add_sample(transfer.rate());
+    }
+
+    /// Expected duration of a `bytes`-sized write on a typical host.
+    /// Falls back to a static until the first write is sampled.
+    pub fn write_estimate(&self, bytes: u32) -> Duration {
+        const DEFAULT: Transfer = Transfer::new(SECTOR_SIZE as u32, Duration::from_secs(5));
+        self.global_write_avg
+            .read()
+            .unwrap()
+            .avg()
+            .map(|rate| Duration::from_secs_f64(bytes as f64 / *rate))
+            .unwrap_or_else(|| DEFAULT.estimate_duration(bytes))
+    }
+
+    /// Expected duration of a `bytes`-sized read on a typical host.
+    /// Falls back to a static until the first read is sampled.
+    pub fn read_estimate(&self, bytes: u32) -> Duration {
+        const DEFAULT: Transfer = Transfer::new(1 << 20, Duration::from_secs(1));
+        self.global_read_avg
+            .read()
+            .unwrap()
+            .avg()
+            .map(|rate| Duration::from_secs_f64(bytes as f64 / *rate))
+            .unwrap_or_else(|| DEFAULT.estimate_duration(bytes))
     }
 
     /// Warms connections to the given hosts by prefetching their prices. This can help seed
@@ -624,11 +467,10 @@ impl<T: Transport> Hosts<T> {
         {
             Ok((prices, false))
         } else {
-            let (prices, elapsed) = timeout(fetch_timeout, transport.host_prices(host_endpoint))
+            let (prices, _) = timeout(fetch_timeout, transport.host_prices(host_endpoint))
                 .await
                 .inspect_err(|_| hosts.add_failure(host_endpoint.public_key))?
                 .inspect_err(|_| hosts.add_failure(host_endpoint.public_key))?;
-            hosts.add_settings_sample(host_endpoint.public_key, elapsed);
             cache.set(host_endpoint.public_key, prices.clone());
             Ok((prices, true))
         }
@@ -655,14 +497,14 @@ impl<T: Transport> Hosts<T> {
                 false,
             )
             .await?;
-            let bytes = sector.len() as u64;
+            let bytes = sector.len() as u32;
             let (root, elapsed) = self
                 .transport
                 .write_sector(&host, prices, account_key, sector)
                 .await
                 .inspect_err(|_| self.hosts.add_failure(host_key))
                 .map_err(RPCError::Rhp)?;
-            self.hosts.add_write_sample(host_key, bytes, elapsed);
+            self.record_write_sample(host_key, bytes, elapsed);
             Ok(root)
         })
         .await?
@@ -682,7 +524,7 @@ impl<T: Transport> Hosts<T> {
         read_timeout: Duration,
     ) -> Result<bytes::Bytes, RPCError> {
         let host = self.host_endpoint(host_key)?;
-        let bytes = length as u64;
+        let bytes = length as u32;
         timeout(read_timeout, async {
             let (prices, _) = Self::fetch_prices(
                 self.transport.clone(),
@@ -699,7 +541,7 @@ impl<T: Transport> Hosts<T> {
                 .await
                 .inspect_err(|_| self.hosts.add_failure(host_key))
                 .map_err(RPCError::Rhp)?;
-            self.hosts.add_read_sample(host_key, bytes, elapsed);
+            self.record_read_sample(host_key, bytes, elapsed);
             Ok(data)
         })
         .await?
@@ -822,156 +664,6 @@ mod test {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[sia_core_derive::cross_target_test]
-    fn test_failure_rate() {
-        let mut fr = FailureRate::default();
-        assert_eq!(fr.rate(), 0, "initial failure rate should be 0%");
-        fr.add_sample(false);
-        assert_eq!(fr.rate(), 100, "initial failure should be 100%");
-
-        for _ in 0..5 {
-            fr.add_sample(true);
-        }
-        assert!(
-            fr.rate() < 100,
-            "failure rate should decrease after successes"
-        );
-
-        let mut fr2 = FailureRate::default();
-        for _ in 0..5 {
-            fr2.add_sample(true);
-        }
-        assert_eq!(
-            fr2.rate(),
-            0,
-            "failure rate should be 0% after only successes"
-        );
-        assert_eq!(
-            fr.cmp(&fr2),
-            std::cmp::Ordering::Greater,
-            "higher failure rate should be greater"
-        );
-    }
-
-    #[sia_core_derive::cross_target_test]
-    fn test_rpc_average() {
-        let mut avg = RPCAverage::default();
-        assert_eq!(
-            avg.avg(),
-            None,
-            "unsampled average should be None (no 1 Gbps default)"
-        );
-
-        avg.add_sample(100);
-        assert_eq!(
-            avg.avg(),
-            Some(100.0),
-            "initial average should be first sample"
-        );
-
-        avg.add_sample(200);
-        assert!(
-            avg.avg() > Some(100.0),
-            "average should increase after higher sample"
-        );
-
-        avg.add_sample(50);
-        assert!(
-            avg.avg() < Some(200.0),
-            "average should decrease after lower sample"
-        );
-    }
-
-    #[sia_core_derive::cross_target_test]
-    fn test_host_metric_ordering() {
-        // Sorting a list of HostMetric by HostScore (inflight=0) should
-        // descend by failure_rate then by throughput.
-        let mut hosts = vec![
-            HostMetric::default(),
-            HostMetric::default(),
-            HostMetric::default(),
-        ];
-        hosts[0].failure_rate.add_sample(false);
-        hosts[1].failure_rate.add_sample(false);
-        hosts[2].failure_rate.add_sample(false);
-        for _ in 0..10 {
-            hosts[0].failure_rate.add_sample(true);
-        }
-        for _ in 0..5 {
-            hosts[1].failure_rate.add_sample(true);
-        }
-        // Sort by HostScore ascending; reverse to get desc.
-        hosts.sort_by(|a, b| HostScore::new(a, 0).cmp(&HostScore::new(b, 0)));
-        let rates = hosts
-            .into_iter()
-            .rev()
-            .map(|h| h.failure_rate)
-            .collect::<Vec<FailureRate>>();
-        assert!(
-            rates.is_sorted(),
-            "hosts should be sorted by failure rate desc"
-        );
-
-        let mut hosts = vec![
-            HostMetric::default(),
-            HostMetric::default(),
-            HostMetric::default(),
-        ];
-        hosts[0].rpc_write_avg.add_sample(100);
-        hosts[1].rpc_write_avg.add_sample(1000);
-        hosts[2].rpc_write_avg.add_sample(500);
-        hosts.sort_by(|a, b| HostScore::new(a, 0).cmp(&HostScore::new(b, 0)));
-        let rates = hosts
-            .into_iter()
-            .rev()
-            .map(|h| h.rpc_write_avg.avg())
-            .collect::<Vec<Option<f64>>>();
-        assert!(
-            rates.is_sorted_by(|a, b| a >= b),
-            "hosts should be sorted by rpc write avg desc"
-        );
-    }
-
-    #[sia_core_derive::cross_target_test]
-    fn test_host_ranking() {
-        // End-to-end host ranking via HostScore at the metric layer.
-        // All-unsampled, all-equal: HostScore::new with inflight=0 is the
-        // pure-quality ranking and ties for hosts with no samples.
-        let unsampled_a = HostScore::new(&HostMetric::default(), 0);
-        let unsampled_b = HostScore::new(&HostMetric::default(), 0);
-        assert_eq!(unsampled_a.cmp(&unsampled_b), std::cmp::Ordering::Equal);
-
-        // Sample one host: unsampled now outranks it (discovery preference).
-        let sampled_slow = {
-            let mut m = HostMetric::default();
-            m.add_write_sample(100, Duration::from_secs(1));
-            m
-        };
-        let sampled_slow_score = HostScore::new(&sampled_slow, 0);
-        assert!(
-            unsampled_a > sampled_slow_score,
-            "unsampled should outrank sampled (discovery)",
-        );
-
-        // Among sampled, faster wins.
-        let sampled_fast = {
-            let mut m = HostMetric::default();
-            m.add_read_sample(1000, Duration::from_secs(1));
-            m
-        };
-        let sampled_fast_score = HostScore::new(&sampled_fast, 0);
-        assert!(sampled_fast_score > sampled_slow_score);
-
-        // Failure trumps throughput.
-        let failing_fast = {
-            let mut m = sampled_fast.clone();
-            m.add_failure();
-            m
-        };
-        let failing_fast_score = HostScore::new(&failing_fast, 0);
-        assert!(failing_fast_score < sampled_slow_score);
-    }
-
-    #[sia_core_derive::cross_target_test]
     fn test_host_queue_pick() {
         let hosts_manager = Hosts::new(Client::new());
         let hk1 = random_pubkey();
@@ -1065,7 +757,7 @@ mod test {
         // Same metric but different inflight: the less-loaded host wins.
         let metric = {
             let mut m = HostMetric::default();
-            m.add_write_sample(1_000_000, Duration::from_secs(1));
+            m.add_write_sample(Transfer::new(1_000_000, Duration::from_secs(1)));
             m
         };
         let busy = HostScore::new(&metric, 4);
@@ -1075,7 +767,7 @@ mod test {
         // A 10x faster host beats an idle slow host even when it has some load.
         let fast_metric = {
             let mut m = HostMetric::default();
-            m.add_write_sample(10_000_000, Duration::from_secs(1));
+            m.add_write_sample(Transfer::new(10_000_000, Duration::from_secs(1)));
             m
         };
         let fast_busy = HostScore::new(&fast_metric, 4);
@@ -1135,10 +827,10 @@ mod test {
         // the only differentiator.
         hosts_manager
             .hosts
-            .add_read_sample(hk1, 1_000_000, Duration::from_secs(1));
+            .add_read_sample(hk1, Transfer::new(1_000_000, Duration::from_secs(1)));
         hosts_manager
             .hosts
-            .add_read_sample(hk2, 1_000_000, Duration::from_secs(1));
+            .add_read_sample(hk2, Transfer::new(1_000_000, Duration::from_secs(1)));
 
         // With both idle, sort order is arbitrary among ties — assert the
         // ranking switches when we add inflight to one of them.

--- a/sia_storage/src/hosts/metrics.rs
+++ b/sia_storage/src/hosts/metrics.rs
@@ -1,0 +1,506 @@
+use std::fmt::Display;
+use std::ops::Deref;
+
+use crate::time::Duration;
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct RPCAverage(Option<TransferRate>); // exponential moving average of throughput in bytes/sec
+
+impl RPCAverage {
+    const ALPHA: f64 = 0.2;
+
+    pub(super) fn add_sample(&mut self, rate: TransferRate) {
+        match self.0 {
+            Some(avg) => {
+                self.0 = Some(Self::ALPHA * rate + (1.0 - Self::ALPHA) * avg);
+            }
+            None => {
+                self.0 = Some(rate);
+            }
+        }
+    }
+
+    /// Returns the current average in bytes/sec, or `None` if no samples have
+    /// been recorded yet. Callers decide how to treat unsampled hosts.
+    pub(crate) fn avg(&self) -> Option<TransferRate> {
+        self.0
+    }
+}
+
+impl Display for RPCAverage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.avg() {
+            Some(v) => Display::fmt(&v, f),
+            None => f.write_str("unsampled"),
+        }
+    }
+}
+
+impl PartialEq for RPCAverage {
+    fn eq(&self, other: &Self) -> bool {
+        self.avg() == other.avg()
+    }
+}
+
+impl Eq for RPCAverage {}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct FailureRate(Option<f64>); // exponential moving average of failure rate
+
+impl FailureRate {
+    const ALPHA: f64 = 0.2;
+
+    pub(super) fn add_sample(&mut self, success: bool) {
+        let sample = if success { 0.0 } else { 1.0 };
+        match self.0 {
+            Some(rate) => {
+                self.0 = Some(Self::ALPHA * sample + (1.0 - Self::ALPHA) * rate);
+            }
+            None => {
+                self.0 = Some(sample);
+            }
+        }
+    }
+
+    // Computes the failure rate as an integer percentage (0-100)
+    pub(crate) fn rate(&self) -> i64 {
+        match self.0 {
+            Some(rate) => (rate * 100.0).round() as i64,
+            None => 0, // presume no failures if no samples
+        }
+    }
+}
+
+impl Display for FailureRate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}%", self.rate())
+    }
+}
+
+impl PartialEq for FailureRate {
+    fn eq(&self, other: &Self) -> bool {
+        self.rate() == other.rate()
+    }
+}
+
+impl Eq for FailureRate {}
+
+impl PartialOrd for FailureRate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for FailureRate {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.rate().cmp(&other.rate())
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub(super) struct HostMetric {
+    rpc_write_avg: RPCAverage,
+    rpc_read_avg: RPCAverage,
+    failure_rate: FailureRate,
+}
+
+impl HostMetric {
+    pub(super) fn add_write_sample(&mut self, transfer: Transfer) {
+        self.rpc_write_avg.add_sample(transfer.rate());
+        self.failure_rate.add_sample(true);
+    }
+
+    pub(super) fn add_read_sample(&mut self, transfer: Transfer) {
+        self.rpc_read_avg.add_sample(transfer.rate());
+        self.failure_rate.add_sample(true);
+    }
+
+    pub(super) fn add_failure(&mut self) {
+        self.failure_rate.add_sample(false);
+    }
+
+    /// Combined read + write throughput average. `None` only when neither side
+    /// has been sampled. Used by [`HostScore`] for the discovery preference
+    /// (unsampled outranks sampled).
+    pub(crate) fn combined_throughput(&self) -> Option<TransferRate> {
+        match (self.rpc_write_avg.avg(), self.rpc_read_avg.avg()) {
+            (None, None) => None,
+            (Some(w), Some(r)) => Some((w + r) / 2.0),
+            (Some(v), None) | (None, Some(v)) => Some(v),
+        }
+    }
+}
+
+/// Score for picking the next upload host. Higher is better.
+///
+/// Sort order:
+/// 1. Lower `failure_rate` wins.
+/// 2. Unsampled hosts (no throughput data) outrank sampled ones — this is
+///    the "discovery" preference so every available host eventually gets
+///    tried at least once.
+/// 3. Among sampled hosts, higher `throughput / (inflight + 1)` wins —
+///    the expected per-shard throughput if you added one more shard. That
+///    penalizes already-busy hosts proportionally to load, so a saturated
+///    fast host can lose to an idle slower one, while a genuinely much
+///    faster host still wins even when serving a few shards.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HostScore {
+    failure_rate: i64,
+    throughput: Option<TransferRate>,
+    inflight: usize,
+}
+
+impl HostScore {
+    pub(super) fn new(metric: &HostMetric, inflight: usize) -> Self {
+        Self {
+            failure_rate: metric.failure_rate.rate(),
+            throughput: metric.combined_throughput(),
+            inflight,
+        }
+    }
+
+    pub(crate) fn weighted_throughput(&self) -> Option<TransferRate> {
+        self.throughput.map(|t| t / (self.inflight as f64 + 1.0))
+    }
+}
+
+impl PartialEq for HostScore {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for HostScore {}
+
+impl Ord for HostScore {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Lower failure_rate is better (so invert here for max-comparison).
+        match other.failure_rate.cmp(&self.failure_rate) {
+            std::cmp::Ordering::Equal => match (self.throughput, other.throughput) {
+                (None, None) => other.inflight.cmp(&self.inflight),
+                // discovery: unsampled outranks sampled
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (Some(_), Some(_)) => self
+                    .weighted_throughput()
+                    .unwrap()
+                    .total_cmp(&other.weighted_throughput().unwrap()),
+            },
+            ord => ord,
+        }
+    }
+}
+
+impl PartialOrd for HostScore {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A successful transfer observation: `size` bytes in `elapsed`. Validated
+/// once at construction; [`Self::rate`] and [`Self::pace`] are views.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Transfer {
+    size: u32,
+    elapsed: Duration,
+}
+
+impl Transfer {
+    pub const fn new(size: u32, elapsed: Duration) -> Self {
+        Self::try_new(size, elapsed).expect("size and elapsed cannot be zero")
+    }
+
+    pub const fn try_new(size: u32, elapsed: Duration) -> Option<Self> {
+        if size == 0 || elapsed.is_zero() {
+            return None;
+        }
+        Some(Self { size, elapsed })
+    }
+
+    /// Returns the rate of the transfer in bytes per second.
+    pub const fn rate(&self) -> TransferRate {
+        TransferRate(self.size as f64 / self.elapsed.as_secs_f64())
+    }
+
+    /// Returns the per-byte latency of the transfer in seconds per byte.
+    pub const fn pace(&self) -> TransferPace {
+        TransferPace(self.elapsed.as_secs_f64() / self.size as f64)
+    }
+
+    /// Returns an estimate of the time it will take to transfer
+    /// `size` bytes.
+    pub fn estimate_duration(&self, size: u32) -> Duration {
+        self.pace().estimate_duration(size)
+    }
+}
+
+impl TransferPace {
+    /// Returns an estimate of the time it will take to transfer
+    /// `size` bytes at this pace.
+    pub fn estimate_duration(&self, size: u32) -> Duration {
+        Duration::from_secs_f64(self.0 * size as f64)
+    }
+}
+
+/// The rate of a transfer in bytes per second.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+pub(crate) struct TransferRate(f64);
+
+/// The per-byte latency of a transfer in seconds per byte.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+pub(crate) struct TransferPace(f64);
+
+// macro for common implementations between pace and rate
+macro_rules! impl_transfer {
+    ($($t:ident),*) => {$(
+        impl Deref for $t {
+            type Target = f64;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $t {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl std::ops::Add for $t {
+            type Output = Self;
+            fn add(self, rhs: Self) -> Self {
+                Self(self.0 + rhs.0)
+            }
+        }
+
+        impl std::ops::Sub for $t {
+            type Output = Self;
+            fn sub(self, rhs: Self) -> Self {
+                Self(self.0 - rhs.0)
+            }
+        }
+
+        impl std::ops::Add<f64> for $t {
+            type Output = Self;
+            fn add(self, rhs: f64) -> Self {
+                Self(self.0 + rhs)
+            }
+        }
+
+        impl std::ops::Sub<f64> for $t {
+            type Output = Self;
+            fn sub(self, rhs: f64) -> Self {
+                Self(self.0 - rhs)
+            }
+        }
+
+        impl std::ops::Mul<f64> for $t {
+            type Output = Self;
+            fn mul(self, rhs: f64) -> Self {
+                Self(self.0 * rhs)
+            }
+        }
+
+        impl std::ops::Div<f64> for $t {
+            type Output = Self;
+            fn div(self, rhs: f64) -> Self {
+                Self(self.0 / rhs)
+            }
+        }
+
+        impl std::ops::Add<$t> for f64 {
+            type Output = $t;
+            fn add(self, rhs: $t) -> $t {
+                $t(self + rhs.0)
+            }
+        }
+
+        impl std::ops::Sub<$t> for f64 {
+            type Output = $t;
+            fn sub(self, rhs: $t) -> $t {
+                $t(self - rhs.0)
+            }
+        }
+
+        impl std::ops::Mul<$t> for f64 {
+            type Output = $t;
+            fn mul(self, rhs: $t) -> $t {
+                $t(self * rhs.0)
+            }
+        }
+
+        impl std::ops::Div<$t> for f64 {
+            type Output = $t;
+            fn div(self, rhs: $t) -> $t {
+                $t(self / rhs.0)
+            }
+        }
+    )*};
+}
+
+impl_transfer!(TransferRate, TransferPace);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    #[sia_core_derive::cross_target_test]
+    fn test_failure_rate() {
+        let mut fr = FailureRate::default();
+        assert_eq!(fr.rate(), 0, "initial failure rate should be 0%");
+        fr.add_sample(false);
+        assert_eq!(fr.rate(), 100, "initial failure should be 100%");
+
+        for _ in 0..5 {
+            fr.add_sample(true);
+        }
+        assert!(
+            fr.rate() < 100,
+            "failure rate should decrease after successes"
+        );
+
+        let mut fr2 = FailureRate::default();
+        for _ in 0..5 {
+            fr2.add_sample(true);
+        }
+        assert_eq!(
+            fr2.rate(),
+            0,
+            "failure rate should be 0% after only successes"
+        );
+        assert_eq!(
+            fr.cmp(&fr2),
+            std::cmp::Ordering::Greater,
+            "higher failure rate should be greater"
+        );
+    }
+
+    #[sia_core_derive::cross_target_test]
+    fn test_rpc_average() {
+        let mut avg = RPCAverage::default();
+        assert_eq!(
+            avg.avg(),
+            None,
+            "unsampled average should be None (no 1 Gbps default)"
+        );
+
+        avg.add_sample(Transfer::new(100, Duration::from_secs(1)).rate());
+        assert_eq!(
+            avg.avg(),
+            Some(Transfer::new(100, Duration::from_secs(1)).rate()),
+            "initial average should be first sample"
+        );
+
+        avg.add_sample(Transfer::new(200, Duration::from_secs(1)).rate());
+        assert!(
+            avg.avg() > Some(Transfer::new(100, Duration::from_secs(1)).rate()),
+            "average should increase after higher sample"
+        );
+
+        avg.add_sample(Transfer::new(50, Duration::from_secs(1)).rate());
+        assert!(
+            avg.avg() < Some(Transfer::new(200, Duration::from_secs(1)).rate()),
+            "average should decrease after lower sample"
+        );
+    }
+
+    #[sia_core_derive::cross_target_test]
+    fn test_host_metric_ordering() {
+        // Sorting a list of HostMetric by HostScore (inflight=0) should
+        // descend by failure_rate then by throughput.
+        let mut hosts = vec![
+            HostMetric::default(),
+            HostMetric::default(),
+            HostMetric::default(),
+        ];
+        hosts[0].failure_rate.add_sample(false);
+        hosts[1].failure_rate.add_sample(false);
+        hosts[2].failure_rate.add_sample(false);
+        for _ in 0..10 {
+            hosts[0].failure_rate.add_sample(true);
+        }
+        for _ in 0..5 {
+            hosts[1].failure_rate.add_sample(true);
+        }
+        // Sort by HostScore ascending; reverse to get desc.
+        hosts.sort_by(|a, b| HostScore::new(a, 0).cmp(&HostScore::new(b, 0)));
+        let rates = hosts
+            .into_iter()
+            .rev()
+            .map(|h| h.failure_rate)
+            .collect::<Vec<FailureRate>>();
+        assert!(
+            rates.is_sorted(),
+            "hosts should be sorted by failure rate desc"
+        );
+
+        let mut hosts = vec![
+            HostMetric::default(),
+            HostMetric::default(),
+            HostMetric::default(),
+        ];
+        hosts[0]
+            .rpc_write_avg
+            .add_sample(Transfer::new(100, Duration::from_secs(1)).rate());
+        hosts[1]
+            .rpc_write_avg
+            .add_sample(Transfer::new(1000, Duration::from_secs(1)).rate());
+        hosts[2]
+            .rpc_write_avg
+            .add_sample(Transfer::new(500, Duration::from_secs(1)).rate());
+        hosts.sort_by(|a, b| HostScore::new(a, 0).cmp(&HostScore::new(b, 0)));
+        let rates = hosts
+            .into_iter()
+            .rev()
+            .map(|h| h.rpc_write_avg.avg())
+            .collect::<Vec<_>>();
+        assert!(
+            rates.is_sorted_by(|a, b| a >= b),
+            "hosts should be sorted by rpc write avg desc"
+        );
+    }
+
+    #[sia_core_derive::cross_target_test]
+    fn test_host_ranking() {
+        // End-to-end host ranking via HostScore at the metric layer.
+        // All-unsampled, all-equal: HostScore::new with inflight=0 is the
+        // pure-quality ranking and ties for hosts with no samples.
+        let unsampled_a = HostScore::new(&HostMetric::default(), 0);
+        let unsampled_b = HostScore::new(&HostMetric::default(), 0);
+        assert_eq!(unsampled_a.cmp(&unsampled_b), std::cmp::Ordering::Equal);
+
+        // Sample one host: unsampled now outranks it (discovery preference).
+        let sampled_slow = {
+            let mut m = HostMetric::default();
+            m.add_write_sample(Transfer::new(100, Duration::from_secs(1)));
+            m
+        };
+        let sampled_slow_score = HostScore::new(&sampled_slow, 0);
+        assert!(
+            unsampled_a > sampled_slow_score,
+            "unsampled should outrank sampled (discovery)",
+        );
+
+        // Among sampled, faster wins.
+        let sampled_fast = {
+            let mut m = HostMetric::default();
+            m.add_read_sample(Transfer::new(1000, Duration::from_secs(1)));
+            m
+        };
+        let sampled_fast_score = HostScore::new(&sampled_fast, 0);
+        assert!(sampled_fast_score > sampled_slow_score);
+
+        // Failure trumps throughput.
+        let failing_fast = {
+            let mut m = sampled_fast.clone();
+            m.add_failure();
+            m
+        };
+        let failing_fast_score = HostScore::new(&failing_fast, 0);
+        assert!(failing_fast_score < sampled_slow_score);
+    }
+}

--- a/sia_storage/src/upload.rs
+++ b/sia_storage/src/upload.rs
@@ -17,8 +17,34 @@ use sia_core::rhp4::SECTOR_SIZE;
 use sia_core::signing::PublicKey;
 use thiserror::Error;
 use tokio::io::{AsyncRead, BufReader};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, watch};
 use tokio::task::JoinSet;
+
+/// RAII increment of the pipeline's waiting-shard count. Held while a
+/// shard has no upload attempt in flight (encode, encrypt, or a permit
+/// wait) and dropped once it does, so the racing gate stays balanced
+/// even when tasks are cancelled mid-wait.
+struct WaitingGuard(watch::Sender<usize>);
+
+impl WaitingGuard {
+    fn new(waiting: watch::Sender<usize>) -> Self {
+        // Only notify on the 0 boundary to avoid spurious wakes
+        waiting.send_if_modified(|w| {
+            *w = w.saturating_add(1);
+            *w == 1
+        });
+        Self(waiting)
+    }
+}
+
+impl Drop for WaitingGuard {
+    fn drop(&mut self) {
+        self.0.send_if_modified(|w| {
+            *w = w.saturating_sub(1);
+            *w == 0
+        });
+    }
+}
 
 struct ShardUpload {
     semaphore: Arc<Semaphore>,
@@ -28,6 +54,7 @@ struct ShardUpload {
     data: Bytes,
     slab_index: usize,
     shard_index: usize,
+    waiting: watch::Sender<usize>,
 }
 
 struct SectorUploadResult {
@@ -37,6 +64,7 @@ struct SectorUploadResult {
 }
 
 const UPLOAD_TIMEOUT: Duration = Duration::from_secs(90);
+const RACE_FACTOR: f64 = 1.5;
 
 impl ShardUpload {
     fn spawn_write(
@@ -89,16 +117,29 @@ impl ShardUpload {
         self.hosts.lock().unwrap().pick()
     }
 
-    async fn upload_shard(self) -> Result<SectorUploadResult, UploadError> {
+    async fn upload_shard(
+        self,
+        waiting_guard: WaitingGuard,
+    ) -> Result<SectorUploadResult, UploadError> {
         let permit = self.semaphore.clone().acquire_owned().await?;
+        // This shard is about to have an attempt in flight; it no longer
+        // blocks racing.
+        drop(waiting_guard);
+        let mut waiting_rx = self.waiting.subscribe();
         let (initial, initial_guard) = self.pick_next_host().ok_or(QueueError::NoMoreHosts)?;
         let mut tasks = JoinSet::new();
         self.spawn_write(&mut tasks, initial, initial_guard, UPLOAD_TIMEOUT, permit);
+        let mut eligible = *waiting_rx.borrow_and_update() == 0;
+        let mut last_event = Instant::now();
+        let race_timeout = self
+            .client
+            .write_estimate(self.data.len() as u32)
+            .mul_f64(RACE_FACTOR);
         loop {
-            let active = tasks.len();
             tokio::select! {
                 biased;
                 Some(res) = tasks.join_next() => {
+                    last_event = Instant::now();
                     match res? {
                         Ok(result) => {
                             if result.sector.host_key != initial {
@@ -120,16 +161,24 @@ impl ShardUpload {
                         }
                     }
                 },
-                _ = sleep(Duration::from_secs(active.max(1) as u64)) => {
-                    if let Ok(racer) = self.semaphore.clone().try_acquire_owned()
+                // Fires once racing will not steal work and no attempt has made progress for a race-timeout interval.
+                _ = sleep((last_event + race_timeout).saturating_duration_since(Instant::now())), if eligible => {
+                    let elapsed = last_event.elapsed();
+                    last_event = Instant::now();
+                    eligible = *waiting_rx.borrow_and_update() == 0;
+                    if eligible
+                        && let Ok(racer) = self.semaphore.clone().try_acquire_owned()
                         && let Some((next, guard)) = self.pick_next_host() {
                             debug!(
-                                "slab {} shard {} racing slow host with {next}",
-                                self.slab_index, self.shard_index
+                                "slab {} shard {} racing slow host with {next} after {:?}",
+                                self.slab_index, self.shard_index, elapsed
                             );
                             self.spawn_write(&mut tasks, next, guard, UPLOAD_TIMEOUT, racer);
                         }
-                }
+                },
+                _ = async { let _ = waiting_rx.wait_for(|waiting| *waiting == 0).await; }, if !eligible => {
+                    eligible = true;
+                },
             }
         }
     }
@@ -212,6 +261,10 @@ pub(crate) struct Upload {
     /// for shard uploads to complete, and we want to allow some buffering to
     /// improve performance.
     shard_sema: Arc<Semaphore>,
+    /// Number of shards that do not yet have an upload attempt in flight.
+    /// Shard tasks only race slow hosts while this is zero, so racers never
+    /// take permits that a primary shard is waiting for.
+    waiting: watch::Sender<usize>,
     slab_tasks: VecDeque<AbortOnDropHandle<Result<UploadedSlab, UploadError>>>,
     shard_uploaded: Option<ShardProgressCallback>,
 }
@@ -249,6 +302,7 @@ impl Upload {
             erasure_coder: Arc::new(erasure_coder),
             slab_sema: Arc::new(Semaphore::new(max_slabs)),
             shard_sema: Arc::new(Semaphore::new(options.max_inflight)),
+            waiting: watch::channel(0).0,
             slab_tasks: VecDeque::new(),
             shard_uploaded: options.shard_uploaded,
         })
@@ -262,6 +316,14 @@ impl Upload {
         let progress_callback = self.shard_uploaded.clone();
         let slab_index = self.slab_tasks.len();
         let permit = self.slab_sema.clone().acquire_owned().await?;
+        // Count this slab's shards as waiting before the task spawns so the
+        // racing gate can't open between buffering and encode.
+        let waiting = self.waiting.clone();
+        let waiting_guards: Vec<WaitingGuard> = slab
+            .shards
+            .iter()
+            .map(|_| WaitingGuard::new(waiting.clone()))
+            .collect();
         let handle = AbortOnDropHandle::new(maybe_spawn!(async move {
             let _permit = permit;
             let total_shards = slab.shards.len();
@@ -293,12 +355,15 @@ impl Upload {
             let hosts: Arc<Mutex<HostQueue>> = Arc::new(Mutex::new(client.upload_queue()));
             let owned_slab_key = Arc::new(slab_key.clone());
             let mut shard_tasks: JoinSet<Result<SectorUploadResult, UploadError>> = JoinSet::new();
-            for (shard_index, mut shard) in shards.into_iter().enumerate() {
+            for ((shard_index, mut shard), waiting_guard) in
+                shards.into_iter().enumerate().zip(waiting_guards)
+            {
                 let owned_slab_key = owned_slab_key.clone();
                 let shard_client = client.clone();
                 let shard_account_key = app_key.clone();
                 let shard_sema_inner = shard_sema.clone();
                 let hosts = hosts.clone();
+                let waiting = waiting.clone();
                 join_set_spawn!(shard_tasks, async move {
                     let shard = maybe_spawn_blocking!({
                         encrypt_shard(&owned_slab_key, shard_index as u8, 0, &mut shard);
@@ -312,8 +377,9 @@ impl Upload {
                         slab_index,
                         shard_index,
                         hosts,
+                        waiting,
                     };
-                    shard_upload.upload_shard().await
+                    shard_upload.upload_shard(waiting_guard).await
                 });
             }
 
@@ -559,6 +625,12 @@ pub(crate) async fn upload_object<R: AsyncRead + Unpin>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Host;
+    use sia_core::signing::PrivateKey;
+    use sia_core::types::v2::{NetAddress, Protocol};
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     fn opts(data: u8, parity: u8) -> UploadOptions {
         UploadOptions {
@@ -566,6 +638,136 @@ mod tests {
             parity_shards: parity,
             ..Default::default()
         }
+    }
+
+    fn test_host(public_key: PublicKey) -> Host {
+        Host {
+            public_key,
+            addresses: vec![NetAddress {
+                protocol: Protocol::QUIC,
+                address: "localhost:1234".to_string(),
+            }],
+            country_code: "US".to_string(),
+            latitude: 0.0,
+            longitude: 0.0,
+            good_for_upload: true,
+        }
+    }
+
+    /// Sets up five fast hosts with seeded write metrics plus one unsampled
+    /// slow host. The discovery preference guarantees the slow host wins the
+    /// initial pick, and the seeded p95 keeps the race timer near its 50ms
+    /// floor so a racer (when allowed) beats the slow host comfortably.
+    fn racing_setup(slow_delay: Duration) -> (Hosts<Client>, Arc<AppKey>, PublicKey) {
+        let transport = Client::new();
+        let hosts_manager = Hosts::new(transport.clone());
+        let app_key = Arc::new(AppKey::import(rand::random()));
+        let fast: Vec<PublicKey> = (0..5)
+            .map(|_| PrivateKey::from_seed(&rand::random()).public_key())
+            .collect();
+        let slow = PrivateKey::from_seed(&rand::random()).public_key();
+        hosts_manager.update(
+            fast.iter()
+                .chain(std::iter::once(&slow))
+                .map(|pk| test_host(*pk))
+                .collect(),
+            true,
+        );
+        for pk in &fast {
+            hosts_manager.record_write_sample(*pk, SECTOR_SIZE as u32, Duration::from_millis(10));
+        }
+        transport.set_slow_hosts([slow], slow_delay);
+        (hosts_manager, app_key, slow)
+    }
+
+    fn shard_upload(
+        hosts_manager: &Hosts<Client>,
+        app_key: &Arc<AppKey>,
+        waiting: &watch::Sender<usize>,
+    ) -> ShardUpload {
+        ShardUpload {
+            semaphore: Arc::new(Semaphore::new(4)),
+            client: hosts_manager.clone(),
+            hosts: Arc::new(Mutex::new(hosts_manager.upload_queue())),
+            account_key: app_key.clone(),
+            data: Bytes::from(vec![0u8; SECTOR_SIZE]),
+            slab_index: 0,
+            shard_index: 0,
+            waiting: waiting.clone(),
+        }
+    }
+
+    #[sia_core_derive::cross_target_test]
+    async fn test_upload_race_gated_while_shards_waiting() {
+        let (hosts_manager, app_key, slow) = racing_setup(Duration::from_millis(600));
+        // another shard is still waiting for an attempt, so the slow initial
+        // host must not be raced
+        let (waiting, _) = watch::channel(1usize);
+        let upload = shard_upload(&hosts_manager, &app_key, &waiting);
+        let start = Instant::now();
+        let result = upload
+            .upload_shard(WaitingGuard::new(waiting.clone()))
+            .await
+            .unwrap();
+        assert_eq!(
+            result.sector.host_key, slow,
+            "gated shard must finish on the slow host"
+        );
+        assert!(
+            start.elapsed() >= Duration::from_millis(500),
+            "gated shard must not race: {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[sia_core_derive::cross_target_test]
+    async fn test_upload_race_when_idle() {
+        let (hosts_manager, app_key, slow) = racing_setup(Duration::from_millis(600));
+        let (waiting, _) = watch::channel(0usize);
+        let upload = shard_upload(&hosts_manager, &app_key, &waiting);
+        let start = Instant::now();
+        let result = upload
+            .upload_shard(WaitingGuard::new(waiting.clone()))
+            .await
+            .unwrap();
+        assert_ne!(
+            result.sector.host_key, slow,
+            "idle pipeline should race the slow host"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(500),
+            "racer should win quickly: {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[sia_core_derive::cross_target_test]
+    async fn test_upload_race_triggered_by_idle_transition() {
+        let (hosts_manager, app_key, slow) = racing_setup(Duration::from_millis(1500));
+        let (waiting, _) = watch::channel(1usize);
+        // the "other" waiting shard starts its attempt 150ms in; the gate
+        // opening should start racing immediately rather than waiting
+        // another race-timeout interval
+        let flip = waiting.clone();
+        maybe_spawn!(async move {
+            sleep(Duration::from_millis(150)).await;
+            flip.send_modify(|w| *w -= 1);
+        });
+        let upload = shard_upload(&hosts_manager, &app_key, &waiting);
+        let start = Instant::now();
+        let result = upload
+            .upload_shard(WaitingGuard::new(waiting.clone()))
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+        assert_ne!(
+            result.sector.host_key, slow,
+            "race should start once the pipeline goes idle"
+        );
+        assert!(
+            elapsed >= Duration::from_millis(140) && elapsed < Duration::from_millis(1000),
+            "racer should win shortly after the gate opens: {elapsed:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Racers will no longer steal slots from higher priority work or pile on to slow connections. For uploads, racing will only start when every shard has an attempt in flight. For downloads, racing will only start when the chunk is near the read head. The race timeout is now derived from global read and write EWMA's instead of a fixed interval so only hosts outside the normal spread get raced.

These changes will not really help until we also add AIMD. I ran benchmarks on both a slow and fast connection to confirm no regressions outside of normal noise.

It looks like a large diff, but a lot of it is moving the metric types into a separate module.